### PR TITLE
docs: community-feedback-driven roadmap (Now/Next/Later) + reconcile [7.0.x] CHANGELOG drift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -507,6 +507,21 @@ clusters.
 
 ## [7.0.x] — 2026-05-10 — Endpoint telemetry wave (PR1–PR6)
 
+> **⚠️ Reconciliation notice (2026-05-12)**: The work described in this
+> section was developed on branch `feat/pr6-osquery-extensions`
+> (commits `e0d70fa1` → `3ab5aa81`) but the branch was **not merged into
+> `main`** before this changelog entry was written. The files referenced
+> below — including `services/osquery-tls/`,
+> `services/connectors/app/connectors/aisoc_direct.py`,
+> `services/agents/app/playbook/steps/osquery_live_query.py`, and the
+> osquery-extensions Go module — exist on that branch and can be reviewed
+> there, but are **not present on `main`** as of v7.1.0 planning. Treat
+> this section as a record of in-flight work pending PR merge, not as
+> shipped functionality. The community-feedback-driven roadmap
+> (`docs/community-feedback/2026-05-12/`) builds the generic
+> `live_action` interface (Issue #8) on `main` directly rather than
+> assuming this section's primitives are in place.
+
 ### Added — osctrl, FleetDM, aisoc-osquery-tls, aisoc-direct, native osquery detections, live-query playbook step, FIM, custom virtual tables
 
 Six-PR wave that closes [#44](https://github.com/beenuar/AiSOC/issues/44)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,5 +1,21 @@
 # AiSOC Roadmap
 
+> **📌 Active planning has moved (2026-05-12)**
+>
+> This file is the **historical record** of major-version deliverables (v4 →
+> v8 planned). Day-to-day planning, prioritization, and contributor-facing
+> issue intake now live in the community-feedback-driven **Now / Next /
+> Later** docs:
+>
+> - [`docs/community-feedback/2026-05-12/AiSOC_ROADMAP.md`](docs/community-feedback/2026-05-12/AiSOC_ROADMAP.md) — strategic narrative
+> - [`docs/community-feedback/2026-05-12/AiSOC_Community_Feedback_Synthesis.md`](docs/community-feedback/2026-05-12/AiSOC_Community_Feedback_Synthesis.md) — themes (`F001`–`Fxxx`)
+> - [`docs/community-feedback/2026-05-12/AiSOC_Proposed_Issues.md`](docs/community-feedback/2026-05-12/AiSOC_Proposed_Issues.md) — 23 implementation tickets
+>
+> Items in v7.1+ sections below that overlap with the new docs are flagged
+> inline with `→ Now/Next/Later: [ID]`. Where the new docs supersede a
+> deferred item entirely, the entry here is left intact for traceability
+> but reasoned about against the newer plan.
+
 This document captures the planned direction for AiSOC across major versions. All v4 deliverables and items deferred beyond v4 are listed here.
 
 ## v4.0 — Shipped

--- a/docs/community-feedback/2026-05-12/AiSOC_Community_Feedback_Synthesis.md
+++ b/docs/community-feedback/2026-05-12/AiSOC_Community_Feedback_Synthesis.md
@@ -1,0 +1,287 @@
+# AiSOC Community Feedback Synthesis — 2026-05-12
+
+This is the canonical, ID-stable themed log of community feedback that
+informed the [Now / Next / Later roadmap](./AiSOC_ROADMAP.md) and the
+[implementation tickets](./AiSOC_Proposed_Issues.md). Every theme has a
+stable `Fxxx` ID — never renumber, append-only.
+
+---
+
+## Methodology
+
+Sources sampled (last 60 days as of 2026-05-12):
+
+- GitHub issues + discussions on `beenuar/AiSOC`.
+- Open PR threads (notably `#43` threat-actor attribution v0).
+- Maintainer-collated DMs and email feedback (paraphrased here, no PII).
+- Public mentions on adjacent OSS forums (paraphrased).
+
+A theme earned a slot if at least three independent sources surfaced the
+same friction point or wish, *or* one source surfaced a security/privacy
+hazard. Single-source wishes without a safety dimension are tracked in the
+maintainer backlog but not synthesized here.
+
+Each theme is rated for **Severity** (S1 ship-blocker / S2 active pain /
+S3 friction / S4 wish), **Reach** (How many adopters does this affect?
+broad / mid / narrow), and **Effort** (S/M/L/XL).
+
+---
+
+## F001 — "I cannot adopt this without a paid EDR"
+
+**Severity:** S2  **Reach:** broad  **Effort:** L
+
+OSS-leaning adopters (homelabs, small MSSPs, public-sector pilots) report
+that the v6.x connector matrix tilts heavily toward commercial EDRs
+(CrowdStrike, SentinelOne, Defender). They want a credible OSS-native
+endpoint coverage path before they can run AiSOC in production.
+
+**Roadmap response:** Now-bucket items #1 (Wazuh), #2 (host-agent), #3
+(audit.d).
+
+---
+
+## F002 — Alert volume is the wrong floor
+
+**Severity:** S2  **Reach:** broad  **Effort:** M
+
+Pilot operators report that out-of-the-box detection content fires too
+frequently on baseline corporate noise (SaaS sign-ins, scheduled CI jobs,
+endpoint update telemetry). The signal/noise floor is set higher than
+operators expect from a "buyer-value" 1.0 release. They want a published
+alert-reduction baseline they can point at, plus per-rule FP visibility.
+
+**Roadmap response:** Now-bucket items #4 (quarantine sweep), #5 (per-rule
+FP gate), #7 (alert-reduction benchmark page).
+
+---
+
+## F003 — "Why did this fire?" is a one-click question, not a five-tab one
+
+**Severity:** S3  **Reach:** broad  **Effort:** M
+
+Triagers want a structured explanation surface on the alert detail view:
+which rule, which contributing events, which MITRE technique, what
+historical FP rate, what the agent suggests. Today they reconstruct it by
+hand from the raw event payload and the rule YAML.
+
+**Roadmap response:** Now-bucket item #6 (`POST /alerts/{id}/explain`).
+
+---
+
+## F004 — Linux server fleets are second-class
+
+**Severity:** S2  **Reach:** mid  **Effort:** L
+
+Adopters running Linux-heavy infrastructure (data engineering shops,
+ML-platform teams) report that the endpoint detection content assumes a
+Windows-or-mac fleet. They want first-class audit.d coverage.
+
+**Roadmap response:** Now-bucket item #3.
+
+---
+
+## F005 — Reserved.
+
+(Originally tracked a duplicate of F002; collapsed but the ID is held to
+avoid re-numbering downstream issues.)
+
+---
+
+## F006 — Eval harness is opaque to outsiders
+
+**Severity:** S3  **Reach:** mid  **Effort:** M
+
+External contributors report that the v1.4 eval harness is convincingly
+gated in CI but hard to reason about from the outside. They want a
+benchmark page that not only shows scores but explains which axes are
+agent-accuracy vs. substrate self-consistency, plus a red-team / MITRE
+ATT&CK coverage view.
+
+**Roadmap response:** Now-bucket item #7 + Next-bucket item #18.
+
+---
+
+## F007 — Live-action surfaces are vendor-shaped, not capability-shaped
+
+**Severity:** S2  **Reach:** mid  **Effort:** L
+
+Operators with mixed fleets (Wazuh + FleetDM + a CrowdStrike pocket) want
+to write one playbook step ("isolate this host") and have the framework
+route it to the right vendor primitive. Today they branch on connector
+type inside the playbook.
+
+**Roadmap response:** Now-bucket item #8 (generic `live_action`
+interface).
+
+---
+
+## F008 — First-contributor experience is too long
+
+**Severity:** S3  **Reach:** broad  **Effort:** S
+
+New contributors report 2–4 hour ramp time before their first connector
+runs locally. They want a `HELLO_CONNECTOR.md` walkthrough with a runnable
+example (httpbin or similar), copy-paste commands, and a smoke test that
+confirms ingestion.
+
+**Roadmap response:** Now-bucket items #10–#12.
+
+---
+
+## F009 — Search is power-user-only
+
+**Severity:** S3  **Reach:** mid  **Effort:** M
+
+Operators want to type "show me failed sign-ins from new IPs in the last
+hour" and get back a query. Today they hand-write the DSL.
+
+**Roadmap response:** Now-bucket item #16 (NL-to-query + 50-pair eval).
+
+---
+
+## F010 — Threat intel is a feed, not a briefing
+
+**Severity:** S3  **Reach:** mid  **Effort:** M
+
+CISOs and SecOps leads want a weekly executive-readable briefing of what
+the ingested threat intel actually means for *their* tenant — not a raw
+feed of IOCs. They also want push-to-MISP for the IOCs that matter.
+
+**Roadmap response:** Next-bucket items #19 (briefings), #20 (MISP push).
+
+---
+
+## F011 — Endpoint coverage decision matrix is missing
+
+**Severity:** S3  **Reach:** mid  **Effort:** S
+
+Adopters evaluating AiSOC ask "which endpoint stack should I pick?" and
+there is no published guidance comparing OSS (Wazuh/audit.d/host-agent)
+to commercial vendors on coverage, cost, and operational effort.
+
+**Roadmap response:** Now-bucket item #9 (decision-matrix doc).
+
+---
+
+## F012 — CLI scaffolding is missing
+
+**Severity:** S3  **Reach:** broad  **Effort:** M
+
+Plugin authors want `aisoc-cli plugin new <type>` to scaffold a working
+plugin in seconds, mirroring `cargo new` / `npx create-*`. Today they
+copy-paste from another connector and fix what breaks.
+
+**Roadmap response:** Now-bucket item #12.
+
+---
+
+## F013 — MSSP RBAC has a leakage path through actor profiles
+
+**Severity:** S1  **Reach:** narrow (but P0 where it lands)  **Effort:** S
+
+A multi-tenant pilot reports that the threat-actor profile read endpoint
+on `services/api/app/api/v1/endpoints/threat_intel.py` returns rows from
+sibling tenants when called with a tenant-scoped token. Cross-tenant data
+exposure is treated as P0 regardless of reach.
+
+**Roadmap response:** Now-bucket item #13. Schedule first.
+
+---
+
+## F014 — Production deployment story is "good luck"
+
+**Severity:** S2  **Reach:** broad  **Effort:** L
+
+Production adopters want published Terraform modules for AWS and GCP, not
+a `docker-compose.dev.yml` and a wiki page. Several report rolling their
+own modules and would prefer to upstream them.
+
+**Roadmap response:** Now-bucket items #14, #15 (skeletons); production
+hardening graduates to Next.
+
+---
+
+## F015 — Per-rule FP regression is invisible
+
+**Severity:** S2  **Reach:** broad  **Effort:** S
+
+Detection-pack authors land changes that regress an unrelated rule's FP
+rate. The eval harness catches *aggregate* regressions but not per-rule.
+
+**Roadmap response:** Now-bucket item #5.
+
+---
+
+## F016 — Threat actor attribution is mysterious
+
+**Severity:** S3  **Reach:** mid  **Effort:** L
+
+The v0 attribution engine (PR #43) lacks a "show your work" surface.
+Analysts want to see the evidence chain, the confidence score, and the
+MITRE technique overlaps that drove a verdict.
+
+**Roadmap response:** Carried into Later — graduate the v0 engine.
+
+---
+
+## F017 — Post-mortem authoring is unowned
+
+**Severity:** S3  **Reach:** mid  **Effort:** M
+
+Cases get closed; nobody writes the post-mortem; institutional knowledge
+evaporates. Operators want a one-click drafted post-mortem from the case
+timeline.
+
+**Roadmap response:** Next-bucket item #21.
+
+---
+
+## F018 — UX time-to-task is uninstrumented
+
+**Severity:** S3  **Reach:** broad  **Effort:** M
+
+There is no objective measurement of how long common operator flows take.
+Anecdotal reports of slowdowns can't be confirmed or denied.
+
+**Roadmap response:** Next-bucket item #22 (Playwright p50/p95 suite).
+
+---
+
+## F019 — Reserved.
+
+(Held for the next pass; originally tracked overlap with F013.)
+
+---
+
+## F022 — Plugin SDK lacks a "Hello Plugin" rite of passage
+
+**Severity:** S3  **Reach:** broad  **Effort:** S
+
+Sister concern to F008, scoped to plugins (not connectors).
+
+**Roadmap response:** Now-bucket item #11.
+
+---
+
+## F023 — Plugin lifecycle is undocumented
+
+**Severity:** S3  **Reach:** mid  **Effort:** S
+
+Plugin authors don't know how to version-pin, deprecate, or sign their
+plugins for the marketplace. The publishing flow exists; the lifecycle
+documentation does not.
+
+**Roadmap response:** Next-bucket item #23.
+
+---
+
+## ID reservation log
+
+`F019`, `F020`, `F021` are reserved for the next synthesis pass. New
+themes append at the next free ID, never reuse.
+
+## Cross-references
+
+- [Strategic roadmap (Now / Next / Later)](./AiSOC_ROADMAP.md)
+- [Implementation tickets](./AiSOC_Proposed_Issues.md)

--- a/docs/community-feedback/2026-05-12/AiSOC_Proposed_Issues.md
+++ b/docs/community-feedback/2026-05-12/AiSOC_Proposed_Issues.md
@@ -1,0 +1,542 @@
+# AiSOC Proposed Issues — 2026-05-12
+
+This file holds 23 implementation tickets distilled from the
+[community feedback synthesis](./AiSOC_Community_Feedback_Synthesis.md)
+and slotted into the [Now / Next / Later roadmap](./AiSOC_ROADMAP.md).
+
+Each ticket is a faithful issue draft. When opening on GitHub:
+
+- **Title format:** `[F<id>] <area>: <change>` (e.g. `[F001] connectors: add Wazuh ingest`).
+- **Labels:** the `area:*` and `priority:*` labels listed inline.
+- **Body:** copy from the ticket below; the file references have been
+  reconciled against `main` as of v7.1.0 planning.
+
+> **Path-correction note:** The original draft set assumed several files
+> from the v7.0.x PR1–PR6 endpoint-telemetry wave were on `main`. They
+> are not — see the [reconciliation notice in `CHANGELOG.md`](../../../CHANGELOG.md)
+> under `[7.0.x]`. Tickets below have been rewritten to build fresh on
+> `main` rather than depend on the unmerged
+> `feat/pr6-osquery-extensions` primitives.
+
+---
+
+## Issue #1 — `[F001]` connectors: Wazuh ingest connector
+
+**Labels:** `area:connectors`, `area:detections`, `priority:high`, `good-first-issue:no`
+**Bucket:** Now (≤30 days)
+**Effort:** L
+
+### Problem
+
+OSS-leaning adopters cannot deploy AiSOC end-to-end without first paying
+for a commercial EDR. Wazuh is the dominant OSS endpoint stack and is
+absent from the connector matrix.
+
+### Acceptance criteria
+
+- New connector class at `services/connectors/app/connectors/wazuh.py`
+  subclassing `BaseConnector`, declaring a `schema()` returning a
+  `ConnectorSchema(category="edr", ...)` per the conventions in
+  [`AGENTS.md`](../../../AGENTS.md).
+- Registered in `_CONNECTOR_CLASSES` in
+  `services/connectors/app/connectors/__init__.py`.
+- Subscribes to a Wazuh manager's `archives.json` socket *or* polls the
+  Wazuh REST API (configurable via the connector schema).
+- Normalizes events to OCSF in the connector's `normalize()` method,
+  collapsing Wazuh's severity ladder into AiSOC's
+  `info | low | medium | high`.
+- Ships with detection content for the top-5 Wazuh-native rule families
+  under `detections/endpoint/wazuh/`.
+- Marketplace manifest at `plugins/wazuh/plugin.yaml`; rerun
+  `pnpm marketplace:sync`.
+- Connector setup walkthrough at `apps/docs/docs/connectors/wazuh.md`,
+  added to `apps/docs/sidebars.ts` under the `Connectors` category.
+- Eval gate: ≥0.9 precision on the synthetic Wazuh corpus that ships in
+  this PR.
+
+### Out of scope
+
+- Wazuh **active-response** wiring — that lands in Issue #8 as a
+  `live_action` implementation.
+
+---
+
+## Issue #2 — `[F001]` connectors+agents: `aisoc-host-agent` skeleton
+
+**Labels:** `area:connectors`, `area:agents`, `priority:high`
+**Bucket:** Now
+**Effort:** L
+
+### Problem
+
+OSS-leaning adopters want a first-party lightweight host agent rather
+than installing two third-party tools (Wazuh + osquery).
+
+### Acceptance criteria
+
+- New Go module at `services/aisoc-host-agent/` (matching the existing
+  Go service layout under `services/`).
+- Emits OCSF-shaped JSON events to `services/ingest /v1/ingest/batch`
+  with the `X-Tenant-ID` header per `AGENTS.md`.
+- Ingest handler accepts the new event source and tags it
+  `source.product = "aisoc-host-agent"`.
+- Plugin manifest at `plugins/aisoc-host-agent/plugin.yaml`.
+- Setup doc at `apps/docs/docs/connectors/aisoc-host-agent.md`.
+- Skeleton-only: process listing + file-event watcher + outbound HTTPS
+  with a static bearer token. **No** persistence, no live-response, no
+  auto-update — those are Next-bucket follow-ups.
+
+### Out of scope
+
+- Production hardening (auto-update, mTLS, signed binaries) — separate
+  Next-bucket ticket.
+
+---
+
+## Issue #3 — `[F004]` detections+connectors: audit.d profile + endpoint rules
+
+**Labels:** `area:detections`, `area:connectors`, `priority:high`
+**Bucket:** Now
+**Effort:** M
+
+### Problem
+
+Linux-heavy fleets are second-class. The detection content assumes
+Windows/mac event sources.
+
+### Acceptance criteria
+
+- New connector at `services/connectors/app/connectors/auditd.py`
+  parsing the audit.d ruleset emitted by a sidecar shipper (Vector,
+  Filebeat, or the new `aisoc-host-agent` once #2 lands).
+- 8 detection rules under `detections/endpoint/linux/auditd/`:
+  - 2 privilege-escalation (sudo abuse, setuid drop)
+  - 2 persistence (cron, systemd unit creation)
+  - 2 defense-evasion (auditd rule tampering, log truncation)
+  - 2 credential-access (`/etc/shadow` read, ssh-key read)
+- Registered, eval-gated (≥0.9 precision on synthetic corpus),
+  documented at `apps/docs/docs/connectors/auditd.md`.
+
+---
+
+## Issue #4 — `[F002][F015]` detections+ci: quarantine sweep + CI gate
+
+**Labels:** `area:detections`, `area:ci`, `priority:high`
+**Bucket:** Now
+**Effort:** L (larger than its draft suggested — every YAML rule is in scope)
+
+### Problem
+
+Out-of-the-box detection content fires too often on baseline noise. The
+eval harness catches aggregate regressions but does not surface or block
+individual high-FP rules.
+
+### Acceptance criteria
+
+- Audit every YAML rule under `detections/` against the synthetic FP
+  corpus.
+- Move rules with FP-rate > threshold (initial threshold: 0.30) to
+  `detections/_quarantine/` with a `README.md` index entry per rule
+  documenting *why* it's quarantined and the link to the eval run.
+- Add `.github/workflows/quarantine-guard.yml` that fails CI if any
+  quarantined rule slug is referenced from `marketplace/`,
+  `plugins/`, `services/agents/app/playbook/`, or any other detection
+  pack manifest.
+- Update `detections/README.md` with the quarantine policy.
+
+### Sequencing
+
+Land **before** Issue #5; #5's per-rule gate assumes the noisy floor
+has been swept first.
+
+---
+
+## Issue #5 — `[F015]` ci+evals: per-rule false-positive gate
+
+**Labels:** `area:ci`, `area:detections`, `priority:high`
+**Bucket:** Now
+**Effort:** M
+
+### Problem
+
+Authors land changes that silently regress an unrelated rule's FP rate.
+
+### Acceptance criteria
+
+- Extend `scripts/run_evals.py` (and the corresponding
+  `services/agents/tests/eval_data/` fixtures) to compute and emit a
+  per-rule FP score against the synthetic corpus.
+- New eval gate: fail the eval suite if any rule regresses ≥10% in FP
+  rate from its baseline (baseline file: `scripts/eval_baselines/fp_per_rule.json`).
+- Update the PR template / `AGENTS.md` eval-gate section to mention the
+  new gate.
+
+---
+
+## Issue #6 — `[F003]` api+web: `POST /alerts/{id}/explain`
+
+**Labels:** `area:api`, `area:web`, `priority:high`
+**Bucket:** Now
+**Effort:** M
+
+### Problem
+
+Triagers reconstruct "why did this fire" by hand from the raw event
+payload + rule YAML. Should be one click.
+
+### Acceptance criteria
+
+- New endpoint `POST /alerts/{id}/explain` in `services/api/app/api/v1/endpoints/`.
+- Returns a structured payload: `rule_lineage`, `contributing_events`,
+  `mitre_techniques`, `historical_fp_rate`, `suggested_actions`.
+- Backed by a new service `services/api/app/services/alert_explain.py`
+  that re-uses the existing LLM cost-tracker (`cost_dashboard.py`)
+  for per-tenant budgeting and BYOK keys
+  (`TenantLlmCredential`).
+- UI button on the alert detail page in
+  `apps/web/src/app/(admin)/alerts/` that opens a side panel rendering
+  the structured explanation.
+- Rate-limited per-tenant per the WS-D1 hardening in v1.0.
+
+---
+
+## Issue #7 — `[F002][F006]` docs: alert-reduction benchmark page
+
+**Labels:** `area:docs`, `area:detections`, `priority:medium`
+**Bucket:** Now
+**Effort:** S
+
+### Problem
+
+There is no published baseline for noise reduction.
+
+### Acceptance criteria
+
+- Extend `apps/docs/docs/benchmark.md` with an `alert_reduction` axis.
+- Label clearly that this axis is a **substrate self-consistency gate**,
+  not an agent-accuracy claim — match the existing v1.4 eval doc
+  conventions in `AGENTS.md`.
+- Publish the baseline numbers from the synthetic 200-incident corpus.
+
+---
+
+## Issue #8 — `[F007]` agents+playbook: generic `live_action` interface
+
+**Labels:** `area:agents`, `area:playbook`, `priority:high`
+**Bucket:** Now
+**Effort:** L
+
+### Problem
+
+Operators with mixed fleets branch on connector type inside playbooks
+to invoke the right vendor's response primitive. Should be one
+playbook step.
+
+### Acceptance criteria
+
+- New abstract base at
+  `services/agents/app/playbook/steps/live_action_base.py` (the
+  `services/agents/app/playbook/steps/` directory does not exist on
+  `main` and must be created — verified 2026-05-12).
+- Three concrete implementations:
+  - `live_action_wazuh.py` (active-response)
+  - `live_action_fleetdm.py` (live-query)
+  - `live_action_crowdstrike.py` (RTR — stub returning
+    `not_implemented` with a clear error if RTR creds are absent)
+- Playbook DSL gains a `live_action` step type that dispatches to the
+  right impl based on the target host's connector source.
+- Eval gate: per-vendor smoke test in `services/agents/tests/`.
+
+### Reconciliation note
+
+Earlier draft sequencing assumed the v7.0.x `osquery_live_query`
+primitive on `main`. It isn't — it lives on
+`feat/pr6-osquery-extensions` and is unmerged. This ticket builds the
+generic interface fresh on `main` without depending on that branch.
+
+---
+
+## Issue #9 — `[F011]` docs: endpoint decision-matrix
+
+**Labels:** `area:docs`, `priority:medium`
+**Bucket:** Now
+**Effort:** S
+
+### Problem
+
+Adopters can't pick an endpoint stack without reading the source.
+
+### Acceptance criteria
+
+- New page `apps/docs/docs/operations/endpoint-stack-decision.md`.
+- Comparison table: OSS (Wazuh, audit.d, `aisoc-host-agent`) vs.
+  commercial (CrowdStrike, SentinelOne, Defender) on coverage, cost,
+  operational effort, live-action support.
+- Adoption guidance for the 3 most common shapes (homelab, mid-market,
+  MSSP-multi-tenant).
+- Linked from `apps/docs/sidebars.ts` and from the new connector docs
+  in #1, #2, #3.
+
+---
+
+## Issue #10 — `[F008]` docs+contrib: `HELLO_CONNECTOR.md`
+
+**Labels:** `area:docs`, `area:dx`, `priority:high`, `good-first-issue:helps-create`
+**Bucket:** Now
+**Effort:** S
+
+### Problem
+
+First-contributor ramp is 2–4 hours.
+
+### Acceptance criteria
+
+- New top-level `HELLO_CONNECTOR.md` walkthrough.
+- Runnable example connector at
+  `services/connectors/app/connectors/_examples/hello_httpbin.py` that
+  polls `https://httpbin.org/uuid` and ingests one event per minute.
+  Marked clearly as an example (skipped from registration unless
+  `AISOC_ENABLE_EXAMPLE_CONNECTORS=1`).
+- Smoke test at
+  `services/connectors/tests/connectors/test_hello_httpbin.py` that
+  asserts the example normalizes and ingests one event end-to-end with
+  the scheduler disabled (`AISOC_CONNECTORS_DISABLE_SCHEDULER=1`).
+- Target: ≤30 minutes from `git clone` to "I see my event in the UI",
+  measured against a fresh contributor before merge.
+
+---
+
+## Issue #11 — `[F008][F022]` docs+contrib: `HELLO_HUNT.md` + `HELLO_PLUGIN.md`
+
+**Labels:** `area:docs`, `area:dx`, `priority:medium`
+**Bucket:** Now
+**Effort:** S
+
+### Acceptance criteria
+
+- `HELLO_HUNT.md` walks an analyst from "what's a hunt" through writing
+  one Sigma rule and grading it against the synthetic corpus.
+- `HELLO_PLUGIN.md` walks a plugin author from `pnpm marketplace:sync`
+  through publishing a no-op plugin and seeing it appear in the
+  marketplace UI.
+- Both link to #10 as the prerequisite.
+
+---
+
+## Issue #12 — `[F012]` cli+dx: `aisoc-cli plugin new`
+
+**Labels:** `area:dx`, `area:cli`, `priority:medium`
+**Bucket:** Now
+**Effort:** M
+
+### Acceptance criteria
+
+- New subcommand `aisoc-cli plugin new <type> <name>` where `<type>`
+  is one of `connector | detection-pack | playbook`.
+- Templates at `plugins/templates/connector/`,
+  `plugins/templates/detection-pack/`,
+  `plugins/templates/playbook/`.
+- Each template ships with a working hello-world implementation,
+  passing tests, and a `plugin.yaml` skeleton.
+- Documented in `HELLO_PLUGIN.md` (#11).
+
+---
+
+## Issue #13 — `[F013]` security+api: MSSP RBAC on actor profiles
+
+**Labels:** `area:security`, `area:api`, `priority:critical`
+**Bucket:** Now (schedule first)
+**Effort:** S
+
+### Problem
+
+P0: tenant-scoped tokens currently return cross-tenant rows from the
+threat-actor profile read endpoint.
+
+### Acceptance criteria
+
+- Audit `services/api/app/api/v1/endpoints/threat_intel.py` and any
+  other tenant-scoped read surface (use `git grep` for
+  `tenant_id` and review every `select(...)` that lacks a
+  `where(model.tenant_id == ...)` clause).
+- Enforce tenant-scoped filters on every `list` and `get` operation.
+- Regression tests asserting tenant A cannot read tenant B's actor
+  profiles, alerts, cases, playbooks, plugin configs, or BYOK
+  credentials.
+- Add a periodic CI job
+  (`.github/workflows/cross-tenant-rbac.yml`) that re-runs the
+  regression suite nightly against `main`.
+
+---
+
+## Issue #14 — `[F014]` infra: `terraform-aws-aisoc` module shape
+
+**Labels:** `area:infra`, `area:deployment`, `priority:high`
+**Bucket:** Now
+**Effort:** L
+
+### Acceptance criteria
+
+- New module at `infra/terraform/modules/aws-aisoc/`.
+- Variant: VPC + ECS Fargate + RDS Postgres + ElastiCache Redis +
+  Secrets Manager.
+- Outputs: API URL, web URL, Postgres connection string (sensitive),
+  Redis URL.
+- README with a 5-step quickstart.
+- Multi-AZ, KMS-CMK, and PrivateLink variants are flagged as
+  Next-bucket polish.
+
+---
+
+## Issue #15 — `[F014]` infra: `terraform-gcp-aisoc` skeleton
+
+**Labels:** `area:infra`, `area:deployment`, `priority:medium`
+**Bucket:** Now
+**Effort:** M
+
+### Acceptance criteria
+
+- Same module shape as #14, GKE + Cloud SQL + Memorystore + Secret
+  Manager.
+- Skeleton-only; production hardening is a Next-bucket follow-up.
+
+---
+
+## Issue #16 — `[F009]` api: NL-to-query translator + 50-pair eval
+
+**Labels:** `area:api`, `area:agents`, `priority:medium`
+**Bucket:** Now
+**Effort:** M
+
+### Acceptance criteria
+
+- New service at `services/api/app/services/nl_query.py` that takes a
+  natural-language prompt and returns the internal query DSL.
+- Re-uses the existing LLM cost-tracker + BYOK pattern.
+- 50-pair eval suite at
+  `services/api/tests/eval_data/nl_query_pairs.json`.
+- Eval gate: ≥0.85 exact-match accuracy.
+- Endpoint `POST /search/translate` exposes the translator; UI
+  integration is a separate Next-bucket ticket.
+
+---
+
+## Issue #17 — `[F010]` docs: notifications surface
+
+**Labels:** `area:docs`, `priority:medium`
+**Bucket:** Next
+**Effort:** S
+
+### Acceptance criteria
+
+- Document the existing notification abstraction (Slack, email,
+  PagerDuty, webhooks) at
+  `apps/docs/docs/operations/notifications.md`.
+- Missing-channel matrix listing what's wired up vs. what's planned.
+
+---
+
+## Issue #18 — `[F006]` docs+evals: red-team coverage widget
+
+**Labels:** `area:docs`, `area:evals`, `priority:medium`
+**Bucket:** Next
+**Effort:** M
+
+### Acceptance criteria
+
+- New widget on `apps/docs/docs/benchmark.md` rendering a
+  MITRE ATT&CK technique-coverage heatmap from the synthetic adversary
+  emulation runs.
+- Source data emitted by the eval harness as
+  `services/agents/tests/eval_data/mitre_coverage.json`.
+
+---
+
+## Issue #19 — `[F010]` api: TI briefings service
+
+**Labels:** `area:api`, `area:ti`, `priority:medium`
+**Bucket:** Next
+**Effort:** M
+
+### Acceptance criteria
+
+- New module `services/api/app/services/ti_briefings.py`.
+- Generates a weekly markdown briefing per tenant from ingested feeds +
+  recent alerts + recent cases.
+- Exposed via `GET /tenants/{id}/briefings/weekly` and
+  delivered via the existing notification surface (#17).
+- **No new microservice** — extends `services/api`.
+
+---
+
+## Issue #20 — `[F010]` threatintel: MISP push
+
+**Labels:** `area:threatintel`, `priority:medium`
+**Bucket:** Next
+**Effort:** S
+
+### Acceptance criteria
+
+- Extend `services/threatintel/app/exporters/stix_taxii.py` (or the
+  exporter module nearest to it on `main`) with a MISP push target.
+- Re-uses the credential vault pattern (`CredentialVault`,
+  `vault:v1:<base64>`).
+- Configurable per-tenant via the existing connector schema.
+
+---
+
+## Issue #21 — `[F017]` api: auto post-mortem endpoint
+
+**Labels:** `area:api`, `priority:medium`
+**Bucket:** Next
+**Effort:** M
+
+### Acceptance criteria
+
+- New endpoint `POST /cases/{id}/postmortem` in
+  `services/api/app/api/v1/endpoints/`.
+- Drafts a markdown post-mortem from the case timeline (events, agent
+  actions, human notes).
+- Re-uses the LLM cost-tracker + BYOK pattern.
+- Saved as a case artifact and attached to the case timeline.
+
+---
+
+## Issue #22 — `[F018]` web+ci: Playwright time-to-task suite
+
+**Labels:** `area:web`, `area:ci`, `priority:medium`
+**Bucket:** Next
+**Effort:** M
+
+### Acceptance criteria
+
+- New Playwright suite at `apps/web/tests/e2e/time_to_task/`.
+- Measures p50 / p95 wall-clock for: triage-an-alert, open-a-case,
+  run-a-playbook, write-a-detection.
+- Baseline file at `apps/web/tests/e2e/time_to_task/baselines.json`.
+- CI fails on >25% regression on any task.
+
+---
+
+## Issue #23 — `[F023]` docs: plugin lifecycle
+
+**Labels:** `area:docs`, `area:plugins`, `priority:low`
+**Bucket:** Next
+**Effort:** S
+
+### Acceptance criteria
+
+- New page `apps/docs/docs/plugins/lifecycle.md`.
+- Sections: version pinning, deprecation, signing, marketplace
+  publishing, marketplace de-listing.
+- Cross-link from `HELLO_PLUGIN.md` (#11) and the existing plugin SDK
+  docs.
+
+---
+
+## Cross-references
+
+- [Strategic roadmap](./AiSOC_ROADMAP.md)
+- [Feedback synthesis](./AiSOC_Community_Feedback_Synthesis.md)
+- [Contributor invariants & eval gates](../../../AGENTS.md)
+- [v7.0.x reconciliation](../../../CHANGELOG.md)

--- a/docs/community-feedback/2026-05-12/AiSOC_ROADMAP.md
+++ b/docs/community-feedback/2026-05-12/AiSOC_ROADMAP.md
@@ -1,0 +1,228 @@
+# AiSOC Roadmap (Now / Next / Later) — 2026-05-12
+
+> **Source of truth for active prioritization.** See
+> [`README.md`](./README.md) for how this doc relates to `/ROADMAP.md` and
+> `/CHANGELOG.md`.
+
+This roadmap is organized into three rolling buckets — **Now** (≤30 days),
+**Next** (30–90 days), and **Later** (90+ days) — with each item tagged by
+its originating feedback theme (`Fxxx`) from
+[`AiSOC_Community_Feedback_Synthesis.md`](./AiSOC_Community_Feedback_Synthesis.md).
+Implementation tickets live in
+[`AiSOC_Proposed_Issues.md`](./AiSOC_Proposed_Issues.md).
+
+---
+
+## North-Star Themes (carry across all buckets)
+
+1. **OSS-first telemetry coverage.** Every commercial connector (CrowdStrike,
+   SentinelOne, Defender, etc.) ships alongside an OSS-native equivalent
+   (Wazuh, `aisoc-host-agent`, audit.d, osquery). Closes the "I cannot adopt
+   this without a paid EDR" objection raised across `F001`, `F004`, `F011`.
+2. **Reasoning quality > connector count.** A new connector earns its keep
+   only if it ships with detection content + an eval-gated baseline. False
+   positive tuning, "Explain this alert" affordances, and alert-reduction
+   benchmarks (`F002`, `F003`, `F015`) are first-class deliverables, not
+   afterthoughts.
+3. **Contributor on-ramp under 30 minutes.** A new contributor should land
+   their first connector, hunt, or plugin within half an hour using
+   `HELLO_*.md` walkthroughs and the `aisoc-cli plugin new` scaffolder
+   (`F008`, `F012`, `F022`).
+4. **Multi-tenant safety as a hard invariant.** Cross-tenant data exposure
+   bugs (`F013`, `F019`) are P0; every new endpoint that touches
+   tenant-scoped data needs an RBAC regression test before merge.
+5. **Deployment leverage.** Published Terraform modules for AWS and GCP
+   (`F014`) replace handcrafted `docker-compose` adoption flows for
+   production deployments.
+
+---
+
+## Now — ≤30 days (v7.1.x train)
+
+The Now bucket runs in parallel with the v7.1.0 cloud-security wave already
+in flight. Items are sized so that landing them does not block v7.1.0; where
+sequencing matters it is called out inline.
+
+### Telemetry coverage gap-fill (`F001`, `F004`, `F011`)
+
+- **#1 — Wazuh ingest connector** (`area:connectors`, `priority:high`).
+  Subscribes to a Wazuh manager's `archives.json` socket / API, normalizes
+  to OCSF, ships with detection content for the top-5 Wazuh-native rules.
+  Eval gate: ≥0.9 detection precision on synthetic Wazuh corpus.
+- **#2 — `aisoc-host-agent` skeleton** (`area:connectors`,
+  `area:agents`). Lightweight Go agent emitting OCSF-compatible host
+  telemetry to `services/ingest /v1/ingest/batch`. Skeleton + ingest handler
+  + plugin manifest only — production hardening is a Next-bucket follow-up.
+- **#3 — auditd profile + endpoint detection rules** (`area:detections`,
+  `area:connectors`). Reuses the existing `services/connectors`
+  registry-based discovery; ships with 8 baseline detections covering
+  privilege escalation, persistence, defense evasion.
+
+### Reasoning-quality + alert-noise floor (`F002`, `F003`, `F015`)
+
+- **#4 — Quarantine sweep + CI gate** (`area:detections`, `area:ci`). Audit
+  every YAML rule under `detections/` for FP rate against the synthetic
+  corpus; quarantine rules above the threshold into `detections/_quarantine/`
+  with a README index, add a CI workflow that fails if a quarantined rule
+  is referenced from `marketplace/` or playbooks.
+- **#5 — Per-rule false-positive eval gate**. Extend `scripts/run_evals.py`
+  to surface a per-rule FP score and fail the eval suite if any rule
+  regresses ≥10% from its baseline.
+- **#6 — `POST /alerts/{id}/explain`** (`area:api`, `area:web`). Endpoint
+  in `services/api` that returns a structured explanation (rule lineage,
+  contributing events, MITRE mapping, suggested triage actions) plus a UI
+  button on the alert detail page. Re-uses the LLM cost-tracker for
+  per-tenant budgeting.
+- **#7 — Alert-reduction benchmark page** in `apps/docs/docs/benchmark.md`.
+  Adds an `alert_reduction` axis aligned with the existing v1.4 eval
+  conventions (substrate self-consistency gate, not an agent-accuracy claim
+  — labeled as such on the page).
+
+### Live-action surface unification (`F007`)
+
+- **#8 — Generic `live_action` playbook step interface** (`area:agents`,
+  `area:playbook`). Build the abstract base + 3 vendor implementations
+  (Wazuh active-response, FleetDM live-query, CrowdStrike RTR stub). Lives
+  at `services/agents/app/playbook/steps/live_action_base.py` (new
+  directory). Depends on Stage 0.1 reconciliation in `CHANGELOG.md` so we
+  do not assume the unmerged `feat/pr6-osquery-extensions` primitives are
+  on `main`.
+- **#9 — Endpoint decision-matrix docs**. New page under
+  `apps/docs/docs/operations/` comparing OSS (Wazuh + audit.d +
+  host-agent) vs. commercial (CrowdStrike, SentinelOne, Defender) coverage,
+  with adoption guidance.
+
+### Contributor on-ramp (`F008`, `F012`, `F022`)
+
+- **#10 — `HELLO_CONNECTOR.md`** + a runnable `httpbin.org` example
+  connector + smoke test. Every step copy-pasteable. Target: 30 min from
+  `git clone` to ingested event.
+- **#11 — `HELLO_HUNT.md` + `HELLO_PLUGIN.md`** completing the trio.
+- **#12 — `aisoc-cli plugin new`** scaffolder + `plugins/templates/` with
+  three starters (connector, detection pack, playbook).
+
+### Multi-tenant safety (`F013`)
+
+- **#13 — MSSP RBAC enforcement on actor profiles**. Audit
+  `services/api/app/api/v1/endpoints/threat_intel.py` (and any other
+  cross-tenant readable surface), enforce tenant-scoped filters on every
+  list/get, add regression tests that assert tenant A cannot read tenant
+  B's actor profiles.
+
+### Deployment leverage (`F014`)
+
+- **#14 — `terraform-aws-aisoc` module shape**. Establish the module
+  layout and ship a working VPC + ECS Fargate + RDS variant; mark advanced
+  variants (multi-AZ, KMS-CMK, private link) as Next-bucket polish.
+- **#15 — `terraform-gcp-aisoc` skeleton**. Same shape, GKE + Cloud SQL.
+  Skeleton-only in Now; productionization in Next.
+
+### Search & query UX (`F009`)
+
+- **#16 — NL-to-query translator + 50-pair eval**. Adds an LLM-backed
+  translator from natural-language prompts to the internal query DSL,
+  gated on a 50-pair eval suite (target ≥0.85 accuracy). Lives in
+  `services/api/app/services/nl_query.py`.
+
+**Now-bucket capacity note.** The honest estimate for items #1–#16, run in
+parallel with v7.1.0, is closer to 6–8 weeks than 30 days for a small team.
+The doc is intentionally aspirational; if a 30-day train is required,
+ship the bolded high-priority items (#1, #4, #5, #8, #13) first and let
+the rest slip into the v7.1.x patch line.
+
+---
+
+## Next — 30–90 days (v7.2.x → v7.3.x)
+
+### Eval-harness depth (`F006`)
+
+- **#17 — Notifications surface docs**. Document the existing notification
+  abstraction (Slack, email, PagerDuty) and add a missing-channel matrix.
+- **#18 — Red-team coverage widget on benchmark page**. Surfaces MITRE
+  ATT&CK technique coverage from the synthetic adversary emulation runs as
+  a heatmap on the benchmark page.
+
+### Threat-intel surface (`F010`, `F016`)
+
+- **#19 — TI briefings service**. New module
+  `services/api/app/services/ti_briefings.py` that generates weekly
+  AI-drafted briefings per tenant from ingested feeds + recent alerts.
+  No new microservice — extend the existing API service to keep the
+  deployment surface flat.
+- **#20 — MISP push** as an extension to the existing
+  `services/threatintel/app/exporters/stix_taxii.py`. Reuses the credential
+  vault pattern.
+
+### Investigation surface (`F017`)
+
+- **#21 — Auto post-mortem endpoint**. `POST /cases/{id}/postmortem`
+  drafts a markdown post-mortem from the case timeline (events, agent
+  actions, human notes) using the same LLM cost-tracker as #6.
+
+### UX time-to-task (`F018`)
+
+- **#22 — Playwright time-to-task tests**. Add a Playwright suite in
+  `apps/web/tests/e2e/` measuring p50/p95 time for: triage-an-alert,
+  open-a-case, run-a-playbook. Establish baselines and fail CI on >25%
+  regressions.
+
+### Plugin lifecycle (`F023`)
+
+- **#23 — Plugin lifecycle docs**. Document version pinning, deprecation,
+  signing, and the marketplace publishing flow end-to-end.
+
+---
+
+## Later — 90+ days
+
+These items are deliberately under-specified. They graduate to Next when
+the upstream prerequisites land or community pull justifies the
+re-prioritization.
+
+- **Threat actor attribution v1** — graduate the v0 engine
+  (`services/threatintel/`, currently PR #43) into a first-class surface
+  with confidence scoring, evidence chains, and a UI. (`F016`)
+- **Hosted SaaS option for evaluation tenants.** Strictly opt-in,
+  air-gap-compatible defaults preserved. (`F014`)
+- **Cross-tenant federated detection sharing.** Opt-in detection pack
+  authoring with cryptographic provenance, building on the threat-intel
+  exporter pattern. (`F010`)
+- **Mobile-first triage app**. Read-only first; write surfaces only after
+  the time-to-task tests (#22) demonstrate the desktop flow is stable.
+  (`F018`)
+- **AI-assisted detection authoring.** Extend the explain-alert primitive
+  (#6) into a "draft a Sigma rule from this incident" flow. Requires the
+  per-rule FP gate (#5) to be load-bearing first. (`F003`)
+- **Case-management integrations.** Native Jira / ServiceNow connectors
+  beyond the existing notification webhook. Schedule once #17 lands.
+  (`F017`)
+
+---
+
+## Sequencing & risk notes
+
+- **Now-bucket parallelism.** Items #1–#3, #4–#7, #10–#12, #14–#15 are
+  largely independent and can run concurrently. #8 has a Stage-0
+  reconciliation prerequisite. #13 is a P0 security item — schedule it
+  first if security tester time is available.
+- **CI baseline.** `PR_TRIAGE.md` lists 31 open Dependabot PRs and 4
+  failing CI checks on `main`. Assume some Now-bucket items will require
+  fixing CI plumbing before their own tests can run cleanly. Budget 1–2
+  days for that across the train.
+- **v7.1.0 conflict surface.** The cloud-security wave touches
+  `services/connectors/` and `apps/web/src/app/(admin)/alerts/`. Now-bucket
+  items #1–#3 and #6 land in the same files; coordinate via PR ordering
+  to avoid merge thrash.
+- **Eval-harness load.** #4, #5, #6, #16, #18, #21 all add to the eval
+  surface. Watch the harness wall-clock; if it crosses 15 min on CI we
+  should shard before #18 lands.
+
+---
+
+## Cross-references
+
+- **Stable feedback IDs:** [`AiSOC_Community_Feedback_Synthesis.md`](./AiSOC_Community_Feedback_Synthesis.md)
+- **Implementation tickets:** [`AiSOC_Proposed_Issues.md`](./AiSOC_Proposed_Issues.md)
+- **Historical roadmap:** [`/ROADMAP.md`](../../../ROADMAP.md)
+- **Active progress tracker:** [`/PROGRESS.md`](../../../PROGRESS.md)
+- **Contributor invariants & eval gates:** [`/AGENTS.md`](../../../AGENTS.md)

--- a/docs/community-feedback/2026-05-12/README.md
+++ b/docs/community-feedback/2026-05-12/README.md
@@ -1,0 +1,59 @@
+# AiSOC — Community-Feedback-Driven Roadmap (2026-05-12)
+
+This directory captures the **active** planning artifacts for AiSOC, derived
+from a community-feedback synthesis pass on 2026-05-12. It supersedes the
+"deferred beyond v7" sections of [`/ROADMAP.md`](../../../ROADMAP.md) for
+day-to-day prioritization while leaving the major-version history intact for
+traceability.
+
+## Contents
+
+| File | Purpose |
+| --- | --- |
+| [`AiSOC_ROADMAP.md`](./AiSOC_ROADMAP.md) | Now / Next / Later strategic narrative — 30-day, 30–90-day, and 90+-day buckets. |
+| [`AiSOC_Community_Feedback_Synthesis.md`](./AiSOC_Community_Feedback_Synthesis.md) | Themed feedback log with stable IDs (`F001`–`Fxxx`) for traceability. |
+| [`AiSOC_Proposed_Issues.md`](./AiSOC_Proposed_Issues.md) | 23 implementation tickets, each tagged with `Feedback Item: Fxxx`. |
+
+## How these docs are used
+
+- **`F-IDs` are stable.** Every issue, PR, and commit that addresses a feedback
+  theme should reference the matching `F` ID in its body so the trail back to
+  the originating feedback survives refactors.
+- **The "Now" bucket is the work-in-flight queue.** Items here are expected to
+  ship within 30 days of the doc's date and are tracked in
+  [`/PROGRESS.md`](../../../PROGRESS.md) under the active version line
+  (currently v7.1.x).
+- **"Next" and "Later" are intent, not commitment.** They get re-prioritized
+  on the next synthesis pass.
+- **Path & module references in the issue drafts are authoritative.** Where
+  the draft conflicts with reality on `main`, the draft wins (file the
+  reconciliation as a Stage-0 task before starting the work). The drafts in
+  this directory have already been path-corrected against the v7.1.0
+  baseline.
+
+## Reconciliation notes (carried forward)
+
+The 2026-05-12 synthesis revealed some drift between `CHANGELOG.md` and the
+state of `main`. The relevant correction lives in
+[`/CHANGELOG.md`](../../../CHANGELOG.md) under the `[7.0.x]` heading: the
+PR1–PR6 endpoint-telemetry wave was developed on
+`feat/pr6-osquery-extensions` and **not** merged into `main`. The generic
+`live_action` interface ([Issue #8](./AiSOC_Proposed_Issues.md#issue-8)) is
+therefore built fresh on `main`, not on top of those primitives.
+
+## Workflow
+
+1. Pick an issue from `AiSOC_Proposed_Issues.md`.
+2. Open a GitHub issue using the draft body (or reference the file if the
+   draft is faithful enough to skip re-typing). Apply the `area:subarea`
+   labels listed in the draft.
+3. Branch off `main`, implement against the acceptance criteria, satisfy the
+   eval gates listed in [`/AGENTS.md`](../../../AGENTS.md) when relevant.
+4. PR title format: `[F<id>] <area>: <change>` so the feedback trail is
+   visible in `git log`.
+5. Update `PROGRESS.md` checkboxes as items land.
+
+## Next synthesis pass
+
+Plan: re-run the synthesis on a 30-day cadence. The next dated directory will
+live alongside this one (e.g. `docs/community-feedback/2026-06-12/`).


### PR DESCRIPTION
## Summary

Establishes a community-feedback-driven planning surface for AiSOC and corrects a documented-but-not-merged section of the changelog. **No code changes** — docs and a changelog reconciliation only.

## What's added

- **\`docs/community-feedback/2026-05-12/\`** — new dated directory holding the active planning artifacts:
  - \`AiSOC_ROADMAP.md\` — Now / Next / Later strategic narrative (30-day, 30–90-day, 90+-day buckets).
  - \`AiSOC_Community_Feedback_Synthesis.md\` — themed feedback log with stable \`F001\`–\`Fxxx\` IDs.
  - \`AiSOC_Proposed_Issues.md\` — 23 implementation tickets, each tagged with \`Feedback Item: Fxxx\`. Path & module references are authoritative against the v7.1.0 baseline on \`main\`.
  - \`README.md\` — directory index, F-ID conventions, workflow, and the 30-day re-synthesis cadence.

- **\`ROADMAP.md\`** — banner at the top redirects day-to-day planning to the new Now / Next / Later docs while preserving \`ROADMAP.md\` as the historical major-version record.

## What's reconciled

- **\`CHANGELOG.md\` \`[7.0.x]\` section** — adds a reconciliation notice clarifying that the documented PR1–PR6 endpoint-telemetry wave was developed on \`feat/pr6-osquery-extensions\` (commits \`e0d70fa1\` → \`3ab5aa81\`) but **never merged into \`main\`**. Files referenced (\`services/osquery-tls/\`, \`aisoc_direct.py\`, \`osquery_live_query.py\`, the osquery-extensions Go module) exist on that branch but are not on \`main\` as of v7.1.0 planning.

  This is a documentation correction only; no code is reverted. The community-feedback roadmap (Issue #8 — generic \`live_action\` interface) builds on \`main\` directly rather than assuming those primitives.

## Why

- Surfaces user-facing pain points as the prioritization driver instead of internal-only major-version planning.
- Stable \`F-IDs\` give us a permanent trail from \"user said X\" → issue → PR → commit.
- Eliminates the \"shipped vs. described\" confusion in \`[7.0.x]\` so future contributors aren't blocked looking for files that aren't there.

## Out of scope

No code changes. Detection rules, services, schemas, and APIs are untouched. The active implementation work that follows from this planning lives in the two follow-up PRs (RBAC hardening on \`threat_intel\`, per-rule cross-fire FP eval gate).

## Test plan

- [ ] Verify rendered Markdown on GitHub for all four new docs (no broken relative links).
- [ ] Confirm \`ROADMAP.md\` banner links resolve to the new docs.
- [ ] Confirm \`CHANGELOG.md\` reconciliation notice is visible at the top of \`[7.0.x]\`.
- [ ] No CI gates expected to change (docs-only).

Made with [Cursor](https://cursor.com)