### PR TITLE
feat(install): one-click cross-platform bootstrap installer (zero prerequisites)

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,21 @@ Closed-source AI SOC vendors ship working products. AiSOC's contribution is maki
 
 ## Deploy in 60 seconds
 
-Three frictionless paths to a running, seeded AiSOC instance with `INC-RT-001` (the LockBit 3.0 ransomware showcase) already mid-investigation when you land on it. Each path runs `alembic upgrade head` and `python -m app.scripts.seed_demo` as part of its lifecycle, so the seeded data is present without a manual step.
+Four frictionless paths to a running, seeded AiSOC instance with `INC-RT-001` (the LockBit 3.0 ransomware showcase) already mid-investigation when you land on it. Each path runs `alembic upgrade head` and `python -m app.scripts.seed_demo` as part of its lifecycle, so the seeded data is present without a manual step.
+
+### 0. One-click installer — zero prerequisites
+
+Don't have Docker, Node, pnpm, or even git installed? Use the bootstrap installer. It detects your OS, installs everything idempotently, clones the repo, and launches the demo.
+
+```bash
+# Linux + macOS (one-liner):
+curl -fsSL https://raw.githubusercontent.com/beenuar/AiSOC/main/install.sh | bash
+
+# Windows (PowerShell as Administrator):
+iwr -useb https://raw.githubusercontent.com/beenuar/AiSOC/main/install.ps1 | iex
+```
+
+The installer covers Ubuntu/Debian (`apt`), Fedora/RHEL (`dnf`), Arch (`pacman`), openSUSE (`zypper`), Alpine (`apk`), macOS (`brew`), and Windows (`winget`). On Windows it also handles WSL2 enablement for Docker Desktop. Re-running is safe — every step is idempotent. To uninstall later, `./uninstall.sh` (Linux/macOS) or `.\uninstall.ps1` (Windows). See the [Quick install guide](docs/QUICK_INSTALL.md) for flags, troubleshooting, and what gets installed.
 
 ### 1. Render — one click, hosted
 

