### PR TITLE
fix: resolve all CI failures — detection duplicates, fixtures, lint, TypeScript

### DIFF
--- a/apps/web/src/components/analytics/TeamAnalyticsView.tsx
+++ b/apps/web/src/components/analytics/TeamAnalyticsView.tsx
@@ -167,7 +167,7 @@ export function TeamAnalyticsView() {
 
         {sorted.length === 0 ? (
           <EmptyState
-            icon={<EmptyStateIcons.Search />}
+            icon={<EmptyStateIcons.search />}
             title="No analysts match your search"
             description="Try a different name or clear the search to see all analysts."
             action={

--- a/apps/web/src/components/coverage/CoverageAdvisorView.tsx
+++ b/apps/web/src/components/coverage/CoverageAdvisorView.tsx
@@ -125,7 +125,7 @@ export default function CoverageAdvisorView() {
                 <tr>
                   <td colSpan={7} className="py-0">
                     <EmptyState
-                      icon={<EmptyStateIcons.Shield />}
+                      icon={<EmptyStateIcons.shield />}
                       title="No techniques match this filter"
                       description="Try selecting a different coverage status or view all techniques."
                       action={

--- a/apps/web/src/components/easm/EASMView.tsx
+++ b/apps/web/src/components/easm/EASMView.tsx
@@ -152,7 +152,7 @@ export function EASMView() {
                 <tr>
                   <td colSpan={5} className="py-0">
                     <EmptyState
-                      icon={<EmptyStateIcons.Shield />}
+                      icon={<EmptyStateIcons.shield />}
                       title="No assets match this filter"
                       description="Try selecting a different status filter or view all assets."
                       action={

--- a/apps/web/src/components/mssp/MSSPDashboardView.tsx
+++ b/apps/web/src/components/mssp/MSSPDashboardView.tsx
@@ -105,7 +105,7 @@ export default function MSSPDashboardView() {
         </div>
         {filteredTenants.length === 0 ? (
           <EmptyState
-            icon={<EmptyStateIcons.Shield />}
+            icon={<EmptyStateIcons.shield />}
             title="No tenants match this SLA filter"
             description="Try a different status filter to view tenants."
             action={

--- a/apps/web/src/components/noise/NoiseTuningView.tsx
+++ b/apps/web/src/components/noise/NoiseTuningView.tsx
@@ -130,7 +130,7 @@ export default function NoiseTuningView() {
                 <tr>
                   <td colSpan={7} className="py-0">
                     <EmptyState
-                      icon={<EmptyStateIcons.Search />}
+                      icon={<EmptyStateIcons.search />}
                       title="No rules match your search"
                       description="Try a different rule name or clear the search field."
                       action={

--- a/apps/web/src/components/settings/RBACView.tsx
+++ b/apps/web/src/components/settings/RBACView.tsx
@@ -299,7 +299,7 @@ export function RBACView() {
 
       {roles && roles.length === 0 && (
         <EmptyState
-          icon={<EmptyStateIcons.Shield />}
+          icon={<EmptyStateIcons.shield />}
           title="No roles defined yet"
           description="Create your first role to start managing access control for your organization."
           action={

--- a/apps/web/src/components/settings/SettingsView.byok.test.tsx
+++ b/apps/web/src/components/settings/SettingsView.byok.test.tsx
@@ -112,12 +112,13 @@ function credentialFixture(
   overrides: Partial<LlmCredentialView> = {},
 ): LlmCredentialView {
   return {
-    tenant_id: 'tenant-abc',
     provider: 'openai',
     base_url: null,
     model: 'gpt-4o-mini',
     has_api_key: true,
     enabled: true,
+    settings: {},
+    created_at: '2026-01-01T00:00:00Z',
     last_rotated_at: '2026-02-01T12:00:00Z',
     updated_at: '2026-02-01T12:00:00Z',
     ...overrides,

--- a/apps/web/src/components/shifts/ShiftsView.tsx
+++ b/apps/web/src/components/shifts/ShiftsView.tsx
@@ -157,7 +157,7 @@ export function ShiftsView() {
                 <tr>
                   <td colSpan={5} className="py-0">
                     <EmptyState
-                      icon={<EmptyStateIcons.Search />}
+                      icon={<EmptyStateIcons.search />}
                       title="No items match this priority"
                       description="Try selecting a different priority level or view all open handoff items."
                       action={

--- a/detections/cloud/m365-exchange-ediscovery-search-created.yaml
+++ b/detections/cloud/m365-exchange-ediscovery-search-created.yaml
@@ -1,4 +1,4 @@
-id: det-cloud-193
+id: det-cloud-219
 name: M365 eDiscovery Compliance Search Created
 description: Detects creation of an eDiscovery compliance search in Microsoft Purview.
   Insider threats and compromised admin accounts abuse eDiscovery to search and export

--- a/detections/cloud/m365-exchange-mail-connector-external-domain.yaml
+++ b/detections/cloud/m365-exchange-mail-connector-external-domain.yaml
@@ -1,4 +1,4 @@
-id: det-cloud-195
+id: det-cloud-220
 name: M365 Exchange Inbound Connector From Untrusted Domain
 description: Detects creation of an Exchange Online inbound connector that accepts mail
   from a specific external sender domain. Adversaries create connectors to bypass spam

--- a/detections/cloud/m365-exchange-transport-rule-redirect-external.yaml
+++ b/detections/cloud/m365-exchange-transport-rule-redirect-external.yaml
@@ -1,4 +1,4 @@
-id: det-cloud-192
+id: det-cloud-221
 name: M365 Exchange Transport Rule Redirects Mail Externally
 description: A transport rule was created or modified to redirect or BCC mail to an
   external domain. Attackers use this for persistent email exfiltration that survives

--- a/detections/cloud/m365-sharepoint-external-sharing-enabled-tenant.yaml
+++ b/detections/cloud/m365-sharepoint-external-sharing-enabled-tenant.yaml
@@ -1,4 +1,4 @@
-id: det-cloud-196
+id: det-cloud-222
 name: M365 SharePoint External Sharing Enabled Tenant-Wide
 description: Detects tenant-level SharePoint sharing policy changed to allow external
   or anonymous sharing. Widens the data-loss attack surface across all sites.

--- a/detections/cloud/m365-sharepoint-site-collection-admin-added.yaml
+++ b/detections/cloud/m365-sharepoint-site-collection-admin-added.yaml
@@ -1,4 +1,4 @@
-id: det-cloud-197
+id: det-cloud-223
 name: M365 SharePoint Site Collection Admin Added
 description: A new site collection administrator was added. Site collection admins
   bypass item-level permissions and can access all content including OneDrive for

--- a/detections/cloud/m365-teams-external-access-enabled.yaml
+++ b/detections/cloud/m365-teams-external-access-enabled.yaml
@@ -1,4 +1,4 @@
-id: det-cloud-198
+id: det-cloud-224
 name: M365 Teams External Access Policy Enabled
 description: Teams external access was changed to allow federation with all external
   domains or specific unblocked domains. Attackers leverage external access to phish

--- a/detections/cloud/m365-unified-audit-log-disabled.yaml
+++ b/detections/cloud/m365-unified-audit-log-disabled.yaml
@@ -1,4 +1,4 @@
-id: det-cloud-194
+id: det-cloud-225
 name: M365 Unified Audit Log Disabled
 description: Detects disabling of the Microsoft 365 unified audit log. Attackers disable
   auditing early in a compromise to erase their trail across Exchange, SharePoint, Teams,

--- a/detections/fixtures/negative/azure-defender-for-cloud-plan-disabled.json
+++ b/detections/fixtures/negative/azure-defender-for-cloud-plan-disabled.json
@@ -1,0 +1,6 @@
+{
+  "operation_name": "Microsoft.Security/pricings/write",
+  "properties": {
+    "pricingTier": "Standard"
+  }
+}

--- a/detections/fixtures/negative/azure-key-vault-purge-protection-disabled.json
+++ b/detections/fixtures/negative/azure-key-vault-purge-protection-disabled.json
@@ -1,0 +1,7 @@
+{
+  "operation_name": "Microsoft.KeyVault/vaults/write",
+  "properties": {
+    "enableSoftDelete": true,
+    "enablePurgeProtection": true
+  }
+}

--- a/detections/fixtures/negative/azure-management-group-elevated-access.json
+++ b/detections/fixtures/negative/azure-management-group-elevated-access.json
@@ -1,0 +1,4 @@
+{
+  "operation_name": "Microsoft.Authorization/roleAssignments/write",
+  "caller": "user@corp.com"
+}

--- a/detections/fixtures/negative/gcp-audit-log-sink-deleted.json
+++ b/detections/fixtures/negative/gcp-audit-log-sink-deleted.json
@@ -1,0 +1,4 @@
+{
+  "method_name": "google.logging.v2.ConfigServiceV2.CreateSink",
+  "principal_email": "admin@example.com"
+}

--- a/detections/fixtures/negative/gcp-cloud-armor-policy-removed.json
+++ b/detections/fixtures/negative/gcp-cloud-armor-policy-removed.json
@@ -1,0 +1,4 @@
+{
+  "method_name": "v1.compute.securityPolicies.insert",
+  "principal_email": "admin@example.com"
+}

--- a/detections/fixtures/negative/gcp-org-policy-constraint-removed.json
+++ b/detections/fixtures/negative/gcp-org-policy-constraint-removed.json
@@ -1,0 +1,10 @@
+{
+  "method_name": "SetOrgPolicy",
+  "request": {
+    "policy": {
+      "booleanPolicy": {
+        "enforced": true
+      }
+    }
+  }
+}

--- a/detections/fixtures/negative/gcp-vpc-firewall-rule-allow-all-ingress.json
+++ b/detections/fixtures/negative/gcp-vpc-firewall-rule-allow-all-ingress.json
@@ -1,0 +1,15 @@
+{
+  "method_name": "v1.compute.firewalls.insert",
+  "request": {
+    "sourceRanges": [
+      "10.0.0.0/8"
+    ],
+    "allowed": [
+      {
+        "ports": [
+          "443"
+        ]
+      }
+    ]
+  }
+}

--- a/detections/fixtures/negative/m365-defender-antiphish-policy-weakened.json
+++ b/detections/fixtures/negative/m365-defender-antiphish-policy-weakened.json
@@ -1,0 +1,6 @@
+{
+  "operation": "Set-AntiPhishPolicy",
+  "parameters": {
+    "EnableSpoofIntelligence": "True"
+  }
+}

--- a/detections/fixtures/negative/m365-defender-safe-attachments-policy-disabled.json
+++ b/detections/fixtures/negative/m365-defender-safe-attachments-policy-disabled.json
@@ -1,0 +1,6 @@
+{
+  "operation": "Set-SafeAttachmentPolicy",
+  "parameters": {
+    "Enable": "True"
+  }
+}

--- a/detections/fixtures/negative/m365-defender-safe-links-policy-disabled.json
+++ b/detections/fixtures/negative/m365-defender-safe-links-policy-disabled.json
@@ -1,0 +1,6 @@
+{
+  "operation": "Set-SafeLinksPolicy",
+  "parameters": {
+    "EnableSafeLinksForEmail": "True"
+  }
+}

--- a/detections/fixtures/negative/m365-entra-conditional-access-policy-disabled.json
+++ b/detections/fixtures/negative/m365-entra-conditional-access-policy-disabled.json
@@ -1,0 +1,8 @@
+{
+  "operation_name": "Update conditional access policy",
+  "new_value": [
+    {
+      "state": "enabled"
+    }
+  ]
+}

--- a/detections/fixtures/negative/m365-entra-cross-tenant-access-policy-changed.json
+++ b/detections/fixtures/negative/m365-entra-cross-tenant-access-policy-changed.json
@@ -1,0 +1,4 @@
+{
+  "operation_name": "Read cross-tenant access setting",
+  "actor": "user@corp.com"
+}

--- a/detections/fixtures/negative/m365-entra-pim-role-activated-global-admin.json
+++ b/detections/fixtures/negative/m365-entra-pim-role-activated-global-admin.json
@@ -1,0 +1,4 @@
+{
+  "operation_name": "Add member to role completed (PIM activation)",
+  "role_name": "Reports Reader"
+}

--- a/detections/fixtures/negative/m365-exchange-audit-bypass-enabled.json
+++ b/detections/fixtures/negative/m365-exchange-audit-bypass-enabled.json
@@ -1,0 +1,6 @@
+{
+  "operation": "Set-MailboxAuditBypassAssociation",
+  "parameters": {
+    "AuditBypassEnabled": "False"
+  }
+}

--- a/detections/fixtures/negative/m365-exchange-ediscovery-export.json
+++ b/detections/fixtures/negative/m365-exchange-ediscovery-export.json
@@ -1,0 +1,6 @@
+{
+  "operation": "New-ComplianceSearchAction",
+  "parameters": {
+    "Action": "Preview"
+  }
+}

--- a/detections/fixtures/negative/m365-exchange-ediscovery-search-all-mailboxes.json
+++ b/detections/fixtures/negative/m365-exchange-ediscovery-search-all-mailboxes.json
@@ -1,0 +1,6 @@
+{
+  "operation": "New-ComplianceSearch",
+  "parameters": {
+    "ExchangeLocation": "user@corp.com"
+  }
+}

--- a/detections/fixtures/negative/m365-exchange-ediscovery-search-created.json
+++ b/detections/fixtures/negative/m365-exchange-ediscovery-search-created.json
@@ -1,0 +1,4 @@
+{
+  "operation": "Get-ComplianceSearch",
+  "actor": "analyst@corp.com"
+}

--- a/detections/fixtures/negative/m365-exchange-mail-connector-external-domain.json
+++ b/detections/fixtures/negative/m365-exchange-mail-connector-external-domain.json
@@ -1,0 +1,6 @@
+{
+  "operation": "New-SendConnector",
+  "parameters": {
+    "AddressSpaces": "SMTP:*.corp.com:1"
+  }
+}

--- a/detections/fixtures/negative/m365-exchange-oauth-app-mailbox-access.json
+++ b/detections/fixtures/negative/m365-exchange-oauth-app-mailbox-access.json
@@ -1,0 +1,5 @@
+{
+  "operation": "MailItemsAccessed",
+  "client_app_id": "app-id-123",
+  "logon_type": "Delegate"
+}

--- a/detections/fixtures/negative/m365-exchange-transport-rule-external-redirect.json
+++ b/detections/fixtures/negative/m365-exchange-transport-rule-external-redirect.json
@@ -1,0 +1,6 @@
+{
+  "operation": "New-TransportRule",
+  "parameters": {
+    "RedirectMessageTo": "internal@corp.com"
+  }
+}

--- a/detections/fixtures/negative/m365-exchange-transport-rule-redirect-external.json
+++ b/detections/fixtures/negative/m365-exchange-transport-rule-redirect-external.json
@@ -1,0 +1,6 @@
+{
+  "operation": "Set-TransportRule",
+  "parameters": {
+    "RedirectMessageTo": "internal@corp.com"
+  }
+}

--- a/detections/fixtures/negative/m365-power-automate-flow-shared-externally.json
+++ b/detections/fixtures/negative/m365-power-automate-flow-shared-externally.json
@@ -1,0 +1,5 @@
+{
+  "operation": "Shared a flow",
+  "shared_with": "colleague@corp.com",
+  "sharing_type": "CanView"
+}

--- a/detections/fixtures/negative/m365-power-platform-dlp-policy-modified.json
+++ b/detections/fixtures/negative/m365-power-platform-dlp-policy-modified.json
@@ -1,0 +1,4 @@
+{
+  "operation": "GetEnvironmentDlpPolicy",
+  "actor": "admin@corp.com"
+}

--- a/detections/fixtures/negative/m365-purview-dlp-policy-disabled.json
+++ b/detections/fixtures/negative/m365-purview-dlp-policy-disabled.json
@@ -1,0 +1,6 @@
+{
+  "operation": "Set-DlpCompliancePolicy",
+  "parameters": {
+    "Enabled": "True"
+  }
+}

--- a/detections/fixtures/negative/m365-purview-retention-policy-deleted.json
+++ b/detections/fixtures/negative/m365-purview-retention-policy-deleted.json
@@ -1,0 +1,4 @@
+{
+  "operation": "Set-RetentionCompliancePolicy",
+  "actor": "admin@corp.com"
+}

--- a/detections/fixtures/negative/m365-purview-sensitivity-label-removed.json
+++ b/detections/fixtures/negative/m365-purview-sensitivity-label-removed.json
@@ -1,0 +1,5 @@
+{
+  "operation": "SensitivityLabelApplied",
+  "item": "document.docx",
+  "actor": "user@corp.com"
+}

--- a/detections/fixtures/negative/m365-sharepoint-external-sharing-enabled-org.json
+++ b/detections/fixtures/negative/m365-sharepoint-external-sharing-enabled-org.json
@@ -1,0 +1,6 @@
+{
+  "operation": "SharingPolicyChanged",
+  "parameters": {
+    "SharingCapability": "Disabled"
+  }
+}

--- a/detections/fixtures/negative/m365-sharepoint-external-sharing-enabled-tenant.json
+++ b/detections/fixtures/negative/m365-sharepoint-external-sharing-enabled-tenant.json
@@ -1,0 +1,6 @@
+{
+  "operation": "Set-SPOTenant",
+  "parameters": {
+    "SharingCapability": "Disabled"
+  }
+}

--- a/detections/fixtures/negative/m365-sharepoint-site-admin-external-user.json
+++ b/detections/fixtures/negative/m365-sharepoint-site-admin-external-user.json
@@ -1,0 +1,4 @@
+{
+  "operation": "SiteCollectionAdminAdded",
+  "target_user": "internal@corp.com"
+}

--- a/detections/fixtures/negative/m365-sharepoint-site-collection-admin-added.json
+++ b/detections/fixtures/negative/m365-sharepoint-site-collection-admin-added.json
@@ -1,0 +1,5 @@
+{
+  "operation": "SiteCollectionAdminRemoved",
+  "actor": "user@corp.com",
+  "site": "https://corp.sharepoint.com/sites/project"
+}

--- a/detections/fixtures/negative/m365-teams-app-sideloading-enabled.json
+++ b/detections/fixtures/negative/m365-teams-app-sideloading-enabled.json
@@ -1,0 +1,6 @@
+{
+  "operation": "TeamsAdminAction",
+  "parameters": {
+    "AllowSideloading": "False"
+  }
+}

--- a/detections/fixtures/negative/m365-teams-external-access-domain-added.json
+++ b/detections/fixtures/negative/m365-teams-external-access-domain-added.json
@@ -1,0 +1,6 @@
+{
+  "operation": "Set-CsTenantFederationConfiguration",
+  "parameters": {
+    "AllowedDomains": ""
+  }
+}

--- a/detections/fixtures/negative/m365-teams-external-access-enabled.json
+++ b/detections/fixtures/negative/m365-teams-external-access-enabled.json
@@ -1,0 +1,6 @@
+{
+  "operation": "Set-CsTenantFederationConfiguration",
+  "parameters": {
+    "AllowFederatedUsers": "False"
+  }
+}

--- a/detections/fixtures/negative/m365-unified-audit-log-disabled.json
+++ b/detections/fixtures/negative/m365-unified-audit-log-disabled.json
@@ -1,0 +1,6 @@
+{
+  "operation": "Set-AdminAuditLogConfig",
+  "parameters": {
+    "UnifiedAuditLogIngestionEnabled": "True"
+  }
+}

--- a/detections/fixtures/positive/azure-defender-for-cloud-plan-disabled.json
+++ b/detections/fixtures/positive/azure-defender-for-cloud-plan-disabled.json
@@ -1,0 +1,6 @@
+{
+  "operation_name": "Microsoft.Security/pricings/write",
+  "properties": {
+    "pricingTier": "Free"
+  }
+}

--- a/detections/fixtures/positive/azure-key-vault-purge-protection-disabled.json
+++ b/detections/fixtures/positive/azure-key-vault-purge-protection-disabled.json
@@ -1,0 +1,7 @@
+{
+  "operation_name": "Microsoft.KeyVault/vaults/write",
+  "properties": {
+    "enableSoftDelete": true,
+    "enablePurgeProtection": false
+  }
+}

--- a/detections/fixtures/positive/azure-management-group-elevated-access.json
+++ b/detections/fixtures/positive/azure-management-group-elevated-access.json
@@ -1,0 +1,4 @@
+{
+  "operation_name": "Microsoft.Authorization/elevateAccess/action",
+  "caller": "user@corp.com"
+}

--- a/detections/fixtures/positive/gcp-audit-log-sink-deleted.json
+++ b/detections/fixtures/positive/gcp-audit-log-sink-deleted.json
@@ -1,0 +1,4 @@
+{
+  "method_name": "google.logging.v2.ConfigServiceV2.DeleteSink",
+  "principal_email": "attacker@example.com"
+}

--- a/detections/fixtures/positive/gcp-cloud-armor-policy-removed.json
+++ b/detections/fixtures/positive/gcp-cloud-armor-policy-removed.json
@@ -1,0 +1,4 @@
+{
+  "method_name": "v1.compute.securityPolicies.delete",
+  "principal_email": "attacker@example.com"
+}

--- a/detections/fixtures/positive/gcp-org-policy-constraint-removed.json
+++ b/detections/fixtures/positive/gcp-org-policy-constraint-removed.json
@@ -1,0 +1,9 @@
+{
+  "method_name": "SetOrgPolicy",
+  "request": {
+    "policy": {
+      "etag": "",
+      "updateTime": ""
+    }
+  }
+}

--- a/detections/fixtures/positive/gcp-vpc-firewall-rule-allow-all-ingress.json
+++ b/detections/fixtures/positive/gcp-vpc-firewall-rule-allow-all-ingress.json
@@ -1,0 +1,15 @@
+{
+  "method_name": "v1.compute.firewalls.insert",
+  "request": {
+    "sourceRanges": [
+      "0.0.0.0/0"
+    ],
+    "allowed": [
+      {
+        "ports": [
+          "0-65535"
+        ]
+      }
+    ]
+  }
+}

--- a/detections/fixtures/positive/m365-defender-antiphish-policy-weakened.json
+++ b/detections/fixtures/positive/m365-defender-antiphish-policy-weakened.json
@@ -1,0 +1,6 @@
+{
+  "operation": "Set-AntiPhishPolicy",
+  "parameters": {
+    "EnableSpoofIntelligence": "False"
+  }
+}

--- a/detections/fixtures/positive/m365-defender-safe-attachments-policy-disabled.json
+++ b/detections/fixtures/positive/m365-defender-safe-attachments-policy-disabled.json
@@ -1,0 +1,6 @@
+{
+  "operation": "Set-SafeAttachmentPolicy",
+  "parameters": {
+    "Enable": "False"
+  }
+}

--- a/detections/fixtures/positive/m365-defender-safe-links-policy-disabled.json
+++ b/detections/fixtures/positive/m365-defender-safe-links-policy-disabled.json
@@ -1,0 +1,6 @@
+{
+  "operation": "Set-SafeLinksPolicy",
+  "parameters": {
+    "EnableSafeLinksForEmail": "False"
+  }
+}

--- a/detections/fixtures/positive/m365-entra-conditional-access-policy-disabled.json
+++ b/detections/fixtures/positive/m365-entra-conditional-access-policy-disabled.json
@@ -1,0 +1,8 @@
+{
+  "operation_name": "Update conditional access policy",
+  "new_value": [
+    {
+      "state": "disabled"
+    }
+  ]
+}

--- a/detections/fixtures/positive/m365-entra-cross-tenant-access-policy-changed.json
+++ b/detections/fixtures/positive/m365-entra-cross-tenant-access-policy-changed.json
@@ -1,0 +1,4 @@
+{
+  "operation_name": "Update a partner cross-tenant access setting",
+  "actor": "attacker@corp.com"
+}

--- a/detections/fixtures/positive/m365-entra-pim-role-activated-global-admin.json
+++ b/detections/fixtures/positive/m365-entra-pim-role-activated-global-admin.json
@@ -1,0 +1,4 @@
+{
+  "operation_name": "Add member to role completed (PIM activation)",
+  "role_name": "Global Administrator"
+}

--- a/detections/fixtures/positive/m365-exchange-audit-bypass-enabled.json
+++ b/detections/fixtures/positive/m365-exchange-audit-bypass-enabled.json
@@ -1,0 +1,6 @@
+{
+  "operation": "Set-MailboxAuditBypassAssociation",
+  "parameters": {
+    "AuditBypassEnabled": "True"
+  }
+}

--- a/detections/fixtures/positive/m365-exchange-ediscovery-export.json
+++ b/detections/fixtures/positive/m365-exchange-ediscovery-export.json
@@ -1,0 +1,6 @@
+{
+  "operation": "New-ComplianceSearchAction",
+  "parameters": {
+    "Action": "Export"
+  }
+}

--- a/detections/fixtures/positive/m365-exchange-ediscovery-search-all-mailboxes.json
+++ b/detections/fixtures/positive/m365-exchange-ediscovery-search-all-mailboxes.json
@@ -1,0 +1,6 @@
+{
+  "operation": "New-ComplianceSearch",
+  "parameters": {
+    "ExchangeLocation": "All"
+  }
+}

--- a/detections/fixtures/positive/m365-exchange-ediscovery-search-created.json
+++ b/detections/fixtures/positive/m365-exchange-ediscovery-search-created.json
@@ -1,0 +1,4 @@
+{
+  "operation": "New-ComplianceSearch",
+  "actor": "analyst@corp.com"
+}

--- a/detections/fixtures/positive/m365-exchange-mail-connector-external-domain.json
+++ b/detections/fixtures/positive/m365-exchange-mail-connector-external-domain.json
@@ -1,0 +1,6 @@
+{
+  "operation": "New-SendConnector",
+  "parameters": {
+    "AddressSpaces": "SMTP:*.external.com:1"
+  }
+}

--- a/detections/fixtures/positive/m365-exchange-oauth-app-mailbox-access.json
+++ b/detections/fixtures/positive/m365-exchange-oauth-app-mailbox-access.json
@@ -1,0 +1,5 @@
+{
+  "operation": "MailItemsAccessed",
+  "client_app_id": "app-id-123",
+  "logon_type": "Application"
+}

--- a/detections/fixtures/positive/m365-exchange-transport-rule-external-redirect.json
+++ b/detections/fixtures/positive/m365-exchange-transport-rule-external-redirect.json
@@ -1,0 +1,6 @@
+{
+  "operation": "New-TransportRule",
+  "parameters": {
+    "RedirectMessageTo": "external@attacker.com"
+  }
+}

--- a/detections/fixtures/positive/m365-exchange-transport-rule-redirect-external.json
+++ b/detections/fixtures/positive/m365-exchange-transport-rule-redirect-external.json
@@ -1,0 +1,7 @@
+{
+  "operation": "Set-TransportRule",
+  "parameters": {
+    "RedirectMessageTo": "attacker@external.com",
+    "SentToScope": "NotInOrganization"
+  }
+}

--- a/detections/fixtures/positive/m365-power-automate-flow-shared-externally.json
+++ b/detections/fixtures/positive/m365-power-automate-flow-shared-externally.json
@@ -1,0 +1,5 @@
+{
+  "operation": "Shared a flow",
+  "shared_with": "external@outside.com",
+  "sharing_type": "CanEdit"
+}

--- a/detections/fixtures/positive/m365-power-platform-dlp-policy-modified.json
+++ b/detections/fixtures/positive/m365-power-platform-dlp-policy-modified.json
@@ -1,0 +1,4 @@
+{
+  "operation": "UpdateEnvironmentDlpPolicy",
+  "actor": "admin@corp.com"
+}

--- a/detections/fixtures/positive/m365-purview-dlp-policy-disabled.json
+++ b/detections/fixtures/positive/m365-purview-dlp-policy-disabled.json
@@ -1,0 +1,6 @@
+{
+  "operation": "Set-DlpCompliancePolicy",
+  "parameters": {
+    "Enabled": "False"
+  }
+}

--- a/detections/fixtures/positive/m365-purview-retention-policy-deleted.json
+++ b/detections/fixtures/positive/m365-purview-retention-policy-deleted.json
@@ -1,0 +1,4 @@
+{
+  "operation": "Remove-RetentionCompliancePolicy",
+  "actor": "admin@corp.com"
+}

--- a/detections/fixtures/positive/m365-purview-sensitivity-label-removed.json
+++ b/detections/fixtures/positive/m365-purview-sensitivity-label-removed.json
@@ -1,0 +1,5 @@
+{
+  "operation": "SensitivityLabelRemoved",
+  "item": "document.docx",
+  "actor": "user@corp.com"
+}

--- a/detections/fixtures/positive/m365-sharepoint-external-sharing-enabled-org.json
+++ b/detections/fixtures/positive/m365-sharepoint-external-sharing-enabled-org.json
@@ -1,0 +1,6 @@
+{
+  "operation": "SharingPolicyChanged",
+  "parameters": {
+    "SharingCapability": "ExternalUserAndGuestSharing"
+  }
+}

--- a/detections/fixtures/positive/m365-sharepoint-external-sharing-enabled-tenant.json
+++ b/detections/fixtures/positive/m365-sharepoint-external-sharing-enabled-tenant.json
@@ -1,0 +1,6 @@
+{
+  "operation": "Set-SPOTenant",
+  "parameters": {
+    "SharingCapability": "ExternalUserAndGuestSharing"
+  }
+}

--- a/detections/fixtures/positive/m365-sharepoint-site-admin-external-user.json
+++ b/detections/fixtures/positive/m365-sharepoint-site-admin-external-user.json
@@ -1,0 +1,4 @@
+{
+  "operation": "SiteCollectionAdminAdded",
+  "target_user": "external@outsider.com"
+}

--- a/detections/fixtures/positive/m365-sharepoint-site-collection-admin-added.json
+++ b/detections/fixtures/positive/m365-sharepoint-site-collection-admin-added.json
@@ -1,0 +1,5 @@
+{
+  "operation": "SiteCollectionAdminAdded",
+  "actor": "user@corp.com",
+  "site": "https://corp.sharepoint.com/sites/project"
+}

--- a/detections/fixtures/positive/m365-teams-app-sideloading-enabled.json
+++ b/detections/fixtures/positive/m365-teams-app-sideloading-enabled.json
@@ -1,0 +1,6 @@
+{
+  "operation": "TeamsAdminAction",
+  "parameters": {
+    "AllowSideloading": "True"
+  }
+}

--- a/detections/fixtures/positive/m365-teams-external-access-domain-added.json
+++ b/detections/fixtures/positive/m365-teams-external-access-domain-added.json
@@ -1,0 +1,6 @@
+{
+  "operation": "Set-CsTenantFederationConfiguration",
+  "parameters": {
+    "AllowedDomains": "attacker.com"
+  }
+}

--- a/detections/fixtures/positive/m365-teams-external-access-enabled.json
+++ b/detections/fixtures/positive/m365-teams-external-access-enabled.json
@@ -1,0 +1,7 @@
+{
+  "operation": "Set-CsTenantFederationConfiguration",
+  "parameters": {
+    "AllowFederatedUsers": "True",
+    "AllowedDomains": "AllowAllKnownDomains"
+  }
+}

--- a/detections/fixtures/positive/m365-unified-audit-log-disabled.json
+++ b/detections/fixtures/positive/m365-unified-audit-log-disabled.json
@@ -1,0 +1,6 @@
+{
+  "operation": "Set-AdminAuditLogConfig",
+  "parameters": {
+    "UnifiedAuditLogIngestionEnabled": "False"
+  }
+}

--- a/scripts/validate_detections.py
+++ b/scripts/validate_detections.py
@@ -417,7 +417,7 @@ def main() -> int:
             continue
         if len(rel_under.parts) < 2:
             continue
-        if rel_under.parts[0] == "fixtures":
+        if rel_under.parts[0] in ("fixtures", "playbooks"):
             continue
 
         classification = classify(path)

--- a/services/slack-bot/tests/test_aisoc_clients.py
+++ b/services/slack-bot/tests/test_aisoc_clients.py
@@ -174,7 +174,11 @@ async def test_transport_error_raises_without_status():
 async def test_invalid_json_raises_client_error():
     settings = _settings()
     with respx.mock() as router:
-        router.get(f"{API_BASE}/api/v1/cases/abc").mock(return_value=httpx.Response(200, text="not json", headers={"content-type": "text/plain"}))
+        router.get(f"{API_BASE}/api/v1/cases/abc").mock(
+            return_value=httpx.Response(
+                200, text="not json", headers={"content-type": "text/plain"}
+            )
+        )
         client = AisocApiClient.from_settings(settings, transport=httpx.MockTransport(router.handler))
         try:
             with pytest.raises(AisocClientError):
@@ -256,7 +260,9 @@ async def test_actions_client_falls_back_to_api_token_when_actions_token_missing
         AISOC_DEFAULT_TENANT_ID=TENANT,
     )
     with respx.mock() as router:
-        route = router.post(f"{ACTIONS_BASE}/api/v1/actions/aaa/approve").mock(return_value=httpx.Response(200, json={"id": "aaa", "status": "completed"}))
+        route = router.post(f"{ACTIONS_BASE}/api/v1/actions/aaa/approve").mock(
+            return_value=httpx.Response(200, json={"id": "aaa", "status": "completed"})
+        )
         client = AisocActionsClient.from_settings(settings, transport=httpx.MockTransport(router.handler))
         try:
             await client.approve_action("aaa")


### PR DESCRIPTION
## Summary

This PR fixes all pre-existing CI failures that were blocking PRs #45, #46, #47, and #49.

- **Detection validation**: Fix duplicate IDs in 7 M365 cloud detection rules (det-cloud-192..198 → 219..225); create 34 pairs of positive/negative fixture JSON files for cloud detections; skip `detections/playbooks/` directory from validation (playbooks are not detection rules)
- **TypeScript**: Fix `EmptyStateIcons` property casing in 7 UI components (`Search`→`search`, `Shield`→`shield`); fix TS2353 in `SettingsView.byok.test.tsx` (remove `tenant_id`, add `settings`/`created_at`)
- **Python lint**: Fix Ruff E501 line-length violations in `services/slack-bot/tests/test_aisoc_clients.py`

## Test plan
- [x] `python3 scripts/validate_detections.py --strict-fixtures` → 6948 rules, 0 failures
- [x] All TypeScript errors resolved via interface alignment
- [x] Ruff E501 violations fixed

Made with [Cursor](https://cursor.com)