### PR TITLE
feat(compose): add docker-compose.dev.yml dev alias

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,14 @@
+# AiSOC — developer compose entrypoint.
+#
+# This file is a thin alias over `docker-compose.yml` so that the Quickstart
+# guide and demo scripts can use a stable, dev-flavoured command:
+#
+#     docker compose -f docker-compose.dev.yml up -d
+#
+# It uses the Compose Spec `include` directive (Docker Compose v2.20+) to
+# pull in the full stack from `docker-compose.yml` without duplicating any
+# service definitions. Override files (e.g. `docker-compose.local.yml`) can
+# still be layered on top with additional `-f` flags.
+
+include:
+  - docker-compose.yml


### PR DESCRIPTION
## Summary

Adds `docker-compose.dev.yml` as a thin Compose Spec `include:` alias over `docker-compose.yml`. This unblocks the v1.5 demo video script and quickstart docs that reference `docker compose -f docker-compose.dev.yml up -d`.

## Why

The video demo script and several docs assume a `docker-compose.dev.yml` exists at repo root, but it never did — the file referenced was missing, causing the demo command to fail on a fresh clone.

## How

Uses the **Compose Spec native `include:` directive** (Docker Compose v2.20+), so this is a one-line file that pulls in the full base stack with zero duplication:

\`\`\`yaml
include:
  - docker-compose.yml
\`\`\`

## Test plan

- [x] \`docker compose -f docker-compose.dev.yml config --services\` resolves all 20 services identically to the base file
- [ ] CI green
- [ ] Auto-merge after CI

## Dependency order

This is **PR 1 of 7** in the v1.5.1 demo-readiness series. No deps; all later PRs assume this lands first.

Made with [Cursor](https://cursor.com)