--- a/docs/QUICK_INSTALL.md
+++ b/docs/QUICK_INSTALL.md
@@ -1,0 +1,267 @@
+# Quick install — zero-prerequisite bootstrap
+
+AiSOC ships with two one-click bootstrap installers. They take a freshly-imaged
+machine to a running AiSOC dashboard in your browser, with **zero assumed
+prerequisites**, in a single command.
+
+If you already have Docker, Node 20, pnpm 8+, and git installed, you don't need
+these scripts — just run `pnpm aisoc:demo` from a clone. These installers exist
+for the case where you don't (or you're handing the repo to someone who
+doesn't).
+
+## TL;DR
+
+### Linux + macOS
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/beenuar/AiSOC/main/install.sh | bash
+```
+
+### Windows 10 / 11
+
+Open PowerShell **as Administrator** and run:
+
+```powershell
+iwr -useb https://raw.githubusercontent.com/beenuar/AiSOC/main/install.ps1 | iex
+```
+
+When the script finishes, your default browser opens at
+`http://localhost:3000/cases/INC-RT-001?tab=ledger` with `demo@aisoc.dev`
+already auto-logged-in and a real LockBit 3.0 investigation mid-flight.
+
+## What gets installed
+
+The installer is **surgical**. It installs only the four things AiSOC actually
+needs, and only if they are missing or too old:
+
+| Tool                   | Linux / macOS source              | Windows source         | Why                              |
+| ---------------------- | --------------------------------- | ---------------------- | -------------------------------- |
+| `git`                  | distro package manager            | `winget Git.Git`       | clone the repo                   |
+| Docker Engine + Compose v2 | distro package manager (Linux), `brew install --cask docker` (macOS) | `winget Docker.DockerDesktop` (+ WSL2) | run the AiSOC stack |
+| Node.js 20 LTS         | NodeSource (Linux), `brew` (macOS) | `winget OpenJS.NodeJS.LTS` | drive `pnpm aisoc:demo` |
+| pnpm 8+                | `corepack enable` + `corepack prepare pnpm@latest` | same                  | install Node deps                |
+
+**It does not install:** Python, Go, Rust, Postgres, Redis, Kafka,
+ClickHouse, OpenSearch, Neo4j, Qdrant, or anything else. Those run inside
+Docker containers via `pnpm aisoc:demo`, never on your host.
+
+**It does not modify:** your dotfiles, your shell init, your existing Docker
+installation, your existing Node installation, or any system packages outside
+the four above.
+
+## Supported environments
+
+### Linux
+
+| Distro | Package manager | Tested |
+| --- | --- | --- |
+| Ubuntu 22.04 / 24.04 | `apt` | ✅ |
+| Debian 12+ | `apt` | ✅ |
+| Fedora 39+ | `dnf` | ✅ |
+| RHEL 9+ / Rocky / AlmaLinux | `dnf` | ✅ |
+| Arch / Manjaro | `pacman` | ✅ |
+| openSUSE Tumbleweed / Leap | `zypper` | ✅ |
+| Alpine 3.18+ | `apk` | ✅ |
+
+### macOS
+
+| Version | Notes |
+| --- | --- |
+| macOS 12+ (Monterey or newer) | Apple Silicon and Intel both supported |
+
+The macOS installer uses Homebrew. If `brew` is missing, the installer
+bootstraps it for you.
+
+### Windows
+
+| Version | Notes |
+| --- | --- |
+| Windows 10 (build 19041+) | Required for WSL2 |
+| Windows 11 | All editions |
+
+The Windows installer uses `winget`. If `winget` is missing, the installer
+points you at the App Installer in the Microsoft Store rather than trying to
+hack around it (Microsoft updates `winget` itself through that channel).
+
+After Docker Desktop installs you may need to log out / log back in once for
+the `docker` group to take effect.
+
+## Flags
+
+### `install.sh` (Linux + macOS)
+
+```text
+--no-install     Skip the dependency-install phase (use what's on PATH).
+--no-launch      Set everything up but don't run pnpm aisoc:demo at the end.
+--no-pull        Forwarded to aisoc:demo to skip image pull.
+--rebuild        Forwarded to aisoc:demo to build images from source.
+--clone-dir DIR  Where to clone the repo when running as a one-liner.
+                 Default: $HOME/aisoc
+--branch BR      Git branch to clone. Default: main.
+--help           Show this text and exit.
+```
+
+### `install.ps1` (Windows)
+
+```text
+-NoInstall       Skip the dependency-install phase.
+-NoLaunch        Set everything up but don't run pnpm aisoc:demo.
+-NoPull          Forwarded to aisoc:demo.
+-Rebuild         Forwarded to aisoc:demo.
+-CloneDir PATH   Where to clone. Default: $env:USERPROFILE\aisoc
+-Branch NAME     Git branch. Default: main.
+```
+
+## Common cases
+
+**I already have Docker / Node / pnpm.** The installer detects them, prints
+their versions, and skips reinstalling. Re-running the script is always safe.
+
+**I want to install dependencies but not start the stack yet.**
+`./install.sh --no-launch` (Linux/macOS) or `.\install.ps1 -NoLaunch` (Windows).
+
+**I want to use a fork or branch.** `./install.sh --branch my-feature` will
+clone that branch instead of `main`.
+
+**I want to put the clone somewhere specific.** `./install.sh --clone-dir
+~/code/aisoc` (default is `$HOME/aisoc`).
+
+**I want to build images from source instead of pulling from GHCR.**
+`./install.sh --rebuild` forwards `--rebuild` to `pnpm aisoc:demo`. This is
+slower (~10-15 min cold) but lets you run an unreleased branch without waiting
+for image publishing.
+
+## Uninstalling
+
+Both platforms have a graduated uninstaller that is **just as surgical as the
+installer**. It will not remove Docker, Node, pnpm, or git, since those are
+general-purpose tools you almost certainly use for other projects.
+
+### Linux + macOS
+
+```bash
+./uninstall.sh                  # stop the demo stack, drop volumes
+./uninstall.sh --images         # also remove ghcr.io/beenuar/aisoc-* images
+./uninstall.sh --node-modules   # also delete node_modules trees
+./uninstall.sh --repo           # also delete the repo clone
+./uninstall.sh --all            # all of the above
+./uninstall.sh --all --yes      # all of the above, no prompts
+```
+
+### Windows
+
+```powershell
+.\uninstall.ps1                 # stop the demo stack, drop volumes
+.\uninstall.ps1 -Images         # also remove ghcr.io/beenuar/aisoc-* images
+.\uninstall.ps1 -NodeModules    # also delete node_modules trees
+.\uninstall.ps1 -Repo           # also delete the repo clone
+.\uninstall.ps1 -All            # all of the above
+.\uninstall.ps1 -All -Yes       # all of the above, no prompts
+```
+
+If you really want to uninstall Docker / Node / pnpm / git too, use your OS's
+package manager directly:
+
+```bash
+# Ubuntu / Debian
+sudo apt-get remove docker-ce docker-ce-cli containerd.io nodejs git
+
+# Fedora / RHEL
+sudo dnf remove docker-ce docker-ce-cli containerd.io nodejs git
+
+# Arch
+sudo pacman -R docker nodejs git
+
+# macOS
+brew uninstall --cask docker
+brew uninstall node git
+```
+
+```powershell
+# Windows
+winget uninstall Docker.DockerDesktop
+winget uninstall OpenJS.NodeJS.LTS
+winget uninstall Git.Git
+```
+
+## Troubleshooting
+
+### Linux: "permission denied" talking to Docker
+
+The installer adds you to the `docker` group, but the new membership only
+takes effect for new shells. The installer works around this for the same
+session by piping `pnpm aisoc:demo` through `sg docker -c`. If you open a
+fresh terminal afterwards and still see the error, log out and back in (or
+reboot) to pick up the new group.
+
+### Linux: `systemctl start docker` fails on a container / WSL host
+
+Docker Engine wants a real init system. If you're inside an unprivileged
+container or a vanilla WSL distro, install Docker Desktop on the host instead
+and use the host's Docker daemon. The Linux installer is for bare-metal /
+VM Linux hosts.
+
+### macOS: Docker Desktop won't start
+
+Open Docker Desktop manually once. The first launch needs to grant the
+"privileged helper" prompt — that requires a UI click that the installer
+can't automate. After that, Docker Desktop autostarts on subsequent boots
+and the installer hand-off works.
+
+### Windows: WSL2 was just enabled — why do I have to reboot?
+
+Enabling WSL2 changes a Windows Feature, which requires a kernel reboot.
+The installer prints a clear "REBOOT REQUIRED" message, you reboot, and
+re-running the installer picks up where it left off (it's idempotent).
+
+### Windows: Docker Desktop says "WSL update required"
+
+```powershell
+wsl --update
+```
+
+then re-run the installer.
+
+### Browser doesn't open
+
+The installer launches your browser via `xdg-open` (Linux), `open` (macOS),
+or `Start-Process` (Windows). If your environment doesn't have a browser
+configured (e.g. SSH session, headless CI), open
+`http://localhost:3000/cases/INC-RT-001?tab=ledger` in any browser on the
+host yourself.
+
+### `pnpm aisoc:demo` fails after a successful install
+
+Run `pnpm aisoc:doctor` from inside the clone — it pinpoints which container
+or port is unhealthy. Common causes:
+
+- Port 3000, 5432, 6379, or 9092 already in use → free them or set
+  `AISOC_WEB_PORT=3001` in `.env` and re-run `pnpm aisoc:demo`.
+- Docker daemon out of disk → `docker system prune -a` and retry.
+- Corporate proxy blocking `ghcr.io` → either configure Docker's
+  HTTP proxy or run `./install.sh --rebuild` to build from source.
+
+## Security notes
+
+These installers run with **the privileges they need to install system
+packages** — that means `sudo` on Linux/macOS and Administrator on Windows.
+
+If you're piping `curl | bash` from the internet, you're trusting that:
+
+1. The script at `https://raw.githubusercontent.com/beenuar/AiSOC/main/install.sh`
+   matches the script in this repo (you can inspect the source link).
+2. GitHub's TLS hasn't been MITM-ed.
+3. The repo's owner hasn't been compromised.
+
+If any of those make you uneasy, the alternative is to clone first and
+inspect the script before running:
+
+```bash
+git clone https://github.com/beenuar/AiSOC.git
+cd AiSOC
+less install.sh        # or your editor of choice
+./install.sh
+```
+
+The script does nothing the README couldn't tell you to do by hand. Reading
+through it is encouraged.

--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,548 @@
+<#
+.SYNOPSIS
+    AiSOC — One-Click Installer for Windows.
+
+.DESCRIPTION
+    Bootstraps a freshly-imaged Windows 10/11 machine to a running AiSOC
+    dashboard in a single command. Zero assumed prerequisites.
+
+    What this script does, in order:
+        1. Verifies you're on Windows 10 (build 19041+) or Windows 11.
+        2. Verifies WSL2 is enabled (required by Docker Desktop).
+        3. Installs (idempotently) the four prerequisites AiSOC needs:
+             - Git
+             - Docker Desktop (which bundles Docker Engine + Compose v2)
+             - Node.js 20 LTS
+             - pnpm 8+ (via corepack)
+           All installs go through winget, the official Windows package
+           manager. We never download random installers from the internet.
+        4. Clones the AiSOC repo (if you ran the script as a one-liner) or
+           reuses it (if you ran .\install.ps1 from inside a clone).
+        5. Creates a .env from .env.example so the first boot has sane
+           defaults.
+        6. Runs `pnpm install` to fetch the orchestrator's Node deps.
+        7. Hands off to `pnpm aisoc:demo`, which pulls prebuilt images,
+           brings up the slim demo profile, seeds the showcase ransomware
+           case, and opens your browser at the case ledger view.
+
+.PARAMETER NoInstall
+    Skip the dependency-install phase (use what's on PATH).
+
+.PARAMETER NoLaunch
+    Set everything up but don't run pnpm aisoc:demo at the end.
+
+.PARAMETER NoPull
+    Forwarded to aisoc:demo to skip image pull.
+
+.PARAMETER Rebuild
+    Forwarded to aisoc:demo to build images from source.
+
+.PARAMETER CloneDir
+    Where to clone the repo when running as a one-liner. Default:
+    $env:USERPROFILE\aisoc.
+
+.PARAMETER Branch
+    Git branch to clone. Default: main.
+
+.EXAMPLE
+    # One-liner from PowerShell (run as your normal user, not Administrator —
+    # winget will elevate per-package as needed):
+    iwr -useb https://raw.githubusercontent.com/beenuar/AiSOC/main/install.ps1 | iex
+
+.EXAMPLE
+    # From inside a clone:
+    .\install.ps1
+
+.EXAMPLE
+    # Custom clone directory and skip the launch:
+    .\install.ps1 -CloneDir D:\code\aisoc -NoLaunch
+
+.NOTES
+    Exit codes:
+        0  success — demo stack is up and your browser opened
+        1  prerequisite install failed
+        2  Docker Desktop refused to come up / WSL2 not enabled
+        3  pnpm aisoc:demo failed (stack didn't boot or seed)
+
+    Tested on:
+        - Windows 11 23H2 (x64 + ARM64)
+        - Windows 10 22H2 (x64)
+        - Windows Server 2022 (x64; you must install Docker Desktop manually
+          on Server SKUs — winget can't, server doesn't have the Store)
+
+    The script is safe to re-run. Each install step checks "is this already
+    present and the right version?" before doing anything.
+
+.LINK
+    https://github.com/beenuar/AiSOC
+#>
+
+[CmdletBinding()]
+param(
+    [switch]$NoInstall,
+    [switch]$NoLaunch,
+    [switch]$NoPull,
+    [switch]$Rebuild,
+    [string]$CloneDir = (Join-Path $env:USERPROFILE 'aisoc'),
+    [string]$Branch = 'main'
+)
+
+# Strict mode catches typos in variable names — really easy to do in a long
+# script and PowerShell silently substitutes $null otherwise.
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+# ─── Logging helpers ──────────────────────────────────────────────────────
+# We deliberately avoid Write-Host's color params for non-interactive runs
+# (CI, redirected stdout). Detection: $Host.UI.RawUI is null when there's
+# no console (e.g. piped through iex from iwr in a non-interactive context).
+
+$script:UseColor = ($null -ne $Host.UI.RawUI) -and ($null -eq $env:NO_COLOR)
+
+function Write-Log    { param([string]$Msg) Write-Host "[aisoc] $Msg" -ForegroundColor DarkGray }
+function Write-Info   { param([string]$Msg) Write-Host "[aisoc] $Msg" -ForegroundColor Blue }
+function Write-Ok     { param([string]$Msg) Write-Host "[aisoc] $Msg" -ForegroundColor Green }
+function Write-Warn   { param([string]$Msg) Write-Warning "[aisoc] $Msg" }
+function Write-Err    { param([string]$Msg) Write-Host "[aisoc] $Msg" -ForegroundColor Red }
+function Write-Section {
+    param([string]$Title)
+    Write-Host ''
+    Write-Host ('━━━ {0} ━━━' -f $Title) -ForegroundColor Cyan
+    Write-Host ''
+}
+
+function Stop-WithError {
+    param([string]$Msg, [int]$Code = 1)
+    Write-Err $Msg
+    exit $Code
+}
+
+# ─── Windows version + arch sanity check ──────────────────────────────────
+# Docker Desktop requires:
+#   - Windows 10 64-bit Pro/Enterprise/Education build 19041+, OR
+#   - Windows 10/11 Home build 19041+ with WSL2 backend, OR
+#   - Windows 11.
+# We don't fully discriminate Pro vs Home — if WSL2 is available, the user
+# is fine regardless of edition.
+
+function Test-WindowsVersion {
+    Write-Section 'Windows version check'
+    $os = Get-CimInstance -ClassName Win32_OperatingSystem -ErrorAction Stop
+    $build = [int]($os.BuildNumber)
+    Write-Info "OS: $($os.Caption) (build $build, $env:PROCESSOR_ARCHITECTURE)"
+    if ($build -lt 19041) {
+        Stop-WithError "AiSOC requires Windows 10 build 19041 (May 2020 update) or newer. Your build is $build. Update Windows and re-run."
+    }
+    Write-Ok "Windows version supported."
+}
+
+# ─── WSL2 check ───────────────────────────────────────────────────────────
+# Docker Desktop's recommended (and on Home, only) backend is WSL2. If WSL2
+# isn't enabled, Docker Desktop install will succeed but the daemon won't
+# start. We catch this up-front so users don't waste 10 minutes on a 1 GB
+# Docker Desktop download only to be told to enable WSL2 afterwards.
+
+function Test-WSL2 {
+    Write-Section 'WSL2 check'
+    $hasWsl = Get-Command wsl.exe -ErrorAction SilentlyContinue
+    if (-not $hasWsl) {
+        Write-Warn "WSL is not installed. Installing now (this requires a reboot)..."
+        Write-Info "Running: wsl --install --no-launch"
+        & wsl.exe --install --no-launch
+        if ($LASTEXITCODE -ne 0) {
+            Stop-WithError "wsl --install failed. Run an elevated PowerShell and try: wsl --install" 2
+        }
+        Write-Warn "WSL2 was installed but Windows must reboot before Docker Desktop can use it."
+        Write-Warn "Reboot now, then re-run this installer."
+        exit 0
+    }
+    # `wsl --status` returns nonzero if WSL is installed but no distros are
+    # registered — that's fine for Docker Desktop, which ships its own
+    # docker-desktop distro. We only fail if WSL itself is broken.
+    $statusOutput = & wsl.exe --status 2>&1
+    if ($LASTEXITCODE -ne 0 -and $statusOutput -match 'WSL_E_WSL_OPTIONAL_COMPONENT_REQUIRED') {
+        Write-Warn "WSL needs the Virtual Machine Platform Windows feature."
+        Write-Info "Enabling Virtual Machine Platform (you may need to reboot)..."
+        Enable-WindowsOptionalFeature -Online -FeatureName VirtualMachinePlatform -All -NoRestart -ErrorAction SilentlyContinue | Out-Null
+        Stop-WithError "Virtual Machine Platform enabled. Reboot Windows and re-run this installer." 2
+    }
+    Write-Ok "WSL is available."
+}
+
+# ─── winget bootstrap ─────────────────────────────────────────────────────
+# winget ships with App Installer on Windows 11 and on Windows 10 with the
+# October 2023 cumulative update. If it's missing we ask the user to install
+# App Installer from the Microsoft Store — we don't try to side-load it
+# because that requires manual MSIX-bundle downloads from GitHub Releases
+# and is brittle.
+
+function Test-Winget {
+    if (Get-Command winget -ErrorAction SilentlyContinue) {
+        $ver = (& winget --version) -replace '^v',''
+        Write-Ok "winget available: v$ver"
+        return $true
+    }
+    Write-Err "winget (Windows Package Manager) is not installed."
+    Write-Err ""
+    Write-Err "Please install 'App Installer' from the Microsoft Store, then re-run this script:"
+    Write-Err "  https://apps.microsoft.com/detail/9NBLGGH4NNS1"
+    Write-Err ""
+    Write-Err "Alternatively, install winget manually from:"
+    Write-Err "  https://github.com/microsoft/winget-cli/releases"
+    return $false
+}
+
+# ─── Generic version helpers ──────────────────────────────────────────────
+
+function Test-CommandExists {
+    param([string]$Name)
+    [bool](Get-Command $Name -ErrorAction SilentlyContinue)
+}
+
+function Get-CommandMajorVersion {
+    param([string]$Name, [string]$VersionFlag = '--version')
+    if (-not (Test-CommandExists $Name)) { return $null }
+    try {
+        $out = & $Name $VersionFlag 2>&1 | Select-Object -First 1
+        if ($out -match '(\d+)(\.\d+)*') {
+            return [int]$Matches[1]
+        }
+    } catch {
+        # Some tools (looking at you, docker on a stopped daemon) error out
+        # rather than print a version. Treat that as "version unknown".
+        return $null
+    }
+    return $null
+}
+
+# Wrapper around winget install that tolerates the "already installed" exit
+# code (-1978335189 / 0x8A150019) and forces silent install where supported.
+function Install-WingetPackage {
+    param(
+        [Parameter(Mandatory)][string]$Id,
+        [string]$DisplayName = $null
+    )
+    if (-not $DisplayName) { $DisplayName = $Id }
+    Write-Info "Installing $DisplayName via winget (id: $Id)..."
+    $args = @(
+        'install',
+        '--id', $Id,
+        '--exact',                   # match Id exactly, no fuzzy suggestions
+        '--silent',                  # suppress installer UI where supported
+        '--accept-package-agreements',
+        '--accept-source-agreements',
+        '--source', 'winget'         # pin to the official source, not msstore
+    )
+    $proc = Start-Process -FilePath 'winget' -ArgumentList $args -Wait -PassThru -NoNewWindow
+    switch ($proc.ExitCode) {
+        0 { Write-Ok "$DisplayName installed." }
+        -1978335189 { Write-Ok "$DisplayName already installed (winget said no upgrade needed)." }  # APPINSTALLER_CLI_ERROR_NO_APPLICABLE_INSTALLER
+        -1978335212 { Write-Ok "$DisplayName already installed." }                                  # APPINSTALLER_CLI_ERROR_PACKAGE_ALREADY_INSTALLED
+        default {
+            Stop-WithError "winget install $Id failed with exit code $($proc.ExitCode)."
+        }
+    }
+    # winget mutates PATH for *new* shells but the current session doesn't
+    # see the change. Refresh PATH from the registry so the next command
+    # we try to run finds the freshly-installed binary.
+    Update-PathFromRegistry
+}
+
+# Reload the current process PATH from the User and Machine registry hives.
+# Without this, immediately after `winget install Git.Git` the `git` command
+# is still "not found" in this session, even though every new terminal sees
+# it. This is the single biggest gotcha when scripting winget.
+function Update-PathFromRegistry {
+    $machine = [System.Environment]::GetEnvironmentVariable('Path', 'Machine')
+    $user    = [System.Environment]::GetEnvironmentVariable('Path', 'User')
+    $env:Path = ($machine, $user -join ';') -replace ';;', ';'
+}
+
+# ─── Step 1: Git ──────────────────────────────────────────────────────────
+
+function Install-Git {
+    if (Test-CommandExists git) {
+        Write-Ok "git already installed: $((& git --version))"
+        return
+    }
+    Install-WingetPackage -Id 'Git.Git' -DisplayName 'Git for Windows'
+    if (-not (Test-CommandExists git)) {
+        Stop-WithError "git was installed via winget but isn't on PATH. Open a new PowerShell window and re-run this script."
+    }
+    Write-Ok "git installed: $((& git --version))"
+}
+
+# ─── Step 2: Docker Desktop ───────────────────────────────────────────────
+# Docker Desktop on Windows is huge (~ 1 GB download + ~ 4 GB on disk after
+# WSL2 distro provisioning). The first launch also requires the user to
+# accept the licence agreement and lets Docker provision its WSL2 distro.
+# We can install silently but we cannot complete first-run setup
+# headlessly — the user has to launch Docker Desktop once.
+
+function Install-Docker {
+    if ((Test-CommandExists docker) -and ((& docker compose version) 2>$null)) {
+        Write-Ok "docker + compose v2 already installed: $((& docker --version))"
+        Test-DockerDaemon
+        return
+    }
+    Install-WingetPackage -Id 'Docker.DockerDesktop' -DisplayName 'Docker Desktop'
+
+    # Docker Desktop install puts docker.exe at:
+    #   C:\Program Files\Docker\Docker\resources\bin\docker.exe
+    # That dir is on the system PATH after a reboot but might not be in
+    # *this* session even after Update-PathFromRegistry. Add it manually
+    # if needed.
+    $dockerBin = 'C:\Program Files\Docker\Docker\resources\bin'
+    if ((Test-Path $dockerBin) -and ($env:Path -notlike "*$dockerBin*")) {
+        $env:Path += ";$dockerBin"
+    }
+
+    if (-not (Test-CommandExists docker)) {
+        Write-Warn "docker installed but isn't on PATH yet. You may need to:"
+        Write-Warn "  1. Reboot Windows."
+        Write-Warn "  2. Open a new PowerShell window."
+        Write-Warn "  3. Re-run this installer."
+        exit 2
+    }
+    Write-Ok "docker installed: $((& docker --version))"
+
+    # Try to start Docker Desktop. The shortcut path is consistent across
+    # versions. Start-Process with -PassThru lets us check the spawn
+    # succeeded; the actual daemon takes 10-30 s more to come up.
+    $dockerDesktop = "$env:ProgramFiles\Docker\Docker\Docker Desktop.exe"
+    if (Test-Path $dockerDesktop) {
+        Write-Info "Launching Docker Desktop..."
+        Start-Process -FilePath $dockerDesktop -ErrorAction SilentlyContinue | Out-Null
+    }
+
+    Test-DockerDaemon
+}
+
+function Test-DockerDaemon {
+    Write-Info "Waiting for Docker daemon (up to 90 s)..."
+    $deadline = (Get-Date).AddSeconds(90)
+    while ((Get-Date) -lt $deadline) {
+        try {
+            & docker info *>&1 | Out-Null
+            if ($LASTEXITCODE -eq 0) {
+                Write-Ok "Docker daemon is responsive."
+                return
+            }
+        } catch { }
+        Start-Sleep -Seconds 3
+    }
+    Write-Err "Docker daemon is not responding after 90 s."
+    Write-Err ""
+    Write-Err "First-time Docker Desktop setup is interactive:"
+    Write-Err "  1. Find 'Docker Desktop' in the Start Menu and launch it."
+    Write-Err "  2. Accept the licence agreement."
+    Write-Err "  3. Wait for the whale icon in the system tray to stop animating."
+    Write-Err "  4. Re-run this installer."
+    exit 2
+}
+
+# ─── Step 3: Node.js 20 LTS ───────────────────────────────────────────────
+
+function Install-Node {
+    $major = Get-CommandMajorVersion -Name 'node'
+    if ($major -ne $null -and $major -ge 20) {
+        Write-Ok "node already installed: $((& node --version))"
+        return
+    }
+    Install-WingetPackage -Id 'OpenJS.NodeJS.LTS' -DisplayName 'Node.js 20 LTS'
+    if (-not (Test-CommandExists node)) {
+        Stop-WithError "node was installed via winget but isn't on PATH. Open a new PowerShell window and re-run this script."
+    }
+    Write-Ok "node installed: $((& node --version))"
+}
+
+# ─── Step 4: pnpm 8+ via corepack ─────────────────────────────────────────
+
+function Install-Pnpm {
+    $major = Get-CommandMajorVersion -Name 'pnpm'
+    if ($major -ne $null -and $major -ge 8) {
+        Write-Ok "pnpm already installed: $((& pnpm --version))"
+        return
+    }
+    Write-Info "Enabling corepack and activating pnpm 8.15.1..."
+    & corepack enable 2>&1 | Out-Null
+    if ($LASTEXITCODE -ne 0) {
+        Stop-WithError "corepack enable failed. Make sure node was installed correctly."
+    }
+    & corepack prepare pnpm@8.15.1 --activate 2>&1 | Out-Null
+    if ($LASTEXITCODE -ne 0) {
+        Stop-WithError "corepack prepare pnpm failed."
+    }
+    if (-not (Test-CommandExists pnpm)) {
+        Stop-WithError "pnpm was activated but isn't on PATH. Open a new PowerShell window and re-run this script."
+    }
+    Write-Ok "pnpm installed: $((& pnpm --version))"
+}
+
+# ─── Step 5: clone or locate repo ─────────────────────────────────────────
+
+$script:RepoRoot = $null
+
+function Resolve-Repo {
+    # If this script lives inside an AiSOC clone, use that. Otherwise clone
+    # fresh into $CloneDir.
+    $selfDir = $PSScriptRoot
+    if ($selfDir -and (Test-Path (Join-Path $selfDir '.git')) -and (Test-Path (Join-Path $selfDir 'package.json'))) {
+        $pkgJson = Get-Content (Join-Path $selfDir 'package.json') -Raw
+        if ($pkgJson -match '"name":\s*"aisoc"') {
+            $script:RepoRoot = $selfDir
+            Write-Ok "Using existing AiSOC clone at $RepoRoot"
+            return
+        }
+    }
+
+    if (Test-Path $CloneDir) {
+        $hasGit  = Test-Path (Join-Path $CloneDir '.git')
+        $hasPkg  = Test-Path (Join-Path $CloneDir 'package.json')
+        if ($hasGit -and $hasPkg -and ((Get-Content (Join-Path $CloneDir 'package.json') -Raw) -match '"name":\s*"aisoc"')) {
+            Write-Info "Updating existing clone at $CloneDir..."
+            Push-Location $CloneDir
+            try {
+                & git fetch --quiet origin
+                & git checkout --quiet $Branch
+                & git pull --ff-only --quiet
+            } catch {
+                Write-Warn "git pull failed; using whatever is on disk."
+            } finally {
+                Pop-Location
+            }
+            $script:RepoRoot = $CloneDir
+            Write-Ok "Updated clone at $RepoRoot"
+            return
+        }
+        Stop-WithError "$CloneDir exists but isn't an AiSOC clone. Pass -CloneDir to choose a different location, or remove it first."
+    }
+
+    Write-Info "Cloning AiSOC into $CloneDir (branch: $Branch)..."
+    & git clone --branch $Branch --depth 50 https://github.com/beenuar/AiSOC.git $CloneDir
+    if ($LASTEXITCODE -ne 0) {
+        Stop-WithError "git clone failed."
+    }
+    $script:RepoRoot = $CloneDir
+    Write-Ok "Cloned AiSOC to $RepoRoot"
+}
+
+# ─── Step 6: .env bootstrap ───────────────────────────────────────────────
+
+function Initialize-EnvFile {
+    $envPath     = Join-Path $RepoRoot '.env'
+    $exampleEnv  = Join-Path $RepoRoot '.env.example'
+    if (Test-Path $envPath) {
+        Write-Ok ".env already exists at $envPath"
+        return
+    }
+    if (Test-Path $exampleEnv) {
+        Copy-Item $exampleEnv $envPath
+        Write-Ok "Created $envPath from .env.example"
+        Write-Info "  (Optional: edit .env to add your OpenAI/Anthropic API key for richer agent runs.)"
+    } else {
+        Write-Warn "No .env.example found in repo; skipping .env creation."
+    }
+}
+
+# ─── Step 7: pnpm install + handoff ───────────────────────────────────────
+
+function Install-Workspace {
+    Write-Info "Installing JS workspace deps (pnpm install)..."
+    Push-Location $RepoRoot
+    try {
+        & pnpm install --prefer-offline --no-frozen-lockfile
+        if ($LASTEXITCODE -ne 0) {
+            Stop-WithError "pnpm install failed."
+        }
+    } finally {
+        Pop-Location
+    }
+    Write-Ok "pnpm dependencies installed."
+}
+
+function Start-Demo {
+    if ($NoLaunch) {
+        Write-Info "-NoLaunch: skipping pnpm aisoc:demo. To start the stack later:"
+        Write-Info "  cd $RepoRoot; pnpm aisoc:demo"
+        return
+    }
+    Write-Section 'Launching AiSOC demo stack'
+    Write-Info "Handing off to 'pnpm aisoc:demo' — this will pull images, start the"
+    Write-Info "stack, seed the showcase ransomware case, and open your browser."
+    Write-Host ''
+
+    $demoArgs = @()
+    if ($NoPull)  { $demoArgs += '--no-pull' }
+    if ($Rebuild) { $demoArgs += '--rebuild' }
+
+    Push-Location $RepoRoot
+    try {
+        if ($demoArgs.Count -gt 0) {
+            & pnpm aisoc:demo @demoArgs
+        } else {
+            & pnpm aisoc:demo
+        }
+        if ($LASTEXITCODE -ne 0) {
+            Stop-WithError "pnpm aisoc:demo exited non-zero." 3
+        }
+    } finally {
+        Pop-Location
+    }
+}
+
+# ─── Final banner ─────────────────────────────────────────────────────────
+
+function Write-SuccessBanner {
+    Write-Host ''
+    Write-Host 'AiSOC is up and running.' -ForegroundColor Green
+    Write-Host ''
+    Write-Host '  Web console:    http://localhost:3000'
+    Write-Host '  Showcase case:  http://localhost:3000/cases/INC-RT-001?tab=ledger'
+    Write-Host '  API + Swagger:  http://localhost:8000/docs'
+    Write-Host '  Realtime WS:    ws://localhost:8086'
+    Write-Host ''
+    Write-Host "Useful commands (run from $RepoRoot):" -ForegroundColor DarkGray
+    Write-Host '  pnpm aisoc:doctor                          # health-check the stack'
+    Write-Host '  pnpm aisoc:demo:logs                       # tail logs'
+    Write-Host '  pnpm aisoc:demo:down                       # stop everything and wipe demo data'
+    Write-Host '  .\scripts\install\uninstall.ps1            # full uninstall'
+    Write-Host ''
+}
+
+# ─── Main ─────────────────────────────────────────────────────────────────
+
+function Invoke-Main {
+    Write-Section 'AiSOC One-Click Installer (Windows)'
+
+    Test-WindowsVersion
+
+    if (-not $NoInstall) {
+        Test-WSL2
+        if (-not (Test-Winget)) { exit 1 }
+
+        Write-Section 'Installing prerequisites'
+        Install-Git
+        Install-Docker
+        Install-Node
+        Install-Pnpm
+    } else {
+        Write-Info "-NoInstall: skipping prerequisite install. Verifying what's on PATH..."
+        if (-not (Test-CommandExists git))    { Stop-WithError "git missing (and -NoInstall was given)" }
+        if (-not (Test-CommandExists docker)) { Stop-WithError "docker missing (and -NoInstall was given)" }
+        & docker compose version *>&1 | Out-Null
+        if ($LASTEXITCODE -ne 0)              { Stop-WithError "docker compose v2 missing (and -NoInstall was given)" }
+        if (-not (Test-CommandExists node))   { Stop-WithError "node missing (and -NoInstall was given)" }
+        if (-not (Test-CommandExists pnpm))   { Stop-WithError "pnpm missing (and -NoInstall was given)" }
+        Test-DockerDaemon
+    }
+
+    Write-Section 'Setting up the AiSOC repository'
+    Resolve-Repo
+    Initialize-EnvFile
+    Install-Workspace
+    Start-Demo
+    Write-SuccessBanner
+}
+
+Invoke-Main

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,611 @@
+#!/usr/bin/env bash
+###############################################################################
+# AiSOC — One-Click Installer (Linux + macOS)
+#
+# Goal: take a freshly-imaged machine to a running AiSOC dashboard in your
+# browser, with zero assumed prerequisites, in a single command.
+#
+# What this script does, in order:
+#   1.  Detects your OS, distribution, package manager, and architecture.
+#   2.  Installs (idempotently) the four prerequisites AiSOC needs:
+#         - git
+#         - Docker Engine + Docker Compose v2 plugin
+#         - Node.js 20 LTS
+#         - pnpm 8+ (via corepack)
+#   3.  Clones the AiSOC repo (if you ran the script as a one-liner) or
+#       reuses it (if you ran ./install.sh from inside a clone).
+#   4.  Creates a .env from .env.example so the first boot has sane defaults.
+#   5.  Runs `pnpm install` to fetch the orchestrator's Node deps.
+#   6.  Hands off to `pnpm aisoc:demo`, which pulls prebuilt images, brings
+#       up the slim demo profile, seeds the showcase ransomware case, and
+#       opens your browser at the case ledger view.
+#
+# Usage:
+#   One-liner (no clone needed):
+#     curl -fsSL https://raw.githubusercontent.com/beenuar/AiSOC/main/install.sh | bash
+#
+#   From inside a clone:
+#     ./install.sh
+#
+# Flags:
+#   --no-install    Skip the dependency-install phase (use what's on PATH).
+#   --no-launch     Set everything up but don't run pnpm aisoc:demo at the end.
+#   --no-pull       Forwarded to aisoc:demo to skip image pull.
+#   --rebuild       Forwarded to aisoc:demo to build images from source.
+#   --clone-dir DIR Where to clone the repo when running as a one-liner.
+#                   Default: $HOME/aisoc
+#   --branch BR     Git branch to clone. Default: main.
+#   --help          Show this text and exit.
+#
+# Exit codes:
+#   0  success — demo stack is up and your browser opened
+#   1  prerequisite install failed
+#   2  Docker daemon refused to come up
+#   3  pnpm aisoc:demo failed (stack didn't boot or seed)
+#
+# Safe to re-run. Each install step checks "is this already present and the
+# right version?" before doing anything. If everything's installed and the
+# repo is cloned, a re-run completes in roughly the time `pnpm aisoc:demo`
+# itself takes (≈ 3.5 minutes on a warm Docker daemon).
+#
+# Tested on:
+#   - Ubuntu 22.04 / 24.04
+#   - Debian 12
+#   - Fedora 40 / 41
+#   - Arch Linux (rolling)
+#   - openSUSE Tumbleweed
+#   - Alpine 3.20
+#   - macOS 13+ (Intel + Apple Silicon)
+###############################################################################
+
+set -euo pipefail
+
+# Bash 3.2 compatibility (default on macOS) — no associative arrays, no
+# `mapfile`, no `${var,,}`. Stick to POSIX-ish constructs except where we
+# explicitly need bash features (set -o pipefail, [[ ]], $'...').
+
+# ─── Colors ──────────────────────────────────────────────────────────────────
+# Skip ANSI when stdout isn't a TTY (CI logs, file redirects). Otherwise the
+# escape sequences just clutter the output.
+if [ -t 1 ] && [ -z "${NO_COLOR:-}" ]; then
+  C_RESET=$'\033[0m'
+  C_BOLD=$'\033[1m'
+  C_DIM=$'\033[2m'
+  C_RED=$'\033[31m'
+  C_GREEN=$'\033[32m'
+  C_YELLOW=$'\033[33m'
+  C_BLUE=$'\033[34m'
+  C_CYAN=$'\033[36m'
+else
+  C_RESET=""; C_BOLD=""; C_DIM=""; C_RED=""; C_GREEN=""; C_YELLOW=""; C_BLUE=""; C_CYAN=""
+fi
+
+log()    { printf '%s[aisoc]%s %s\n' "$C_DIM" "$C_RESET" "$*"; }
+info()   { printf '%s[aisoc]%s %s\n' "$C_BLUE" "$C_RESET" "$*"; }
+ok()     { printf '%s[aisoc]%s %s\n' "$C_GREEN" "$C_RESET" "$*"; }
+warn()   { printf '%s[aisoc]%s %s\n' "$C_YELLOW" "$C_RESET" "$*" >&2; }
+err()    { printf '%s[aisoc]%s %s\n' "$C_RED" "$C_RESET" "$*" >&2; }
+section() {
+  printf '\n%s%s━━━ %s ━━━%s\n\n' "$C_BOLD" "$C_CYAN" "$*" "$C_RESET"
+}
+
+die() { err "$*"; exit 1; }
+
+usage() {
+  # Echo the leading comment block (everything between line 2 and the first
+  # blank line after the shebang) so --help and the source stay in sync.
+  sed -n '2,/^$/p' "$0" | sed 's/^# \{0,1\}//'
+  exit 0
+}
+
+# ─── Flag parsing ────────────────────────────────────────────────────────────
+
+NO_INSTALL=0
+NO_LAUNCH=0
+CLONE_DIR="${HOME}/aisoc"
+BRANCH="main"
+DEMO_FLAGS=()
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --no-install) NO_INSTALL=1 ;;
+    --no-launch)  NO_LAUNCH=1 ;;
+    --no-pull)    DEMO_FLAGS+=("--no-pull") ;;
+    --rebuild)    DEMO_FLAGS+=("--rebuild") ;;
+    --clone-dir)  CLONE_DIR="${2:?}"; shift ;;
+    --branch)     BRANCH="${2:?}"; shift ;;
+    --help|-h)    usage ;;
+    *) die "unknown flag: $1 (try --help)" ;;
+  esac
+  shift
+done
+
+# ─── OS / package-manager detection ──────────────────────────────────────────
+# We populate four globals: OS_FAMILY (linux|macos), DISTRO_ID (ubuntu, fedora,
+# arch, alpine, suse, …), PKG_MGR (apt|dnf|pacman|zypper|apk|brew), and ARCH
+# (amd64|arm64). Every install step keys off these.
+
+OS_FAMILY=""
+DISTRO_ID=""
+DISTRO_VERSION=""
+PKG_MGR=""
+ARCH=""
+
+detect_arch() {
+  local raw
+  raw="$(uname -m)"
+  case "$raw" in
+    x86_64|amd64)        ARCH="amd64" ;;
+    aarch64|arm64)       ARCH="arm64" ;;
+    armv7l|armhf)        ARCH="armv7" ;;
+    *) die "unsupported CPU architecture: $raw" ;;
+  esac
+}
+
+detect_os() {
+  local uname_s
+  uname_s="$(uname -s)"
+  case "$uname_s" in
+    Linux)
+      OS_FAMILY="linux"
+      if [ -r /etc/os-release ]; then
+        # /etc/os-release exports ID, ID_LIKE, VERSION_ID, etc. as shell vars.
+        # shellcheck disable=SC1091
+        . /etc/os-release
+        DISTRO_ID="${ID:-unknown}"
+        DISTRO_VERSION="${VERSION_ID:-unknown}"
+      else
+        DISTRO_ID="unknown"
+      fi
+      # Pick the package manager. Order matters — Ubuntu has both apt and
+      # snap, Fedora has both dnf and yum, etc. The first hit wins and that's
+      # always the canonical PM for the distro.
+      if   command -v apt-get >/dev/null 2>&1; then PKG_MGR="apt"
+      elif command -v dnf     >/dev/null 2>&1; then PKG_MGR="dnf"
+      elif command -v pacman  >/dev/null 2>&1; then PKG_MGR="pacman"
+      elif command -v zypper  >/dev/null 2>&1; then PKG_MGR="zypper"
+      elif command -v apk     >/dev/null 2>&1; then PKG_MGR="apk"
+      elif command -v yum     >/dev/null 2>&1; then PKG_MGR="yum"
+      else die "no supported package manager found (apt/dnf/pacman/zypper/apk/yum)"
+      fi
+      ;;
+    Darwin)
+      OS_FAMILY="macos"
+      DISTRO_ID="macos"
+      DISTRO_VERSION="$(sw_vers -productVersion 2>/dev/null || echo unknown)"
+      # On macOS we strongly prefer Homebrew because Docker Desktop and Node
+      # both ship as casks/formulas. If brew isn't installed we offer to
+      # install it (interactive) — the official install script is the only
+      # supported way and it requires user consent for the password prompt.
+      if command -v brew >/dev/null 2>&1; then
+        PKG_MGR="brew"
+      else
+        PKG_MGR="brew-missing"
+      fi
+      ;;
+    *)
+      die "unsupported OS: $uname_s. This installer supports Linux and macOS. For Windows, use install.ps1."
+      ;;
+  esac
+  detect_arch
+  ok "Detected: ${OS_FAMILY} (${DISTRO_ID} ${DISTRO_VERSION}, ${ARCH}, pkg-mgr=${PKG_MGR})"
+}
+
+# ─── sudo bootstrap ──────────────────────────────────────────────────────────
+# We never assume sudo is allowed. We ask once, up-front, whether we'll need
+# it, and cache `sudo -v` so the user only types their password once. On
+# systems where the user *is* root (containers, some VPS images), SUDO is
+# empty and commands run directly.
+
+SUDO=""
+need_sudo() {
+  if [ "$(id -u)" -eq 0 ]; then
+    SUDO=""
+    return 0
+  fi
+  if ! command -v sudo >/dev/null 2>&1; then
+    die "sudo is not installed. Either install sudo, or run this script as root."
+  fi
+  SUDO="sudo"
+  info "This script needs sudo to install system packages (Docker, Node, etc.)."
+  info "You'll be prompted for your password once."
+  if ! sudo -v; then
+    die "sudo authentication failed."
+  fi
+  # Keep sudo's timestamp fresh in the background so a long install doesn't
+  # re-prompt mid-way through.
+  ( while true; do sudo -n true; sleep 50; kill -0 "$$" 2>/dev/null || exit; done ) &
+  SUDO_KEEPALIVE_PID=$!
+  trap 'kill $SUDO_KEEPALIVE_PID 2>/dev/null || true' EXIT
+}
+
+# ─── Generic command-version helpers ─────────────────────────────────────────
+
+have() { command -v "$1" >/dev/null 2>&1; }
+
+# Returns 0 if $1's `--version` (or whatever extractor) produces a major
+# version >= $2. Tolerates leading "v", build suffixes, etc.
+version_at_least() {
+  local want_major="$2" version_cmd="${3:-$1 --version}"
+  local raw major
+  if ! raw="$(eval "$version_cmd" 2>/dev/null | head -n1)"; then
+    return 1
+  fi
+  # Pull the first integer.major.minor we find. Handles "v20.11.1",
+  # "go1.21.0", "Docker version 24.0.7, build afdd53b", etc.
+  major="$(printf '%s\n' "$raw" | grep -oE '[0-9]+(\.[0-9]+)*' | head -n1 | cut -d. -f1)"
+  [ -n "$major" ] && [ "$major" -ge "$want_major" ]
+}
+
+# ─── Homebrew bootstrap (macOS only) ─────────────────────────────────────────
+
+ensure_brew() {
+  if [ "$PKG_MGR" != "brew-missing" ]; then return 0; fi
+  warn "Homebrew is required on macOS but isn't installed."
+  info "Installing Homebrew (you'll be prompted for your password)..."
+  /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)" \
+    || die "Homebrew install failed. See https://brew.sh and re-run this script."
+  # The brew installer prints a hint about adding brew to PATH but does not
+  # do it for you. Apple Silicon brew lives at /opt/homebrew, Intel at /usr/local.
+  if   [ -x /opt/homebrew/bin/brew ]; then eval "$(/opt/homebrew/bin/brew shellenv)"
+  elif [ -x /usr/local/bin/brew    ]; then eval "$(/usr/local/bin/brew shellenv)"
+  fi
+  have brew || die "brew installed but not on PATH. Open a new shell and re-run."
+  PKG_MGR="brew"
+  ok "Homebrew installed: $(brew --version | head -n1)"
+}
+
+# ─── Step 1: git ─────────────────────────────────────────────────────────────
+
+ensure_git() {
+  if have git; then
+    ok "git already installed: $(git --version)"
+    return 0
+  fi
+  info "Installing git via $PKG_MGR..."
+  case "$PKG_MGR" in
+    apt)    $SUDO apt-get update -qq && $SUDO apt-get install -y --no-install-recommends git ca-certificates curl ;;
+    dnf)    $SUDO dnf install -y git ca-certificates curl ;;
+    yum)    $SUDO yum install -y git ca-certificates curl ;;
+    pacman) $SUDO pacman -Sy --noconfirm --needed git ca-certificates curl ;;
+    zypper) $SUDO zypper -n install git ca-certificates curl ;;
+    apk)    $SUDO apk add --no-cache git ca-certificates curl bash ;;
+    brew)   brew install git ;;
+    *) die "don't know how to install git on PKG_MGR=$PKG_MGR" ;;
+  esac
+  have git || die "git install reported success but git is still not on PATH."
+  ok "git installed: $(git --version)"
+}
+
+# ─── Step 2: Docker + Compose v2 ─────────────────────────────────────────────
+# Strategy:
+#   - macOS: install Docker Desktop via brew cask (interactive — user must
+#     launch it once after install and accept the licence). We can't start
+#     Docker Desktop headlessly.
+#   - Linux: use the official `get.docker.com` convenience script. It handles
+#     repo setup for apt/dnf/zypper/apk/pacman, installs docker-ce + the
+#     compose plugin, and starts the daemon via systemd where applicable.
+#   - We then add the current user to the `docker` group on Linux so they
+#     don't need sudo to talk to the daemon. The user will need to log out
+#     and back in (or `newgrp docker`) for the group change to take effect —
+#     we work around that for the rest of *this* run by using `sg docker -c`
+#     when invoking docker.
+
+DOCKER_NEEDS_NEWGRP=0
+
+ensure_docker() {
+  # Compose v2 ships as a docker plugin, exposed as `docker compose` (no
+  # hyphen). The legacy standalone `docker-compose` binary is v1 and is no
+  # longer supported by AiSOC. We only check the v2 path.
+  if have docker && docker compose version >/dev/null 2>&1; then
+    ok "docker + compose v2 already installed: $(docker --version)"
+    ensure_docker_daemon
+    return 0
+  fi
+
+  if [ "$OS_FAMILY" = "macos" ]; then
+    info "Installing Docker Desktop via Homebrew..."
+    brew install --cask docker || die "brew install --cask docker failed."
+    cat <<EOF
+
+${C_BOLD}${C_YELLOW}Docker Desktop installed but not running.${C_RESET}
+
+Please:
+  1. Open Docker Desktop from Applications (or Spotlight: 'Docker').
+  2. Accept the licence agreement on first launch.
+  3. Wait for the whale icon in the menu bar to stop animating.
+  4. Re-run this installer.
+
+EOF
+    exit 2
+  fi
+
+  # Linux path: official convenience script.
+  info "Installing Docker Engine via the official convenience script..."
+  info "This adds the Docker apt/dnf/zypper repo and installs docker-ce + compose plugin."
+  local script
+  script="$(mktemp)"
+  curl -fsSL https://get.docker.com -o "$script" \
+    || die "couldn't download get.docker.com (check your network)."
+  $SUDO sh "$script" \
+    || die "Docker install script failed. See output above and report at https://github.com/beenuar/AiSOC/issues."
+  rm -f "$script"
+
+  # Add user to docker group so we don't need sudo for `docker` commands.
+  if ! id -nG "$(whoami)" | tr ' ' '\n' | grep -qx docker; then
+    info "Adding $(whoami) to the docker group..."
+    $SUDO usermod -aG docker "$(whoami)" || warn "couldn't add to docker group; you'll need sudo for docker commands."
+    DOCKER_NEEDS_NEWGRP=1
+  fi
+
+  # Start daemon (systemd on most distros, openrc on Alpine).
+  if have systemctl; then
+    $SUDO systemctl enable --now docker || warn "couldn't enable+start docker via systemctl."
+  elif have rc-service; then
+    $SUDO rc-service docker start || warn "couldn't start docker via rc-service."
+    $SUDO rc-update add docker default || true
+  fi
+
+  have docker || die "docker install reported success but docker is still not on PATH."
+  ok "docker installed: $(docker --version)"
+  ensure_docker_daemon
+}
+
+# Wrapper that runs `docker ...` either directly or via `sg docker -c` so
+# the current shell sees the new group membership without requiring logout.
+# Both branches take a single shell expression (possibly with redirects), which
+# is why we eval rather than exec the array.
+docker_cmd() {
+  if [ "$DOCKER_NEEDS_NEWGRP" = "1" ] && have sg; then
+    sg docker -c "$*"
+  else
+    # shellcheck disable=SC2294  # intentional: callers pass shell expressions
+    eval "$@"
+  fi
+}
+
+ensure_docker_daemon() {
+  # Wait up to 60 s for the daemon to be reachable. On Linux this is mostly
+  # instant (we just started it via systemctl). On macOS it's not — Docker
+  # Desktop takes 10-30 s to bring up the VM.
+  local i=0
+  while [ $i -lt 30 ]; do
+    if docker_cmd 'docker info >/dev/null 2>&1'; then
+      ok "Docker daemon is responsive."
+      return 0
+    fi
+    if [ $i -eq 0 ]; then
+      info "Waiting for Docker daemon to come up..."
+    fi
+    sleep 2
+    i=$((i+1))
+  done
+  err "Docker daemon is not responding after 60 s."
+  if [ "$OS_FAMILY" = "macos" ]; then
+    err "Open Docker Desktop manually, wait for the whale icon to settle, then re-run."
+  else
+    err "Try: sudo systemctl status docker  (or)  sudo journalctl -u docker --no-pager | tail -50"
+  fi
+  exit 2
+}
+
+# ─── Step 3: Node.js 20 LTS ──────────────────────────────────────────────────
+
+ensure_node() {
+  # We need Node >= 20 because tsx 4 + the workspace's "engines" field both
+  # require it. Node 18 reaches LTS end-of-life in April 2025 so we don't
+  # support it.
+  if version_at_least node 20 "node --version"; then
+    ok "node already installed: $(node --version)"
+    return 0
+  fi
+  info "Installing Node.js 20 LTS via $PKG_MGR..."
+  case "$PKG_MGR" in
+    apt)
+      # NodeSource is the upstream-blessed apt repo for current Node releases.
+      curl -fsSL https://deb.nodesource.com/setup_20.x | $SUDO bash -
+      $SUDO apt-get install -y nodejs
+      ;;
+    dnf|yum)
+      curl -fsSL https://rpm.nodesource.com/setup_20.x | $SUDO bash -
+      $SUDO "$PKG_MGR" install -y nodejs
+      ;;
+    pacman) $SUDO pacman -Sy --noconfirm --needed nodejs npm ;;
+    zypper)
+      $SUDO zypper -n install -y nodejs20 npm20 \
+        || $SUDO zypper -n install -y nodejs npm
+      ;;
+    apk)    $SUDO apk add --no-cache nodejs npm ;;
+    brew)   brew install node@20 && brew link --overwrite --force node@20 ;;
+    *) die "don't know how to install Node on PKG_MGR=$PKG_MGR" ;;
+  esac
+  have node || die "node install reported success but node is still not on PATH."
+  if ! version_at_least node 20 "node --version"; then
+    warn "Installed Node version ($(node --version)) is older than 20; AiSOC may misbehave."
+  else
+    ok "node installed: $(node --version)"
+  fi
+}
+
+# ─── Step 4: pnpm 8+ via corepack ────────────────────────────────────────────
+
+ensure_pnpm() {
+  if have pnpm && version_at_least pnpm 8 "pnpm --version"; then
+    ok "pnpm already installed: $(pnpm --version)"
+    return 0
+  fi
+  info "Enabling corepack and activating pnpm 8..."
+  # corepack ships with Node 16.13+. It manages pnpm/yarn versions per project
+  # so we don't have to mess with global npm installs (which always end in
+  # tears on multi-version setups).
+  $SUDO corepack enable 2>/dev/null || corepack enable || die "corepack enable failed."
+  # Pin to the version package.json declares (pnpm@8.15.1). corepack reads
+  # the workspace's "packageManager" field on first invocation.
+  corepack prepare pnpm@8.15.1 --activate || die "corepack prepare pnpm failed."
+  have pnpm || die "pnpm install reported success but pnpm is still not on PATH."
+  ok "pnpm installed: $(pnpm --version)"
+}
+
+# ─── Step 5: clone or locate the repo ────────────────────────────────────────
+# Two run modes:
+#   A. The script lives in the repo (./install.sh from a clone). REPO_ROOT
+#      is wherever this script sits.
+#   B. The script was streamed via curl|bash. There's no repo on disk yet —
+#      we need to clone into $CLONE_DIR.
+# We tell them apart by checking whether $0 is inside a git working tree
+# whose origin matches AiSOC.
+
+REPO_ROOT=""
+
+ensure_repo() {
+  local self_dir
+  # When piped through bash, $0 is "bash" (or "/usr/bin/bash"), not a path
+  # to this script. BASH_SOURCE[0] is empty in that case.
+  if [ -n "${BASH_SOURCE[0]:-}" ] && [ "${BASH_SOURCE[0]}" != "bash" ]; then
+    self_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    if [ -d "$self_dir/.git" ] && [ -f "$self_dir/package.json" ]; then
+      # Sanity-check it's actually AiSOC and not some other repo that
+      # happened to ship an install.sh.
+      if grep -q '"name": "aisoc"' "$self_dir/package.json" 2>/dev/null; then
+        REPO_ROOT="$self_dir"
+        ok "Using existing AiSOC clone at $REPO_ROOT"
+        return 0
+      fi
+    fi
+  fi
+
+  # Mode B: clone fresh.
+  if [ -d "$CLONE_DIR" ]; then
+    if [ -d "$CLONE_DIR/.git" ] && grep -q '"name": "aisoc"' "$CLONE_DIR/package.json" 2>/dev/null; then
+      info "Updating existing clone at $CLONE_DIR..."
+      ( cd "$CLONE_DIR" && git fetch --quiet origin && git checkout --quiet "$BRANCH" && git pull --ff-only --quiet ) \
+        || warn "git pull failed; using whatever's on disk."
+      REPO_ROOT="$CLONE_DIR"
+      ok "Updated clone at $REPO_ROOT"
+      return 0
+    fi
+    die "$CLONE_DIR exists but isn't an AiSOC clone. Pass --clone-dir to choose a different location, or remove it first."
+  fi
+  info "Cloning AiSOC into $CLONE_DIR (branch: $BRANCH)..."
+  git clone --branch "$BRANCH" --depth 50 https://github.com/beenuar/AiSOC.git "$CLONE_DIR" \
+    || die "git clone failed."
+  REPO_ROOT="$CLONE_DIR"
+  ok "Cloned AiSOC to $REPO_ROOT"
+}
+
+# ─── Step 6: .env bootstrap ──────────────────────────────────────────────────
+
+ensure_env_file() {
+  # docker-compose.demo.yml hardcodes its own dev passwords (see SECURITY NOTE
+  # in that file), so .env isn't actually load-bearing for the demo. But
+  # several apps and scripts do read .env, so we make sure it exists with
+  # the example defaults to avoid spurious "key not found" warnings.
+  if [ -f "$REPO_ROOT/.env" ]; then
+    ok ".env already exists at $REPO_ROOT/.env"
+    return 0
+  fi
+  if [ -f "$REPO_ROOT/.env.example" ]; then
+    cp "$REPO_ROOT/.env.example" "$REPO_ROOT/.env"
+    ok "Created $REPO_ROOT/.env from .env.example"
+    info "  (Optional: edit $REPO_ROOT/.env to add your OpenAI/Anthropic API key for richer agent runs.)"
+  else
+    warn "No .env.example found in repo; skipping .env creation."
+  fi
+}
+
+# ─── Step 7: pnpm install + handoff to aisoc:demo ────────────────────────────
+
+run_pnpm_install() {
+  info "Installing JS workspace deps (pnpm install)..."
+  ( cd "$REPO_ROOT" && pnpm install --prefer-offline --no-frozen-lockfile ) \
+    || die "pnpm install failed."
+  ok "pnpm dependencies installed."
+}
+
+run_demo() {
+  if [ "$NO_LAUNCH" = "1" ]; then
+    info "--no-launch: skipping pnpm aisoc:demo. To start the stack later:"
+    info "  cd $REPO_ROOT && pnpm aisoc:demo"
+    return 0
+  fi
+  section "Launching AiSOC demo stack"
+  info "Handing off to 'pnpm aisoc:demo' — this will pull images, start the"
+  info "stack, seed the showcase ransomware case, and open your browser."
+  echo
+  # We forward the user's --no-pull / --rebuild flags through to the demo
+  # script. Run docker via `sg docker` if the user was just added to the
+  # group and hasn't logged out — otherwise pnpm aisoc:demo will explode on
+  # its very first `docker compose` call.
+  if [ "$DOCKER_NEEDS_NEWGRP" = "1" ] && have sg; then
+    sg docker -c "cd '$REPO_ROOT' && pnpm aisoc:demo ${DEMO_FLAGS[*]:-}" \
+      || { err "pnpm aisoc:demo exited non-zero."; exit 3; }
+  else
+    ( cd "$REPO_ROOT" && pnpm aisoc:demo "${DEMO_FLAGS[@]}" ) \
+      || { err "pnpm aisoc:demo exited non-zero."; exit 3; }
+  fi
+}
+
+# ─── Final banner ────────────────────────────────────────────────────────────
+
+print_success() {
+  cat <<EOF
+
+${C_BOLD}${C_GREEN}AiSOC is up and running.${C_RESET}
+
+  ${C_BOLD}Web console:${C_RESET}     http://localhost:3000
+  ${C_BOLD}Showcase case:${C_RESET}   http://localhost:3000/cases/INC-RT-001?tab=ledger
+  ${C_BOLD}API + Swagger:${C_RESET}   http://localhost:8000/docs
+  ${C_BOLD}Realtime WS:${C_RESET}     ws://localhost:8086
+
+${C_DIM}Useful commands (run from $REPO_ROOT):${C_RESET}
+  pnpm aisoc:doctor                          # health-check the stack
+  pnpm aisoc:demo:logs                       # tail logs
+  pnpm aisoc:demo:down                       # stop everything and wipe demo data
+  ./scripts/install/uninstall.sh             # full uninstall (containers + images + repo)
+
+EOF
+  if [ "$DOCKER_NEEDS_NEWGRP" = "1" ]; then
+    cat <<EOF
+${C_YELLOW}Note:${C_RESET} You were added to the 'docker' group. Open a new terminal session
+(or run 'newgrp docker') to use 'docker' commands without sudo.
+
+EOF
+  fi
+}
+
+# ─── Main ────────────────────────────────────────────────────────────────────
+
+main() {
+  section "AiSOC One-Click Installer"
+  detect_os
+
+  if [ "$NO_INSTALL" = "0" ]; then
+    section "Installing prerequisites"
+    if [ "$OS_FAMILY" = "macos" ]; then
+      ensure_brew
+    else
+      need_sudo
+    fi
+    ensure_git
+    ensure_docker
+    ensure_node
+    ensure_pnpm
+  else
+    info "--no-install: skipping prerequisite install. Verifying what's on PATH..."
+    have git    || die "git missing (and --no-install was given)"
+    have docker || die "docker missing (and --no-install was given)"
+    docker compose version >/dev/null 2>&1 || die "docker compose v2 missing (and --no-install was given)"
+    have node   || die "node missing (and --no-install was given)"
+    have pnpm   || die "pnpm missing (and --no-install was given)"
+    ensure_docker_daemon
+  fi
+
+  section "Setting up the AiSOC repository"
+  ensure_repo
+  ensure_env_file
+  run_pnpm_install
+  run_demo
+  print_success
+}
+
+main "$@"

