### PR TITLE
feat(env): three-vars header in .env.example + POSTGRES_PASSWORD split

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,19 @@
 # AiSOC Environment Variables
 # Copy this file to .env and fill in your values
+#
+# ╔════════════════════════════════════════════════════════════════════════════╗
+# ║ REQUIRED FOR LOCAL DEV — set these three before `aisoc serve`:             ║
+# ║                                                                            ║
+# ║   1. OPENAI_API_KEY        your LLM provider API key (see "AI / LLM")      ║
+# ║   2. POSTGRES_PASSWORD     dev Postgres password (the default below works  ║
+# ║                            out of the box; change for shared envs)         ║
+# ║   3. AISOC_CREDENTIAL_KEY  Fernet key for the connector credential vault.  ║
+# ║                            A dev-only key is pre-filled below — generate   ║
+# ║                            your own for any non-laptop deployment.         ║
+# ║                                                                            ║
+# ║ Everything else has sensible defaults for `docker compose -f               ║
+# ║ docker-compose.dev.yml up -d`.                                             ║
+# ╚════════════════════════════════════════════════════════════════════════════╝
 
 # ─── Image Pinning ────────────────────────────────────────────────────────────
 # Tag pulled by every `image: ghcr.io/beenuar/aisoc-*:${AISOC_VERSION:-latest}`
@@ -16,9 +30,9 @@ SECRET_KEY=change-this-to-a-random-secret-key-at-least-32-chars
 # Application-layer encryption key for connector credentials and other
 # secret payloads stored in Postgres. Generate with:
 #   python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
-# Required outside development. Leave blank in development to auto-generate
-# an ephemeral key (warning: connectors won't survive a process restart).
-AISOC_CREDENTIAL_KEY=
+# Required outside development. The value below is a DEV-ONLY key safe for
+# local laptop usage; rotate it (and remove from any image) before deploying.
+AISOC_CREDENTIAL_KEY=tpDDex4w7lO2lKbJ7O1uGoaGkfjQYvRBM3DrIESuXvI=
 # Comma-separated list of previous credential keys to support zero-downtime
 # rotation. Leave blank unless you are mid-rotation.
 AISOC_CREDENTIAL_KEY_ROTATION_FROM=
@@ -32,7 +46,11 @@ CONNECTORS_SERVICE_URL=http://connectors:8003
 CONNECTORS_SERVICE_TIMEOUT_SECONDS=15
 
 # ─── Database ─────────────────────────────────────────────────────────────────
-DATABASE_URL=postgresql+asyncpg://aisoc:aisoc_dev_secret@localhost:5432/aisoc
+# POSTGRES_PASSWORD is the dev password for the bundled Postgres container.
+# `docker-compose.yml` and the API both interpolate this value, so changing it
+# here is enough to rotate the dev password across the stack.
+POSTGRES_PASSWORD=aisoc_dev_secret
+DATABASE_URL=postgresql+asyncpg://aisoc:${POSTGRES_PASSWORD}@localhost:5432/aisoc
 REDIS_URL=redis://:redis_dev_secret@localhost:6379/0
 CLICKHOUSE_URL=http://aisoc:clickhouse_dev_secret@localhost:8123/aisoc
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,7 +39,7 @@ services:
     environment:
       POSTGRES_DB: aisoc
       POSTGRES_USER: aisoc
-      POSTGRES_PASSWORD: aisoc_dev_secret
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-aisoc_dev_secret}
     ports:
       - "127.0.0.1:5432:5432"
     volumes:
@@ -229,7 +229,7 @@ services:
     ports:
       - "127.0.0.1:8000:8000"
     environment:
-      DATABASE_URL: postgresql+asyncpg://aisoc:aisoc_dev_secret@postgres:5432/aisoc
+      DATABASE_URL: postgresql+asyncpg://aisoc:${POSTGRES_PASSWORD:-aisoc_dev_secret}@postgres:5432/aisoc
       REDIS_URL: redis://:redis_dev_secret@redis:6379/0
       KAFKA_BOOTSTRAP_SERVERS: kafka:29092
       CLICKHOUSE_URL: http://aisoc:clickhouse_dev_secret@clickhouse:8123/aisoc
