### PR TITLE
security(codeql): fix py/log-injection in alert_explain + py/unused-global in vendor sync

### DIFF
--- a/scripts/sync_vendored_nl_query.py
+++ b/scripts/sync_vendored_nl_query.py
@@ -77,6 +77,10 @@ def _check() -> int:
         if not filecmp.cmp(src, dst, shallow=False):
             drift.append(f"  - out of date: {name}")
 
+    for name in VENDORED_ONLY:
+        if not (VENDORED_DIR / name).is_file():
+            drift.append(f"  - missing vendored-only file: {name}")
+
     # Make sure no stray extra .py files snuck into the vendored tree.
     vendored_pyfiles = {p.name for p in VENDORED_DIR.iterdir() if p.is_file() and p.suffix == ".py"}
     extra_py = vendored_pyfiles - set(SYNCED_FILES)
@@ -123,8 +127,7 @@ def _sync() -> int:
             print(f"removing stale {path.relative_to(REPO_ROOT)}")
             path.unlink()
 
-    print("\nDone. Don't forget to commit the changes under "
-          "services/api/app/_vendor/nl_query/.")
+    print("\nDone. Don't forget to commit the changes under services/api/app/_vendor/nl_query/.")
     return 0
 
 

--- a/services/api/app/api/v1/endpoints/alert_explain.py
+++ b/services/api/app/api/v1/endpoints/alert_explain.py
@@ -43,6 +43,7 @@ from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
 from sqlalchemy import select
 
 from app.api.v1.deps import AuthUser, require_permission
+from app.core.logging import safe_log_value
 from app.db.rls import TenantDBSession
 from app.models.alert import Alert
 from app.services.alert_explain import (
@@ -93,7 +94,7 @@ async def _acquire_or_429(
         # error envelope so retry-after semantics survive the 429.
         logger.info(
             "explain.rate_limited tenant_id=%s cost=%.2f remaining=%.2f retry_after=%.2fs",
-            tenant_id,
+            safe_log_value(tenant_id),
             cost,
             decision.remaining,
             decision.retry_after_seconds,
@@ -174,11 +175,15 @@ async def explain_alert(
         # errors, etc. — so reaching this branch means something
         # unexpected (e.g. database read failure mid-explain) blew up.
         # Log loudly and return a 502 so the client can retry; we do
-        # *not* expose the exception text to the caller.
+        # *not* expose the exception text to the caller. Tenant/alert
+        # IDs are UUIDs in practice but they originate from the request,
+        # so we route them through ``safe_log_value`` to neutralise any
+        # CR/LF injection attempt before they hit the log stream
+        # (CWE-117 / CodeQL ``py/log-injection``).
         logger.exception(
             "explain.failed tenant=%s alert=%s",
-            current_user.tenant_id,
-            alert_id,
+            safe_log_value(current_user.tenant_id),
+            safe_log_value(alert_id),
         )
         raise HTTPException(
             status_code=status.HTTP_502_BAD_GATEWAY,
@@ -215,11 +220,16 @@ async def explain_alert(
         # Audit-log failures must never break the explain response.
         # We log a warning so ops can investigate, but we do not
         # propagate — the user already got their answer.
+        # Sanitise every interpolated value: tenant_id/alert_id come
+        # from the request and ``exc`` may carry arbitrary text
+        # (e.g. database constraint messages). ``safe_log_value``
+        # escapes CR/LF/NUL/ESC and truncates, defending against
+        # CWE-117 (CodeQL ``py/log-injection``).
         logger.warning(
             "explain.audit_failed tenant=%s alert=%s error=%s",
-            current_user.tenant_id,
-            alert_id,
-            exc,
+            safe_log_value(current_user.tenant_id),
+            safe_log_value(alert_id),
+            safe_log_value(exc),
         )
 
     return _explanation_to_payload(explanation)


### PR DESCRIPTION
## Summary

Closes the three open CodeQL alerts on `main` reported at https://github.com/beenuar/AiSOC/security/code-scanning:

| # | Rule | File:Line | Severity |
|---|---|---|---|
| 1 | `py/log-injection` (CWE-117) | `services/api/app/api/v1/endpoints/alert_explain.py:181` | high |
| 2 | `py/log-injection` (CWE-117) | `services/api/app/api/v1/endpoints/alert_explain.py:221` | high |
| 3 | `py/unused-global-variable` | `scripts/sync_vendored_nl_query.py:36` (`VENDORED_ONLY`) | low |

## Changes

### `services/api/app/api/v1/endpoints/alert_explain.py`
- Import `safe_log_value` from `app.core.logging` — already exists for exactly this purpose (escapes CR/LF/NUL/ESC, truncates to `_MAX_LOG_VALUE_LEN`).
- Wrap every user-derived value in the three log statements that interpolate request data:
  - `explain.failed` (the originally-flagged 502 path) → `tenant_id`, `alert_id`
  - `explain.audit_failed` (the originally-flagged audit-log fallback) → `tenant_id`, `alert_id`, `exc`
  - `explain.rate_limited` (proactively hardened — same class of issue, same data path, just not yet flagged) → `tenant_id`
- No behaviour change. Inline comments now point at CWE-117 / CodeQL `py/log-injection` so the next maintainer keeps the pattern.

### `scripts/sync_vendored_nl_query.py`
- `VENDORED_ONLY` listed `VENDORED.md` as the marker file in the vendored tree but was never read, so CodeQL correctly called it out as dead. Wired it into the `--check` loop: drift is now reported if any file declared in `VENDORED_ONLY` is missing from `services/api/app/_vendor/nl_query/`. The variable has a real behavioural contract instead of being documentation-only.
- Reformatted a wrapped `print()` that `ruff format` complained about after the edit.

## Test plan

- [x] `python3 -m pytest services/api/tests/test_alert_explain.py -x -q` → 58 passed
- [x] `python3 scripts/sync_vendored_nl_query.py --check` → `OK: vendored nl_query matches source tree.`
- [x] `ruff check` + `ruff format --check` clean on both edited files
- [x] `python3 -c "import ast; ast.parse(...)"` on both files
- [ ] CI green (CodeQL job in particular)
- [ ] CodeQL alerts auto-close once `main` re-runs the scan post-merge

## Notes

`safe_log_value` is the existing project-wide remediation utility; this PR is intentionally narrow and uses it rather than introducing a new sanitiser. If you want me to do a sweep of the rest of `services/api/app/api/v1/endpoints/*.py` for the same pattern in a follow-up, say the word.

Made with [Cursor](https://cursor.com)