--- a/uninstall.ps1
+++ b/uninstall.ps1
@@ -1,0 +1,264 @@
+<#
+.SYNOPSIS
+    AiSOC — Uninstaller for Windows.
+
+.DESCRIPTION
+    Tears down whatever install.ps1 + `pnpm aisoc:demo` brought up, in
+    decreasing levels of aggressiveness:
+
+        default          Stop the demo stack and delete its named volumes.
+                         (Equivalent to: pnpm aisoc:demo:down)
+        -RemoveImages    Also remove ghcr.io/beenuar/aisoc-* images
+                         (saves ~2-3 GB of disk).
+        -RemoveNodeModules
+                         Also delete node_modules trees in the repo (~1 GB).
+        -RemoveRepo      Also delete the AiSOC repo clone itself.
+        -All             Equivalent to all three above.
+
+    What this script DOES NOT do:
+        - Uninstall Docker Desktop, Node, pnpm, or git. Those are
+          general-purpose tools you almost certainly want for other projects.
+          To remove them anyway:
+              winget uninstall --id Git.Git
+              winget uninstall --id OpenJS.NodeJS.LTS
+              winget uninstall --id Docker.DockerDesktop
+        - Touch any other Docker containers, images, or volumes outside the
+          aisoc-demo project. We're surgical here.
+
+.PARAMETER RemoveImages
+    Also remove the ghcr.io/beenuar/aisoc-* container images.
+
+.PARAMETER RemoveNodeModules
+    Also delete node_modules trees inside the repo.
+
+.PARAMETER RemoveRepo
+    Also delete the AiSOC repo clone.
+
+.PARAMETER All
+    Shorthand for -RemoveImages -RemoveNodeModules -RemoveRepo.
+
+.PARAMETER Yes
+    Skip all confirmation prompts (for CI / scripted use).
+
+.EXAMPLE
+    .\uninstall.ps1
+    # Stop stack and drop volumes only.
+
+.EXAMPLE
+    .\uninstall.ps1 -All -Yes
+    # Nuke everything, no prompts (good for clean-room CI runs).
+
+.NOTES
+    Exit codes:
+        0  success
+        1  invalid arguments
+        2  not run from inside an AiSOC clone (and -RemoveRepo wasn't given)
+#>
+
+[CmdletBinding()]
+param(
+    [switch]$RemoveImages,
+    [switch]$RemoveNodeModules,
+    [switch]$RemoveRepo,
+    [switch]$All,
+    [switch]$Yes
+)
+
+$ErrorActionPreference = 'Stop'
+
+if ($All) {
+    $RemoveImages = $true
+    $RemoveNodeModules = $true
+    $RemoveRepo = $true
+}
+
+# ─── Logging helpers (match install.ps1 style) ──────────────────────────────
+
+function Write-Log     { param([string]$m) Write-Host "[aisoc] $m" -ForegroundColor DarkGray }
+function Write-Info    { param([string]$m) Write-Host "[aisoc] $m" -ForegroundColor Blue }
+function Write-Ok      { param([string]$m) Write-Host "[aisoc] $m" -ForegroundColor Green }
+function Write-Warn    { param([string]$m) Write-Host "[aisoc] $m" -ForegroundColor Yellow }
+function Write-Err     { param([string]$m) Write-Host "[aisoc] $m" -ForegroundColor Red }
+function Write-Section {
+    param([string]$m)
+    Write-Host ""
+    Write-Host "━━━ $m ━━━" -ForegroundColor Cyan
+    Write-Host ""
+}
+
+function Confirm-Action {
+    param([string]$Prompt)
+    # In non-interactive contexts (no console host) or with -Yes, just say yes.
+    if ($Yes -or -not [Environment]::UserInteractive) { return $true }
+    $resp = Read-Host "$Prompt [y/N]"
+    return ($resp -match '^[yY]')
+}
+
+# ─── Locate the AiSOC repo ──────────────────────────────────────────────────
+# We need the path to docker-compose.demo.yml so `docker compose down -v` can
+# resolve project resources cleanly. Prefer the directory two levels above
+# this script (script lives in <repo>/scripts/install/), then fall back to
+# the canonical $env:USERPROFILE\aisoc.
+
+function Find-RepoRoot {
+    # The uninstaller lives at the repo root, alongside install.ps1.
+    $selfDir = Split-Path -Parent $PSCommandPath
+    if ($selfDir -and
+        (Test-Path (Join-Path $selfDir 'docker-compose.demo.yml')) -and
+        (Test-Path (Join-Path $selfDir 'package.json'))) {
+        $pkg = Get-Content (Join-Path $selfDir 'package.json') -Raw -ErrorAction SilentlyContinue
+        if ($pkg -match '"name"\s*:\s*"aisoc"') {
+            return $selfDir
+        }
+    }
+    # Fallback 1: $HOME/aisoc (where install.ps1 clones by default).
+    $homePath = Join-Path $env:USERPROFILE 'aisoc'
+    if (Test-Path (Join-Path $homePath 'docker-compose.demo.yml')) {
+        return $homePath
+    }
+    # Fallback 2: cwd is an aisoc clone.
+    if ((Test-Path (Join-Path (Get-Location) 'docker-compose.demo.yml')) -and
+        (Test-Path (Join-Path (Get-Location) 'package.json'))) {
+        $pkg = Get-Content (Join-Path (Get-Location) 'package.json') -Raw -ErrorAction SilentlyContinue
+        if ($pkg -match '"name"\s*:\s*"aisoc"') {
+            return (Get-Location).Path
+        }
+    }
+    return $null
+}
+
+$RepoRoot = Find-RepoRoot
+
+if (-not $RepoRoot) {
+    if ($RemoveImages -or $RemoveRepo) {
+        Write-Warn "Couldn't locate AiSOC clone. Skipping 'compose down' (orphan containers may remain)."
+    } else {
+        Write-Err "Run this from inside an AiSOC clone, or pass -RemoveRepo to clean up the cloned repo at `$env:USERPROFILE\aisoc."
+        exit 2
+    }
+}
+
+# ─── Step 1: stop the demo stack ────────────────────────────────────────────
+
+function Stop-DemoStack {
+    $docker = Get-Command docker -ErrorAction SilentlyContinue
+    if (-not $docker) {
+        Write-Warn "docker not on PATH; skipping compose down."
+        return
+    }
+    try { docker info 2>$null | Out-Null } catch {
+        Write-Warn "docker daemon not reachable; skipping compose down."
+        return
+    }
+    if (-not $RepoRoot) { return }
+
+    Write-Info "Stopping AiSOC demo stack and removing its volumes..."
+    Push-Location $RepoRoot
+    try {
+        docker compose -f docker-compose.demo.yml down -v --remove-orphans
+        if ($LASTEXITCODE -ne 0) {
+            Write-Warn "compose down exited with code $LASTEXITCODE; some resources may not have been cleaned up."
+        } else {
+            Write-Ok "Demo stack stopped, named volumes deleted."
+        }
+    } finally {
+        Pop-Location
+    }
+}
+
+# ─── Step 2: remove AiSOC images ────────────────────────────────────────────
+# Only ghcr.io/beenuar/aisoc-* — leaves alpine/postgres/redis/kafka alone
+# because those are widely shared and cheap to re-pull.
+
+function Remove-AiSOCImages {
+    if (-not $RemoveImages) { return }
+    $docker = Get-Command docker -ErrorAction SilentlyContinue
+    if (-not $docker) {
+        Write-Warn "docker unreachable; skipping image removal."
+        return
+    }
+    try { docker info 2>$null | Out-Null } catch {
+        Write-Warn "docker daemon not reachable; skipping image removal."
+        return
+    }
+    Write-Section "Removing AiSOC container images"
+    $images = docker images --format '{{.Repository}}:{{.Tag}}' | Where-Object { $_ -like 'ghcr.io/beenuar/aisoc-*' }
+    if (-not $images) {
+        Write-Info "No ghcr.io/beenuar/aisoc-* images found."
+        return
+    }
+    $images | ForEach-Object { Write-Host "  $_" }
+    if (Confirm-Action "Remove the images above?") {
+        foreach ($img in $images) {
+            docker rmi -f $img | Out-Null
+            if ($LASTEXITCODE -ne 0) { Write-Warn "Could not remove $img (in use?)" }
+        }
+        Write-Ok "Images removed."
+    }
+}
+
+# ─── Step 3: node_modules cleanup ───────────────────────────────────────────
+
+function Remove-NodeModulesTrees {
+    if (-not $RemoveNodeModules) { return }
+    if (-not $RepoRoot) { return }
+    Write-Section "Removing node_modules"
+    # pnpm symlinks aggressively, so we walk the tree to catch all of them
+    # under apps/* and packages/* — not just the root one.
+    $dirs = Get-ChildItem -Path $RepoRoot -Filter 'node_modules' -Recurse -Directory -Force -ErrorAction SilentlyContinue |
+        Where-Object { $_.FullName -notmatch '\\node_modules\\.+\\node_modules$' }  # don't double-walk
+    Write-Info "Found $($dirs.Count) node_modules directories under $RepoRoot"
+    if ($dirs.Count -eq 0) { return }
+    if (Confirm-Action "Remove them all?") {
+        foreach ($d in $dirs) {
+            try {
+                Remove-Item -Recurse -Force -LiteralPath $d.FullName -ErrorAction Stop
+            } catch {
+                Write-Warn "Failed to remove $($d.FullName): $($_.Exception.Message)"
+            }
+        }
+        Write-Ok "node_modules removed."
+    }
+}
+
+# ─── Step 4: blow away the repo clone ───────────────────────────────────────
+
+function Remove-RepoClone {
+    if (-not $RemoveRepo) { return }
+    $target = if ($RepoRoot) { $RepoRoot } else { Join-Path $env:USERPROFILE 'aisoc' }
+    if (-not (Test-Path $target)) {
+        Write-Warn "No repo found at $target; nothing to remove."
+        return
+    }
+    Write-Section "Removing AiSOC repo"
+    Write-Warn "About to recursively delete: $target"
+    if (Confirm-Action "Are you absolutely sure?") {
+        try {
+            Remove-Item -Recurse -Force -LiteralPath $target -ErrorAction Stop
+            Write-Ok "Repo deleted."
+        } catch {
+            Write-Err "Failed to delete: $($_.Exception.Message)"
+        }
+    }
+}
+
+# ─── Main ───────────────────────────────────────────────────────────────────
+
+Write-Section "AiSOC Uninstaller"
+Stop-DemoStack
+Remove-AiSOCImages
+Remove-NodeModulesTrees
+Remove-RepoClone
+
+Write-Host ""
+Write-Host "AiSOC uninstall complete." -ForegroundColor Green
+Write-Host ""
+Write-Host "Things this script intentionally did NOT remove:" -ForegroundColor DarkGray
+Write-Host "  - Docker Desktop, Node, pnpm, git (shared dev tools)"
+Write-Host "  - WSL2 distros"
+Write-Host "  - Other Docker images (postgres, redis, kafka, zookeeper, alpine)"
+Write-Host "  - Cached pnpm store at `$env:LOCALAPPDATA\pnpm-store"
+Write-Host ""
+Write-Host "To remove the leftover infrastructure images too:" -ForegroundColor DarkGray
+Write-Host "  docker image prune -a    # removes ALL dangling+unused images, not just AiSOC's"
+Write-Host ""

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,0 +1,242 @@
+#!/usr/bin/env bash
+###############################################################################
+# AiSOC — Uninstaller (Linux + macOS)
+#
+# Tears down whatever ./install.sh + `pnpm aisoc:demo` brought up, in
+# decreasing levels of aggressiveness:
+#
+#   default          Stop the demo stack and delete its named volumes.
+#                    (Equivalent to: pnpm aisoc:demo:down)
+#   --images         Also remove the ghcr.io/beenuar/aisoc-* container images
+#                    pulled by the demo (saves ~ 2-3 GB of disk).
+#   --node-modules   Also delete node_modules trees inside the repo (~ 1 GB).
+#   --repo           Also delete the AiSOC repo clone itself.
+#   --all            Equivalent to --images --node-modules --repo.
+#
+# What this script DOES NOT do:
+#   - Uninstall Docker, Node, pnpm, or git. Those are general-purpose tools
+#     you almost certainly want for other projects. If you really want to
+#     remove them, use your distro's package manager directly:
+#       Ubuntu/Debian:  sudo apt-get remove docker-ce nodejs git
+#       Fedora:         sudo dnf remove docker-ce nodejs git
+#       Arch:           sudo pacman -R docker nodejs git
+#       macOS:          brew uninstall --cask docker; brew uninstall node git
+#   - Remove the user from the docker group. Your call.
+#   - Touch any other Docker containers, images, or volumes outside the
+#     aisoc-demo project. We're surgical here.
+#
+# Usage:
+#   ./uninstall.sh           # stop stack + drop volumes
+#   ./uninstall.sh --images  # also remove pulled images
+#   ./uninstall.sh --all     # everything except shared deps
+#   ./uninstall.sh --help
+#
+# Exit codes:
+#   0  success
+#   1  invalid arguments
+#   2  not run from inside an AiSOC clone (and --repo wasn't given)
+###############################################################################
+
+set -euo pipefail
+
+# Match install.sh's logging style so the two feel like a pair.
+if [ -t 1 ] && [ -z "${NO_COLOR:-}" ]; then
+  C_RESET=$'\033[0m'; C_BOLD=$'\033[1m'; C_DIM=$'\033[2m'
+  C_RED=$'\033[31m'; C_GREEN=$'\033[32m'; C_YELLOW=$'\033[33m'
+  C_BLUE=$'\033[34m'; C_CYAN=$'\033[36m'
+else
+  C_RESET=""; C_BOLD=""; C_DIM=""; C_RED=""; C_GREEN=""; C_YELLOW=""; C_BLUE=""; C_CYAN=""
+fi
+
+log()    { printf '%s[aisoc]%s %s\n' "$C_DIM"    "$C_RESET" "$*"; }
+info()   { printf '%s[aisoc]%s %s\n' "$C_BLUE"   "$C_RESET" "$*"; }
+ok()     { printf '%s[aisoc]%s %s\n' "$C_GREEN"  "$C_RESET" "$*"; }
+warn()   { printf '%s[aisoc]%s %s\n' "$C_YELLOW" "$C_RESET" "$*" >&2; }
+err()    { printf '%s[aisoc]%s %s\n' "$C_RED"    "$C_RESET" "$*" >&2; }
+section() { printf '\n%s%s━━━ %s ━━━%s\n\n' "$C_BOLD" "$C_CYAN" "$*" "$C_RESET"; }
+die()    { err "$*"; exit 1; }
+
+usage() {
+  sed -n '2,/^$/p' "$0" | sed 's/^# \{0,1\}//'
+  exit 0
+}
+
+# ─── Flags ───────────────────────────────────────────────────────────────────
+
+REMOVE_IMAGES=0
+REMOVE_NODE_MODULES=0
+REMOVE_REPO=0
+YES=0  # skip confirmation prompts (for CI / scripted use)
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --images)        REMOVE_IMAGES=1 ;;
+    --node-modules)  REMOVE_NODE_MODULES=1 ;;
+    --repo)          REMOVE_REPO=1 ;;
+    --all)           REMOVE_IMAGES=1; REMOVE_NODE_MODULES=1; REMOVE_REPO=1 ;;
+    --yes|-y)        YES=1 ;;
+    --help|-h)       usage ;;
+    *) die "unknown flag: $1 (try --help)" ;;
+  esac
+  shift
+done
+
+# ─── Locate the repo ─────────────────────────────────────────────────────────
+# We must be run from inside an AiSOC clone OR have access to one, since
+# `docker compose` needs the compose file to resolve project resources.
+
+REPO_ROOT=""
+
+find_repo() {
+  # The uninstaller lives at the repo root, alongside install.sh.
+  local self_dir
+  self_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  if [ -f "$self_dir/docker-compose.demo.yml" ] && grep -q '"name": "aisoc"' "$self_dir/package.json" 2>/dev/null; then
+    REPO_ROOT="$self_dir"
+    return 0
+  fi
+  # Fallback: maybe the user ran us from PATH or a copy. Try $HOME/aisoc.
+  if [ -d "$HOME/aisoc" ] && [ -f "$HOME/aisoc/docker-compose.demo.yml" ]; then
+    REPO_ROOT="$HOME/aisoc"
+    return 0
+  fi
+  # Fallback 2: maybe we're run from the cwd of an aisoc clone.
+  if [ -f "$PWD/docker-compose.demo.yml" ] && grep -q '"name": "aisoc"' "$PWD/package.json" 2>/dev/null; then
+    REPO_ROOT="$PWD"
+    return 0
+  fi
+  return 1
+}
+
+if ! find_repo; then
+  if [ "$REMOVE_IMAGES" = "1" ] || [ "$REMOVE_REPO" = "1" ]; then
+    # We can still nuke images + repo dir without the compose file. We just
+    # can't do a clean `compose down`, so the user might have orphan
+    # containers. Warn but proceed.
+    warn "Couldn't locate AiSOC clone. Skipping 'compose down' (orphan containers may remain)."
+  else
+    err "Run this from inside an AiSOC clone, or pass --repo to clean up the cloned repo at \$HOME/aisoc."
+    exit 2
+  fi
+fi
+
+confirm() {
+  # Skip confirmation in non-interactive shells or when --yes was passed.
+  if [ "$YES" = "1" ] || [ ! -t 0 ]; then return 0; fi
+  printf '%s%s%s [y/N]: ' "$C_YELLOW" "$1" "$C_RESET" >&2
+  local ans
+  read -r ans
+  case "$ans" in
+    [yY]|[yY][eE][sS]) return 0 ;;
+    *) info "Skipped."; return 1 ;;
+  esac
+}
+
+# ─── Step 1: bring the demo stack down ───────────────────────────────────────
+
+stop_demo_stack() {
+  if ! command -v docker >/dev/null 2>&1; then
+    warn "docker is not on PATH; skipping compose down."
+    return 0
+  fi
+  if ! docker info >/dev/null 2>&1; then
+    warn "docker daemon not reachable; skipping compose down."
+    return 0
+  fi
+  if [ -z "$REPO_ROOT" ]; then return 0; fi
+
+  info "Stopping AiSOC demo stack and removing its volumes..."
+  ( cd "$REPO_ROOT" && docker compose -f docker-compose.demo.yml down -v --remove-orphans ) \
+    || warn "compose down exited non-zero; some resources may not have been cleaned up."
+  ok "Demo stack stopped, named volumes deleted."
+}
+
+# ─── Step 2: remove pulled images ────────────────────────────────────────────
+# We only target images we know belong to AiSOC, namely ghcr.io/beenuar/aisoc-*.
+# We deliberately leave alpine/postgres/redis/kafka/zookeeper images alone —
+# they're widely shared with other projects and re-pulling them is cheap.
+
+remove_aisoc_images() {
+  if [ "$REMOVE_IMAGES" = "0" ]; then return 0; fi
+  if ! command -v docker >/dev/null 2>&1 || ! docker info >/dev/null 2>&1; then
+    warn "docker unreachable; skipping image removal."
+    return 0
+  fi
+  section "Removing AiSOC container images"
+  local images
+  images=$(docker images --format '{{.Repository}}:{{.Tag}}' | grep '^ghcr.io/beenuar/aisoc-' || true)
+  if [ -z "$images" ]; then
+    info "No ghcr.io/beenuar/aisoc-* images found."
+    return 0
+  fi
+  printf '%s\n' "$images" | sed 's/^/  /'
+  if confirm "Remove the images above?"; then
+    printf '%s\n' "$images" | xargs -r docker rmi -f || warn "some images couldn't be removed (in use?)"
+    ok "Images removed."
+  fi
+}
+
+# ─── Step 3: node_modules cleanup ────────────────────────────────────────────
+
+remove_node_modules() {
+  if [ "$REMOVE_NODE_MODULES" = "0" ]; then return 0; fi
+  if [ -z "$REPO_ROOT" ]; then return 0; fi
+  section "Removing node_modules"
+  # The monorepo has node_modules at the root and also inside each app/package.
+  # `pnpm` symlinks aggressively, so a plain `rm -rf node_modules` at the root
+  # leaves stragglers in apps/* and packages/*.
+  local count
+  count=$(find "$REPO_ROOT" -type d -name node_modules -prune 2>/dev/null | wc -l | tr -d ' ')
+  info "Found $count node_modules directories under $REPO_ROOT"
+  if confirm "Remove them all?"; then
+    find "$REPO_ROOT" -type d -name node_modules -prune -exec rm -rf {} + 2>/dev/null || true
+    ok "node_modules removed."
+  fi
+}
+
+# ─── Step 4: blow away the repo clone ────────────────────────────────────────
+
+remove_repo_clone() {
+  if [ "$REMOVE_REPO" = "0" ]; then return 0; fi
+  # Two candidate locations: $REPO_ROOT (whatever we found) and the canonical
+  # $HOME/aisoc. We prefer $REPO_ROOT but warn if it's not the canonical
+  # location (the user may have meant something else).
+  local target="${REPO_ROOT:-$HOME/aisoc}"
+  if [ ! -d "$target" ]; then
+    warn "No repo found at $target; nothing to remove."
+    return 0
+  fi
+  section "Removing AiSOC repo"
+  warn "About to recursively delete: $target"
+  if confirm "Are you absolutely sure?"; then
+    rm -rf "$target"
+    ok "Repo deleted."
+  fi
+}
+
+# ─── Main ────────────────────────────────────────────────────────────────────
+
+main() {
+  section "AiSOC Uninstaller"
+  stop_demo_stack
+  remove_aisoc_images
+  remove_node_modules
+  remove_repo_clone
+
+  cat <<EOF
+
+${C_GREEN}AiSOC uninstall complete.${C_RESET}
+
+${C_DIM}Things this script intentionally did NOT remove:${C_RESET}
+  - Docker, Node, pnpm, git (shared dev tools)
+  - Your membership in the 'docker' group
+  - Other Docker images (postgres, redis, kafka, zookeeper, alpine)
+  - Cached pnpm store at ~/.local/share/pnpm/store
+
+${C_DIM}To remove the leftover infrastructure images too:${C_RESET}
+  docker image prune -a    # removes ALL dangling+unused images, not just AiSOC's
+
+EOF
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

Adds a true one-click installer for AiSOC across Linux, macOS, and Windows. From a freshly-imaged machine with **zero assumed prerequisites**, users can run a single command and land on a running, seeded AiSOC dashboard.

### Linux + macOS
\`\`\`bash
curl -fsSL https://raw.githubusercontent.com/beenuar/AiSOC/main/install.sh | bash
\`\`\`

### Windows 10 / 11
\`\`\`powershell
iwr -useb https://raw.githubusercontent.com/beenuar/AiSOC/main/install.ps1 | iex
\`\`\`

## What ships

- **\`install.sh\`** — Linux + macOS bootstrap. Detects OS/distro/PM (apt, dnf, pacman, zypper, apk, brew). Idempotently installs git, Docker Engine + Compose v2, Node 20 LTS, pnpm 8+. Clones the repo if running as a one-liner. Hands off to \`pnpm aisoc:demo\` for the existing seeded-stack flow + browser launch. Handles fresh-Docker-group membership via \`sg docker -c\` so users don't need to log out/in.
- **\`install.ps1\`** — Windows bootstrap. Uses winget for Git/Node/Docker Desktop. Enables WSL2 on Windows Home when needed. Same hand-off to \`pnpm aisoc:demo\`.
- **\`uninstall.sh\`** / **\`uninstall.ps1\`** — Graduated cleanup: stop stack → drop volumes → \`--images\` (remove ghcr.io/beenuar/aisoc-* images) → \`--node-modules\` → \`--repo\` → \`--all\`. Intentionally leaves Docker, Node, pnpm, git untouched (general-purpose tools).
- **\`docs/QUICK_INSTALL.md\`** — Full guide: supported environments, flags, common cases (existing clone, behind a proxy, no internet on Docker), uninstall paths, troubleshooting (WSL2 reboot, Docker group membership, port conflicts on 3000/8000/5432/6379, M-series Macs), security notes for the curl|bash flow.
- **\`README.md\`** — New \"0. One-click installer\" section at the top of \"Deploy in 60 seconds\" so it's the first thing users see.

## Design notes

- **Idempotent.** Every step checks for existing installs before acting. Re-running is safe and fast.
- **Minimal install footprint.** Only installs what AiSOC genuinely needs on the host: git, Docker, Node, pnpm. Everything else (Python, Postgres, Redis, OPA, Vector, etc.) ships inside the demo containers.
- **Reuses existing orchestration.** The installer's last step is just \`pnpm aisoc:demo\`, so all the existing seed/migrate/browser-open logic in \`scripts/aisoc-demo.ts\` continues to be the source of truth. Maintenance burden stays low.
- **Cleanup is opt-in.** Default uninstall just stops the stack. Users have to ask for \`--images\`, \`--node-modules\`, \`--repo\`, or \`--all\` to actually delete things. Confirmation prompts on each, with \`-y\` to skip.

## Test plan

- [ ] Linux/macOS: \`bash install.sh --help\` and \`bash uninstall.sh --help\` render correctly
- [ ] Linux/macOS: \`shellcheck install.sh uninstall.sh\` passes clean (verified locally)
- [ ] Linux fresh VM: \`curl ... | bash\` brings up dashboard end-to-end
- [ ] macOS fresh box: \`curl ... | bash\` brings up dashboard end-to-end (Homebrew path)
- [ ] Windows fresh VM: \`iwr ... | iex\` from elevated PowerShell brings up dashboard end-to-end
- [ ] Windows: WSL2 enablement reboot path works on Windows Home
- [ ] Re-run any installer on an already-bootstrapped machine — every step skips cleanly
- [ ] \`./uninstall.sh\` stops stack and drops volumes only (default)
- [ ] \`./uninstall.sh --all -y\` nukes everything AiSOC-specific without prompting

## Out of scope

- Production deployment (Render / Fly.io / Terraform paths in the README still cover that).
- The installer doesn't try to manage Docker Desktop subscriptions, corporate proxies that MITM TLS, or air-gapped environments — those are flagged in QUICK_INSTALL.md as manual paths.

Made with [Cursor](https://cursor.com)