@@ -313,7 +313,7 @@ services:
     environment:
       KAFKA_BOOTSTRAP_SERVERS: kafka:29092
       REDIS_URL: redis://:redis_dev_secret@redis:6379/3
-      DATABASE_URL: postgresql+asyncpg://aisoc:aisoc_dev_secret@postgres:5432/aisoc
+      DATABASE_URL: postgresql+asyncpg://aisoc:${POSTGRES_PASSWORD:-aisoc_dev_secret}@postgres:5432/aisoc
     networks:
       - aisoc
     restart: unless-stopped
@@ -333,7 +333,7 @@ services:
     ports:
       - "127.0.0.1:8001:8084"
     environment:
-      DATABASE_URL: postgresql+asyncpg://aisoc:aisoc_dev_secret@postgres:5432/aisoc
+      DATABASE_URL: postgresql+asyncpg://aisoc:${POSTGRES_PASSWORD:-aisoc_dev_secret}@postgres:5432/aisoc
       REDIS_URL: redis://:redis_dev_secret@redis:6379/4
       CORE_API_URL: http://api:8000
       QDRANT_URL: http://qdrant:6333
@@ -366,7 +366,7 @@ services:
     profiles:
       - osquery
     environment:
-      DATABASE_URL: postgresql+asyncpg://aisoc:aisoc_dev_secret@postgres:5432/aisoc
+      DATABASE_URL: postgresql+asyncpg://aisoc:${POSTGRES_PASSWORD:-aisoc_dev_secret}@postgres:5432/aisoc
       AISOC_OSQUERY_TLS_ENROLL_SECRET: ${AISOC_OSQUERY_TLS_ENROLL_SECRET:-change-me-in-production}
       # The ingest service is registered as `ingest-worker` in this compose
       # file; the previous `http://ingest:8080` would not resolve via DNS.
@@ -392,7 +392,7 @@ services:
     environment:
       KAFKA_BOOTSTRAP_SERVERS: kafka:29092
       REDIS_URL: redis://:redis_dev_secret@redis:6379/5
-      DATABASE_URL: postgresql+asyncpg://aisoc:aisoc_dev_secret@postgres:5432/aisoc
+      DATABASE_URL: postgresql+asyncpg://aisoc:${POSTGRES_PASSWORD:-aisoc_dev_secret}@postgres:5432/aisoc
       CORE_API_URL: http://api:8000
     networks:
       - aisoc
@@ -417,7 +417,7 @@ services:
     environment:
       KAFKA_BOOTSTRAP_SERVERS: kafka:29092
       REDIS_URL: redis://:redis_dev_secret@redis:6379/6
-      DATABASE_URL: postgresql+asyncpg://aisoc:aisoc_dev_secret@postgres:5432/aisoc
+      DATABASE_URL: postgresql+asyncpg://aisoc:${POSTGRES_PASSWORD:-aisoc_dev_secret}@postgres:5432/aisoc
       CORE_API_URL: http://api:8000
       CROWDSTRIKE_CLIENT_ID: ${CROWDSTRIKE_CLIENT_ID:-}
       CROWDSTRIKE_CLIENT_SECRET: ${CROWDSTRIKE_CLIENT_SECRET:-}
@@ -477,7 +477,7 @@ services:
     ports:
       - "127.0.0.1:8007:8004"
     environment:
-      DATABASE_URL: postgresql+asyncpg://aisoc:aisoc_dev_secret@postgres:5432/aisoc
+      DATABASE_URL: postgresql+asyncpg://aisoc:${POSTGRES_PASSWORD:-aisoc_dev_secret}@postgres:5432/aisoc
       REDIS_URL: redis://:redis_dev_secret@redis:6379/8
       KAFKA_BOOTSTRAP_SERVERS: kafka:29092
       CLICKHOUSE_URL: http://aisoc:clickhouse_dev_secret@clickhouse:8123/aisoc
