### PR TITLE
docs(changelog): reconcile v7.0.x osquery_live_query + aisoc-direct paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -547,10 +547,20 @@ v7.0.0 baseline and the v7.0.1 hardening patch.
 - **`services/actions/app/clients/osquery_allowlist.py`** — Strict allowlist
   enforcing only safe SELECT-only queries against approved tables (no
   `ATTACH`, no `INSERT`, no `pragma_*` introspection of secrets).
-- **`services/agents/app/playbook/steps/osquery_live_query.py`** — New
-  `osquery_live_query` step type. Pushes allowlisted distributed queries to a
-  single host or fleet-wide via osctrl / FleetDM / aisoc-direct with
-  HMAC-signed ChatOps approval before execution.
+- **`services/agents/app/playbook/engine.py::_handle_osquery_live_query`** —
+  New `osquery_live_query` step type, registered in
+  `services/agents/app/playbook/models.py` as `StepType.OSQUERY_LIVE_QUERY` and
+  dispatched from the `STEP_HANDLERS` table at the bottom of `engine.py`.
+  Pushes allowlisted distributed queries to a single host or fleet-wide via
+  osctrl / FleetDM / aisoc-direct with HMAC-signed ChatOps approval before
+  execution. Tests live in
+  `services/agents/tests/test_osquery_live_query_step.py`.
+
+  > **v7.0.x reconciliation:** Earlier drafts of this CHANGELOG referenced a
+  > separate module at `services/agents/app/playbook/steps/osquery_live_query.py`.
+  > That module never landed on `main` — the handler is inlined in `engine.py`
+  > to keep the playbook engine's dispatch table in one place. The behaviour,
+  > tests, and CLI surface are identical to the originally documented design.
 
 #### PR4 — `aisoc-osquery-tls` FastAPI service + `aisoc-direct` connector
 
@@ -560,10 +570,26 @@ v7.0.0 baseline and the v7.0.1 hardening patch.
   Self-hosted osquery TLS plugin endpoints are FleetDM-compatible so any
   off-the-shelf osquery agent can enroll without a third-party SaaS hop.
   Uses dedicated SQLite + Alembic migrations under `services/osquery-tls/db/`.
-- **`services/connectors/app/connectors/aisoc_direct.py`** + matching
-  `plugins/aisoc-direct/plugin.yaml` — Direct-from-agent ingest connector that
-  consumes the osquery-tls log stream and normalises into the standard alert
-  schema; bypasses third-party SaaS entirely.
+- **`services/osquery-tls/app/api/v1/endpoints/log.py`** + matching
+  `plugins/aisoc-direct/plugin.yaml` and
+  `services/actions/app/clients/aisoc_direct_client.py` — Direct-from-agent
+  ingest path that consumes the osquery-tls log stream and normalises into
+  the standard alert schema; bypasses third-party SaaS entirely. The
+  `aisoc-direct` connector is implemented as a **virtual connector**: agents
+  push events directly into `/api/v1/log` on the osquery-tls service, which
+  fans them out to the same ingest pipeline the polled connectors use. The
+  marketplace manifest lives at `plugins/aisoc-direct/plugin.yaml`; the
+  outbound client (used by playbooks to drive distributed queries) lives at
+  `services/actions/app/clients/aisoc_direct_client.py`.
+
+  > **v7.0.x reconciliation:** Earlier drafts of this CHANGELOG referenced a
+  > polled connector module at
+  > `services/connectors/app/connectors/aisoc_direct.py`. That module never
+  > landed on `main`. The connector is implemented as a push-based virtual
+  > connector (the `osquery-tls` service is itself the ingest endpoint), so
+  > there is nothing to register in `services/connectors/app/connectors/__init__.py`.
+  > Functionally the data path is identical to the originally documented
+  > design.
 
 #### PR5 — Osquery packs + FIM endpoint + FIM dashboard
 


### PR DESCRIPTION
## Summary

Stage 0.1 of the community roadmap: two v7.0.x CHANGELOG entries pointed at module paths that never landed on `main`. This PR corrects them in place (no code changes) so the next batch of Stage 2 docs can cite real paths.

| Old (incorrect) path | Reality |
|---|---|
| \`services/agents/app/playbook/steps/osquery_live_query.py\` | Inlined as \`_handle_osquery_live_query\` in \`services/agents/app/playbook/engine.py\`, dispatched from \`STEP_HANDLERS\` via \`StepType.OSQUERY_LIVE_QUERY\` in \`services/agents/app/playbook/models.py\`. Tests at \`services/agents/tests/test_osquery_live_query_step.py\`. |
| \`services/connectors/app/connectors/aisoc_direct.py\` | \`aisoc-direct\` is a **virtual connector**: agents push directly to \`services/osquery-tls/app/api/v1/endpoints/log.py\`. Marketplace manifest: \`plugins/aisoc-direct/plugin.yaml\`. Outbound playbook client: \`services/actions/app/clients/aisoc_direct_client.py\`. Not registered in \`services/connectors/app/connectors/__init__.py\` because there's nothing to poll. |

Each corrected bullet keeps a short \`v7.0.x reconciliation\` callout pointing operators reading old release notes at the real implementation.

## Why this exists

PR #51 (merged at \`dc815e55\`) shipped the live-query + aisoc-direct functionality, but the standalone module files described in commit \`3ab5aa81\` (on \`feat/pr6-osquery-extensions\`) were never carried over. The behaviour is identical to the documented design — only the file layout differs.

## Test plan

- [x] \`rg\` confirms every path / symbol referenced in the new bullets exists on \`main\`
- [x] No code changes — purely documentation
- [ ] CI green (lint, OpenAPI, marketplace sync, axe-core a11y)

## Unblocks

- Stage 2 #2: \`docs/operations/threat-actor-attribution.md\`
- Stage 2 #3: \`docs/connectors/cyble-vision.md\` walkthrough
- Stage 2 #8: \`docs/cost/byok-llm.md\` cost notes

Made with [Cursor](https://cursor.com)