@@ -504,7 +504,7 @@ services:
     ports:
       - "127.0.0.1:8008:8005"
     environment:
-      DATABASE_URL: postgresql+asyncpg://aisoc:aisoc_dev_secret@postgres:5432/aisoc
+      DATABASE_URL: postgresql+asyncpg://aisoc:${POSTGRES_PASSWORD:-aisoc_dev_secret}@postgres:5432/aisoc
       REDIS_URL: redis://:redis_dev_secret@redis:6379/9
       KAFKA_BOOTSTRAP_SERVERS: kafka:29092
       CORE_API_URL: http://api:8000
@@ -528,7 +528,7 @@ services:
     ports:
       - "127.0.0.1:8006:8006"
     environment:
-      DATABASE_URL: postgresql+asyncpg://aisoc:aisoc_dev_secret@postgres:5432/aisoc
+      DATABASE_URL: postgresql+asyncpg://aisoc:${POSTGRES_PASSWORD:-aisoc_dev_secret}@postgres:5432/aisoc
       REDIS_URL: redis://:redis_dev_secret@redis:6379/10
       CORE_API_URL: http://api:8000
       ATTCK_DATA_PATH: /app/data/enterprise-attack.json

--- a/services/api/app/core/config.py
+++ b/services/api/app/core/config.py
@@ -153,7 +153,12 @@ class Settings(BaseSettings):
     WEEKLY_DIGEST_POLL_INTERVAL_SECONDS: int = 3600
 
     # Database
-    DATABASE_URL: PostgresDsn = "postgresql+asyncpg://aisoc:aisoc@localhost:5432/aisoc"  # type: ignore[assignment]
+    # The default points at the bundled compose Postgres with its dev password.
+    # In docker-compose.yml and .env.example the password is parameterised via
+    # ``POSTGRES_PASSWORD`` so a single env var rotates it across the stack;
+    # this default mirrors the compose default so ``aisoc serve`` works on a
+    # fresh clone with zero configuration.
+    DATABASE_URL: PostgresDsn = "postgresql+asyncpg://aisoc:aisoc_dev_secret@localhost:5432/aisoc"  # type: ignore[assignment]
     DATABASE_POOL_SIZE: int = 20
     DATABASE_MAX_OVERFLOW: int = 10
 


### PR DESCRIPTION
## Summary

PR 2 of 7 in the video-script fix series. Makes the three required env vars discoverable so a fresh-clone laptop quickstart Just Works.

- New header block in `.env.example` names the three required vars (`OPENAI_API_KEY`, `POSTGRES_PASSWORD`, `AISOC_CREDENTIAL_KEY`) at the top of the file
- `POSTGRES_PASSWORD` split out as a standalone variable; `DATABASE_URL` and every service in `docker-compose.yml` now interpolate it so rotating the dev password is a one-liner
- `AISOC_CREDENTIAL_KEY` pre-filled with a freshly-generated, clearly-marked **DEV-ONLY** Fernet key so `aisoc serve` doesn't warn on a fresh clone (comment makes the prod expectation explicit)
- `services/api/app/core/config.py` default mirrors the compose default for consistency

## Test plan

- [x] `docker compose config` parses cleanly with new interpolation
- [x] Default `POSTGRES_PASSWORD=aisoc_dev_secret` keeps existing `docker compose up` flow working
- [ ] CI green

## Series

- [x] PR 1: compose-alias (#merged)
- [ ] **PR 2: env-template (this PR)**
- [ ] PR 3: eval-suite
- [ ] PR 4: cli-subcommands
- [ ] PR 5: submit-example
- [ ] PR 6: docs-pathc
- [ ] PR 7: version-bump

Made with [Cursor](https://cursor.com)