### PR TITLE
docs(quickstart): add Path C — founder-style CLI walkthrough

### DIFF
--- a/apps/docs/docs/quickstart.md
+++ b/apps/docs/docs/quickstart.md
@@ -4,7 +4,7 @@ sidebar_position: 3
 
 # Quick Start
 
-Three paths to a running AiSOC instance, in increasing order of how much you
+Four paths to a running AiSOC instance, in increasing order of how much you
 already have installed:
 
 0. **Zero-prerequisite bootstrap** — one shell command from a freshly-imaged
@@ -17,10 +17,14 @@ already have installed:
 2. **Full development stack** — every microservice (UEBA, Honeytokens, Purple
    Team, ClickHouse, OpenSearch, Neo4j, Qdrant, MCP, osquery TLS server,
    Slack bot) for hacking on AiSOC itself.
+3. **Founder-style CLI** — the same dev stack as Path B, but driven entirely
+   through the `aisoc` CLI: `aisoc serve`, `aisoc db upgrade`, `aisoc submit`,
+   `aisoc mcp serve`. Ideal for screen-recording demos and for operators who
+   prefer a single binary over `docker compose` + `alembic` + `curl`.
 
-This page covers Paths A and B. If you don't have Docker / Node / pnpm yet,
-or if you just want a guaranteed-clean environment in one command, start with
-[Path 0 (One-click install)](./installation).
+This page covers Paths A, B, and C. If you don't have Docker / Node / pnpm
+yet, or if you just want a guaranteed-clean environment in one command, start
+with [Path 0 (One-click install)](./installation).
 
 ## Prerequisites
 
@@ -250,6 +254,148 @@ permissions / scopes / role assignments and a troubleshooting section.
 | Compliance | `/compliance` | SOC 2, ISO 27001, NIST CSF, PCI-DSS, HIPAA, DORA |
 | Audit Log | `/audit` | Immutable, tenant-scoped activity ledger |
 | Responder PWA | `/responder` | Mobile passkey-only console for on-call analysts |
+
+## Path C — founder-style CLI
+
+Same backing services as Path B (full dev stack), but every step is one
+`aisoc <verb>` command. This is the path the recorded product demo follows
+and the fastest way to go from "fresh clone" to "alert submitted, agent
+investigating" without remembering the `docker compose` / `alembic` /
+`curl` invocations.
+
+### 1. Clone & install the CLI
+
+```bash
+git clone https://github.com/beenuar/AiSOC.git
+cd AiSOC
+cp .env.example .env
+
+python -m venv .venv && source .venv/bin/activate
+pip install -e packages/aisoc-cli
+```
+
+`.env.example` is already wired up with a working `POSTGRES_PASSWORD` and a
+pre-generated dev `AISOC_CREDENTIAL_KEY`. Add at least one AI provider key
+(`OPENAI_API_KEY` or `ANTHROPIC_API_KEY`) before continuing.
+
+Confirm the CLI is on PATH:
+
+```bash
+aisoc --help
+```
+
+You should see the operator commands: `serve`, `db`, `mcp`, `submit`,
+`plugin`, `detection`, `keygen`.
+
+### 2. Start the dev stack
+
+```bash
+aisoc serve
+```
+
+Under the hood this runs `docker compose -f docker-compose.dev.yml up -d`
+against the full dev profile (Postgres, Redis, Kafka, ClickHouse, api,
+agents, fusion, ingest-worker, web, mcp, …). The command resolves the repo
+root automatically, so it works from any subdirectory.
+
+Use `aisoc serve --no-detach` if you want to watch the logs inline, or run
+`docker compose ps` separately to confirm every container is healthy.
+
+### 3. Run database migrations
+
+```bash
+aisoc db upgrade
+```
+
+This shells into the `api` container and runs the project's migration
+script against Postgres. It is idempotent — safe to re-run after each
+`aisoc serve`.
+
+### 4. Submit your first alert
+
+The repo ships a canonical OCSF / Okta System Log fixture under
+[`examples/alerts/lateral-movement.json`](https://github.com/beenuar/AiSOC/blob/main/examples/alerts/lateral-movement.json):
+two `user.session.start` events for the same user — first from a New York
+corporate IP, then from Saint Petersburg eight minutes later — designed to
+trip the impossible-travel detector.
+
+```bash
+aisoc submit examples/alerts/lateral-movement.json
+```
+
+What this does:
+
+1. Reads the JSON file. The fixture is self-describing — its
+   `connector_id` / `connector_type` / `source_format` (if present) win
+   over the CLI flags, so the same fixture works against any environment.
+2. POSTs to `http://127.0.0.1:8081/v1/ingest/batch` (override with
+   `--ingest-url` or `AISOC_INGEST_URL`) using the canonical envelope:
+   `connector_id`, `connector_type`, `source_format`, `events`.
+3. Sends the required `X-Tenant-ID` header (override with `--tenant-id`
+   or `AISOC_TENANT_ID`).
+4. Prints `accepted` / `rejected` counts plus the `request_id`.
+
+A non-zero exit code means the ingest service rejected the payload or
+isn't reachable; the error message tells you to run `aisoc serve` first
+if the latter.
+
+### 5. Watch fusion + agents pick it up
+
+```bash
+# Tail the API logs to watch the event flow through fusion → detection
+docker compose logs -f api fusion agents
+
+# Or just open the UI and watch /alerts populate
+open http://localhost:3000/alerts
+```
+
+Within a few seconds you should see the two Okta events normalized into
+OCSF `class_uid 3002` (Authentication), correlated by user, and surfaced
+on the alerts board.
+
+### 6. Hook your IDE in over MCP (optional)
+
+If you use Cursor, Claude Desktop, or Continue, point them at the local
+MCP server so you can talk to your running AiSOC instance from the editor:
+
+```bash
+# Stand up the MCP server over stdio (Cursor / Claude / Continue)
+aisoc mcp serve --transport stdio
+
+# Or auto-wire it into a specific IDE config
+aisoc mcp install --host cursor
+aisoc mcp install --host claude
+aisoc mcp install --host continue
+```
+
+`aisoc mcp serve` prefers the local TypeScript build at
+`services/mcp/dist/index.js` when present, and falls back to
+`npx @aisoc/mcp` otherwise — so it works on a fresh clone before you've
+run `pnpm build`.
+
+### 7. Tear down
+
+```bash
+docker compose -f docker-compose.dev.yml down
+```
+
+Or keep the stack running and re-submit different fixtures — `aisoc
+submit` accepts any JSON file shaped like a single event, a list of
+events, or `{ "events": [...] }`. Drop in your own Okta / Entra / GitHub
+sample exports to dogfood your detection content end to end.
+
+### Founder-style CLI cheat sheet
+
+| Step | Command |
+|---|---|
+| Start the dev stack | `aisoc serve` |
+| Apply DB migrations | `aisoc db upgrade` |
+| Submit a sample alert | `aisoc submit examples/alerts/lateral-movement.json` |
+| Run the MCP server over stdio | `aisoc mcp serve --transport stdio` |
+| Wire MCP into Cursor / Claude / Continue | `aisoc mcp install --host <host>` |
+| Validate a plugin manifest | `aisoc plugin validate plugins/<id>` |
+| Validate a Sigma rule | `aisoc detection validate detections/<id>.yml` |
+| Generate a vault `AISOC_CREDENTIAL_KEY` | `aisoc keygen` |
 
 ## Next Steps
 

--- a/examples/alerts/lateral-movement.json
+++ b/examples/alerts/lateral-movement.json
@@ -1,0 +1,85 @@
+{
+  "_description": "Two-event lateral-movement scenario in Okta System Log format. The same user (alice@example.com) successfully authenticates from a New York corp IP at 09:30 UTC, then from a Saint Petersburg IP eight minutes later. Routes through the okta_system_log connector profile (OCSF class_uid 3002, Authentication) when posted to /v1/ingest/batch.",
+  "_usage": "aisoc submit examples/alerts/lateral-movement.json",
+  "events": [
+    {
+      "uuid": "11111111-1111-4111-8111-111111111111",
+      "published": "2026-05-14T09:30:14.123Z",
+      "eventType": "user.session.start",
+      "displayMessage": "User login to Okta",
+      "severity": "INFO",
+      "actor": {
+        "id": "00u1abc23xYZdEfgHi45",
+        "type": "User",
+        "alternateId": "alice@example.com",
+        "displayName": "Alice Carter"
+      },
+      "client": {
+        "ipAddress": "203.0.113.42",
+        "userAgent": {
+          "rawUserAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 14_5) AppleWebKit/537.36",
+          "os": "Mac OS X",
+          "browser": "CHROME"
+        },
+        "device": "Computer",
+        "geographicalContext": {
+          "city": "New York",
+          "state": "New York",
+          "country": "United States",
+          "geolocation": {"lat": 40.7128, "lon": -74.006}
+        }
+      },
+      "outcome": {
+        "result": "SUCCESS",
+        "reason": "User authenticated"
+      },
+      "transaction": {"id": "txn-lat-mov-001"},
+      "authenticationContext": {
+        "authenticationProvider": "FACTOR_PROVIDER",
+        "credentialType": "PASSWORD"
+      }
+    },
+    {
+      "uuid": "22222222-2222-4222-8222-222222222222",
+      "published": "2026-05-14T09:38:02.987Z",
+      "eventType": "user.session.start",
+      "displayMessage": "User login to Okta",
+      "severity": "WARN",
+      "actor": {
+        "id": "00u1abc23xYZdEfgHi45",
+        "type": "User",
+        "alternateId": "alice@example.com",
+        "displayName": "Alice Carter"
+      },
+      "client": {
+        "ipAddress": "185.220.101.7",
+        "userAgent": {
+          "rawUserAgent": "Mozilla/5.0 (X11; Linux x86_64) Gecko/20100101 Firefox/126.0",
+          "os": "Linux",
+          "browser": "FIREFOX"
+        },
+        "device": "Unknown",
+        "geographicalContext": {
+          "city": "Saint Petersburg",
+          "country": "Russia",
+          "geolocation": {"lat": 59.9343, "lon": 30.3351}
+        }
+      },
+      "outcome": {
+        "result": "SUCCESS",
+        "reason": "User authenticated"
+      },
+      "transaction": {"id": "txn-lat-mov-002"},
+      "authenticationContext": {
+        "authenticationProvider": "FACTOR_PROVIDER",
+        "credentialType": "PASSWORD"
+      },
+      "debugContext": {
+        "debugData": {
+          "risk": "HIGH",
+          "behaviors": "New Geo-Location=POSITIVE, New IP=POSITIVE, Velocity=POSITIVE"
+        }
+      }
+    }
+  ]
+}

--- a/packages/aisoc-cli/src/aisoc_cli/main.py
+++ b/packages/aisoc-cli/src/aisoc_cli/main.py
@@ -12,6 +12,7 @@ Commands:
   aisoc db upgrade                  Run database migrations against the dev stack
   aisoc mcp serve [--transport]     Launch the MCP server for IDE assistants
   aisoc mcp install --host <h>      Wire AiSOC into Claude / Cursor / Continue
+  aisoc submit <file>               POST an alert/event JSON payload to the ingest API
 """
 from __future__ import annotations
 
@@ -701,6 +702,223 @@ def mcp_install(host: str) -> None:
     result = subprocess.run(argv, cwd=str(repo_root))
     if result.returncode != 0:
         sys.exit(result.returncode)
+
+
+# ── submit command ───────────────────────────────────────────────────────────
+#
+# `aisoc submit <file>` lets the founder-flow demo and any operator land a
+# canned OCSF/Okta-shaped payload on the local dev stack in one command.
+# It POSTs to the Go ingest service's batch endpoint with the same envelope
+# the real connectors use (see services/connectors/app/ingest_client.py):
+#
+#     POST {ingest_url}/v1/ingest/batch
+#     X-Tenant-ID: <uuid>
+#     { connector_id, connector_type, source_format, events: [...] }
+#
+# The fixture format is intentionally forgiving — the file may be:
+#   * { "events": [...], "connector_id": ..., "connector_type": ..., "source_format": ... }
+#   * a bare JSON list of event dicts
+#   * a single event dict (auto-wrapped)
+# Any keys present in a dict-shaped fixture override the matching CLI flags,
+# so a fixture can pin its own connector identity without operator flags.
+
+_DEFAULT_INGEST_URL = "http://127.0.0.1:8081"
+_DEFAULT_TENANT_ID = "00000000-0000-0000-0000-000000000001"
+_DEFAULT_CONNECTOR_ID = "aisoc-cli-submit"
+_DEFAULT_CONNECTOR_TYPE = "okta_system_log"
+_DEFAULT_SOURCE_FORMAT = "json"
+
+
+def _coerce_events(payload: Any) -> tuple[list[dict[str, Any]], dict[str, str]]:
+    """Normalize a parsed JSON payload into (events, fixture_overrides).
+
+    Returns the event list plus any connector_id / connector_type /
+    source_format overrides that a dict-shaped fixture wants to pin.
+    """
+    overrides: dict[str, str] = {}
+    if isinstance(payload, list):
+        events = payload
+    elif isinstance(payload, dict):
+        if "events" in payload and isinstance(payload["events"], list):
+            events = payload["events"]
+            for key in ("connector_id", "connector_type", "source_format"):
+                value = payload.get(key)
+                if isinstance(value, str) and value:
+                    overrides[key] = value
+        else:
+            events = [payload]
+    else:
+        raise click.ClickException(
+            "Payload must be a JSON object, a list of events, "
+            "or an object with an 'events' list."
+        )
+
+    cleaned: list[dict[str, Any]] = []
+    for idx, event in enumerate(events):
+        if not isinstance(event, dict):
+            raise click.ClickException(
+                f"Event at index {idx} is not a JSON object (got {type(event).__name__})."
+            )
+        cleaned.append(event)
+
+    if not cleaned:
+        raise click.ClickException("No events to submit — the payload is empty.")
+
+    return cleaned, overrides
+
+
+@cli.command()
+@click.argument(
+    "file",
+    type=click.Path(exists=True, dir_okay=False, readable=True, path_type=Path),
+)
+@click.option(
+    "--ingest-url",
+    envvar="AISOC_INGEST_URL",
+    default=_DEFAULT_INGEST_URL,
+    show_default=True,
+    help="Base URL for the ingest service (e.g. http://127.0.0.1:8081).",
+)
+@click.option(
+    "--tenant-id",
+    envvar="AISOC_TENANT_ID",
+    default=_DEFAULT_TENANT_ID,
+    show_default=True,
+    help="Tenant UUID sent in the X-Tenant-ID header.",
+)
+@click.option(
+    "--connector-id",
+    default=_DEFAULT_CONNECTOR_ID,
+    show_default=True,
+    help="connector_id field in the ingest envelope.",
+)
+@click.option(
+    "--connector-type",
+    default=_DEFAULT_CONNECTOR_TYPE,
+    show_default=True,
+    help="connector_type field — chooses the normalizer profile (e.g. okta_system_log).",
+)
+@click.option(
+    "--source-format",
+    default=_DEFAULT_SOURCE_FORMAT,
+    show_default=True,
+    help="source_format hint for the normalizer.",
+)
+@click.option(
+    "--timeout",
+    type=float,
+    default=30.0,
+    show_default=True,
+    help="HTTP timeout in seconds.",
+)
+def submit(
+    file: Path,
+    ingest_url: str,
+    tenant_id: str,
+    connector_id: str,
+    connector_type: str,
+    source_format: str,
+    timeout: float,
+) -> None:
+    """Submit a JSON alert/event payload to the local ingest service.
+
+    Reads ``FILE``, normalizes it into the ingest batch envelope, and POSTs to
+    ``{ingest_url}/v1/ingest/batch`` with the tenant header. Used by the
+    quickstart video script to drop a lateral-movement alert into the stack
+    in one command.
+    """
+    try:
+        raw = file.read_text(encoding="utf-8")
+    except OSError as exc:  # pragma: no cover - click handles `exists=True`
+        raise click.ClickException(f"Could not read {file}: {exc}") from exc
+
+    # Strip a leading BOM, which `json.loads` otherwise refuses.
+    if raw.startswith("\ufeff"):
+        raw = raw.lstrip("\ufeff")
+
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise click.ClickException(f"{file} is not valid JSON: {exc}") from exc
+
+    events, overrides = _coerce_events(payload)
+    connector_id = overrides.get("connector_id", connector_id)
+    connector_type = overrides.get("connector_type", connector_type)
+    source_format = overrides.get("source_format", source_format)
+
+    url = f"{ingest_url.rstrip('/')}/v1/ingest/batch"
+    body = {
+        "connector_id": connector_id,
+        "connector_type": connector_type,
+        "source_format": source_format,
+        "events": events,
+    }
+
+    console.print(
+        Panel(
+            f"[bold]file:[/bold] {file}\n"
+            f"[bold]url:[/bold] {url}\n"
+            f"[bold]tenant:[/bold] {tenant_id}\n"
+            f"[bold]connector_id:[/bold] {connector_id}\n"
+            f"[bold]connector_type:[/bold] {connector_type}\n"
+            f"[bold]source_format:[/bold] {source_format}\n"
+            f"[bold]events:[/bold] {len(events)}",
+            title="[bold green]aisoc submit[/bold green]",
+        )
+    )
+
+    headers = {
+        "Content-Type": "application/json",
+        "X-Tenant-ID": tenant_id,
+    }
+
+    try:
+        with httpx.Client(timeout=timeout) as client:
+            resp = client.post(url, headers=headers, json=body)
+    except httpx.HTTPError as exc:
+        console.print(
+            f"[red]Ingest service unreachable at {url}:[/red] {exc}\n"
+            "Is the dev stack running? Try [bold]aisoc serve[/bold] first."
+        )
+        sys.exit(1)
+
+    if resp.status_code >= 400:
+        console.print(
+            f"[red]Ingest service returned {resp.status_code}:[/red] {resp.text[:500]}"
+        )
+        sys.exit(1)
+
+    try:
+        data = resp.json()
+    except ValueError:
+        console.print(
+            f"[red]Ingest service returned non-JSON ({resp.status_code}):[/red] "
+            f"{resp.text[:200]}"
+        )
+        sys.exit(1)
+
+    accepted = data.get("accepted", 0)
+    rejected = data.get("rejected", 0)
+    request_id = data.get("request_id", "-")
+    errors = data.get("errors") or []
+
+    console.print(
+        Panel(
+            f"[bold]status:[/bold] {resp.status_code}\n"
+            f"[bold]accepted:[/bold] {accepted}\n"
+            f"[bold]rejected:[/bold] {rejected}\n"
+            f"[bold]request_id:[/bold] {request_id}",
+            title="[bold green]ingest response[/bold green]",
+        )
+    )
+
+    if errors:
+        console.print("[yellow]errors:[/yellow]")
+        for err in errors:
+            console.print(f"  • {err}")
+
+    if rejected and not accepted:
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/packages/aisoc-cli/tests/test_submit_command.py
+++ b/packages/aisoc-cli/tests/test_submit_command.py
@@ -1,0 +1,347 @@
+"""CLI surface tests for ``aisoc submit``.
+
+These tests pin the contract the founder-flow quickstart relies on:
+
+* ``aisoc submit <file>`` is registered and discoverable via ``--help``.
+* The CLI POSTs to ``{ingest_url}/v1/ingest/batch`` with an ``X-Tenant-ID``
+  header and the canonical ingest envelope shape (connector_id,
+  connector_type, source_format, events).
+* Fixture-level overrides (a file with ``connector_id`` / ``connector_type``
+  / ``source_format`` keys) win over the matching CLI flags.
+* The CLI surfaces accepted / rejected counts on success, and exits non-zero
+  on transport errors, 4xx responses, or non-JSON responses.
+
+We use ``httpx.MockTransport`` to intercept the HTTP call without standing
+up a real ingest service. If these tests break, the quickstart video will
+desync from the CLI.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+from click.testing import CliRunner
+
+from aisoc_cli import main as cli_main
+from aisoc_cli.main import cli
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+def _write_fixture(tmp_path: Path, payload: Any, name: str = "alert.json") -> Path:
+    path = tmp_path / name
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+class _CapturingTransport(httpx.MockTransport):
+    """Mock transport that records each request and returns a canned response."""
+
+    def __init__(self, response_factory):
+        self.requests: list[httpx.Request] = []
+        super().__init__(self._handler)
+        self._response_factory = response_factory
+
+    def _handler(self, request: httpx.Request) -> httpx.Response:
+        self.requests.append(request)
+        return self._response_factory(request)
+
+
+def _install_transport(
+    monkeypatch: pytest.MonkeyPatch,
+    response_factory,
+) -> _CapturingTransport:
+    """Patch ``httpx.Client`` so the CLI uses the mock transport."""
+    transport = _CapturingTransport(response_factory)
+    real_client = httpx.Client
+
+    def _client_factory(*args, **kwargs):
+        kwargs["transport"] = transport
+        return real_client(*args, **kwargs)
+
+    monkeypatch.setattr(cli_main.httpx, "Client", _client_factory)
+    return transport
+
+
+def test_submit_help_lists_command(runner: CliRunner) -> None:
+    result = runner.invoke(cli, ["--help"])
+    assert result.exit_code == 0, result.output
+    assert "submit" in result.output
+
+
+def test_submit_help_shows_options(runner: CliRunner) -> None:
+    result = runner.invoke(cli, ["submit", "--help"])
+    assert result.exit_code == 0, result.output
+    for flag in ("--ingest-url", "--tenant-id", "--connector-id", "--connector-type", "--source-format"):
+        assert flag in result.output
+
+
+def test_submit_posts_envelope_with_tenant_header(
+    runner: CliRunner,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fixture_path = _write_fixture(
+        tmp_path,
+        {
+            "events": [
+                {"uuid": "abc", "eventType": "user.session.start"},
+                {"uuid": "def", "eventType": "user.session.start"},
+            ]
+        },
+    )
+
+    def respond(_: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={"accepted": 2, "rejected": 0, "request_id": "req-001"},
+        )
+
+    transport = _install_transport(monkeypatch, respond)
+
+    result = runner.invoke(
+        cli,
+        ["submit", str(fixture_path), "--ingest-url", "http://localhost:8081"],
+    )
+    assert result.exit_code == 0, result.output
+    assert len(transport.requests) == 1
+
+    req = transport.requests[0]
+    assert req.method == "POST"
+    assert str(req.url) == "http://localhost:8081/v1/ingest/batch"
+    assert req.headers["X-Tenant-ID"] == "00000000-0000-0000-0000-000000000001"
+    assert req.headers["Content-Type"].startswith("application/json")
+
+    body = json.loads(req.content.decode("utf-8"))
+    assert body["connector_id"] == "aisoc-cli-submit"
+    assert body["connector_type"] == "okta_system_log"
+    assert body["source_format"] == "json"
+    assert len(body["events"]) == 2
+
+    assert "accepted: 2" in result.output
+    assert "request_id: req-001" in result.output
+
+
+def test_submit_accepts_bare_list_payload(
+    runner: CliRunner,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fixture_path = _write_fixture(tmp_path, [{"uuid": "1"}, {"uuid": "2"}])
+
+    transport = _install_transport(
+        monkeypatch,
+        lambda _: httpx.Response(200, json={"accepted": 2, "rejected": 0}),
+    )
+
+    result = runner.invoke(cli, ["submit", str(fixture_path)])
+    assert result.exit_code == 0, result.output
+    body = json.loads(transport.requests[0].content.decode("utf-8"))
+    assert len(body["events"]) == 2
+
+
+def test_submit_wraps_single_object_payload(
+    runner: CliRunner,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fixture_path = _write_fixture(tmp_path, {"uuid": "only"})
+
+    transport = _install_transport(
+        monkeypatch,
+        lambda _: httpx.Response(200, json={"accepted": 1, "rejected": 0}),
+    )
+
+    result = runner.invoke(cli, ["submit", str(fixture_path)])
+    assert result.exit_code == 0, result.output
+    body = json.loads(transport.requests[0].content.decode("utf-8"))
+    assert body["events"] == [{"uuid": "only"}]
+
+
+def test_submit_fixture_overrides_beat_cli_flags(
+    runner: CliRunner,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fixture_path = _write_fixture(
+        tmp_path,
+        {
+            "connector_id": "fixture-conn",
+            "connector_type": "splunk_enterprise",
+            "source_format": "raw_json",
+            "events": [{"uuid": "x"}],
+        },
+    )
+
+    transport = _install_transport(
+        monkeypatch,
+        lambda _: httpx.Response(200, json={"accepted": 1, "rejected": 0}),
+    )
+
+    result = runner.invoke(
+        cli,
+        [
+            "submit",
+            str(fixture_path),
+            "--connector-id",
+            "cli-conn",
+            "--connector-type",
+            "okta_system_log",
+            "--source-format",
+            "json",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    body = json.loads(transport.requests[0].content.decode("utf-8"))
+    assert body["connector_id"] == "fixture-conn"
+    assert body["connector_type"] == "splunk_enterprise"
+    assert body["source_format"] == "raw_json"
+
+
+def test_submit_uses_cli_flags_when_fixture_has_no_overrides(
+    runner: CliRunner,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fixture_path = _write_fixture(tmp_path, {"events": [{"uuid": "x"}]})
+
+    transport = _install_transport(
+        monkeypatch,
+        lambda _: httpx.Response(200, json={"accepted": 1, "rejected": 0}),
+    )
+
+    result = runner.invoke(
+        cli,
+        [
+            "submit",
+            str(fixture_path),
+            "--tenant-id",
+            "deadbeef-0000-4000-8000-000000000000",
+            "--connector-id",
+            "demo-cli",
+            "--connector-type",
+            "okta_system_log",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    req = transport.requests[0]
+    assert req.headers["X-Tenant-ID"] == "deadbeef-0000-4000-8000-000000000000"
+    body = json.loads(req.content.decode("utf-8"))
+    assert body["connector_id"] == "demo-cli"
+
+
+def test_submit_env_overrides_default_url_and_tenant(
+    runner: CliRunner,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fixture_path = _write_fixture(tmp_path, {"events": [{"uuid": "x"}]})
+    monkeypatch.setenv("AISOC_INGEST_URL", "http://ingest-worker:8080")
+    monkeypatch.setenv("AISOC_TENANT_ID", "11111111-1111-4111-8111-111111111111")
+
+    transport = _install_transport(
+        monkeypatch,
+        lambda _: httpx.Response(200, json={"accepted": 1, "rejected": 0}),
+    )
+
+    result = runner.invoke(cli, ["submit", str(fixture_path)])
+    assert result.exit_code == 0, result.output
+    req = transport.requests[0]
+    assert str(req.url) == "http://ingest-worker:8080/v1/ingest/batch"
+    assert req.headers["X-Tenant-ID"] == "11111111-1111-4111-8111-111111111111"
+
+
+def test_submit_returns_nonzero_on_4xx(
+    runner: CliRunner,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fixture_path = _write_fixture(tmp_path, {"events": [{"uuid": "x"}]})
+    _install_transport(
+        monkeypatch,
+        lambda _: httpx.Response(400, text="missing X-Tenant-ID"),
+    )
+
+    result = runner.invoke(cli, ["submit", str(fixture_path)])
+    assert result.exit_code == 1, result.output
+    assert "Ingest service returned 400" in result.output
+
+
+def test_submit_returns_nonzero_on_transport_error(
+    runner: CliRunner,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fixture_path = _write_fixture(tmp_path, {"events": [{"uuid": "x"}]})
+
+    def boom(_: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("connection refused")
+
+    _install_transport(monkeypatch, boom)
+
+    result = runner.invoke(cli, ["submit", str(fixture_path)])
+    assert result.exit_code == 1, result.output
+    assert "Ingest service unreachable" in result.output
+    assert "aisoc serve" in result.output
+
+
+def test_submit_rejects_invalid_json(
+    runner: CliRunner,
+    tmp_path: Path,
+) -> None:
+    bad = tmp_path / "broken.json"
+    bad.write_text("{ not json", encoding="utf-8")
+
+    result = runner.invoke(cli, ["submit", str(bad)])
+    assert result.exit_code != 0, result.output
+    assert "not valid JSON" in result.output
+
+
+def test_submit_rejects_empty_event_list(
+    runner: CliRunner,
+    tmp_path: Path,
+) -> None:
+    fixture_path = _write_fixture(tmp_path, {"events": []})
+
+    result = runner.invoke(cli, ["submit", str(fixture_path)])
+    assert result.exit_code != 0, result.output
+    assert "empty" in result.output.lower()
+
+
+def test_submit_rejects_non_object_event(
+    runner: CliRunner,
+    tmp_path: Path,
+) -> None:
+    fixture_path = _write_fixture(tmp_path, {"events": ["just-a-string"]})
+
+    result = runner.invoke(cli, ["submit", str(fixture_path)])
+    assert result.exit_code != 0, result.output
+    assert "not a JSON object" in result.output
+
+
+def test_submit_real_lateral_movement_fixture(
+    runner: CliRunner,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Smoke-test the actual repo fixture so the demo path stays wired up."""
+    repo_root = Path(__file__).resolve().parents[3]
+    fixture_path = repo_root / "examples" / "alerts" / "lateral-movement.json"
+    if not fixture_path.exists():
+        pytest.skip("lateral-movement fixture is created in this PR; run from repo root")
+
+    transport = _install_transport(
+        monkeypatch,
+        lambda _: httpx.Response(200, json={"accepted": 2, "rejected": 0, "request_id": "req-9"}),
+    )
+
+    result = runner.invoke(cli, ["submit", str(fixture_path)])
+    assert result.exit_code == 0, result.output
+    body = json.loads(transport.requests[0].content.decode("utf-8"))
+    assert len(body["events"]) == 2
+    assert body["events"][0]["actor"]["alternateId"] == "alice@example.com"


### PR DESCRIPTION
## Why

PR6 of the founder-flow series. PR1–PR5 fixed the codebase so the screen-recording video runs verbatim; PR6 makes the **quickstart docs** match what the recording shows, so anyone hitting the docs cold gets the same on-rails experience without watching the video.

## What changed

- `apps/docs/docs/quickstart.md` now describes **four** paths instead of three. New **Path C — founder-style CLI** documents the recorded demo flow end to end:
  - clone + `pip install -e packages/aisoc-cli`
  - `aisoc serve` (wraps `docker compose -f docker-compose.dev.yml up -d`)
  - `aisoc db upgrade` (idempotent migrations against the dev stack)
  - `aisoc submit examples/alerts/lateral-movement.json` (the canonical Okta impossible-travel fixture introduced in PR5)
  - watch `/alerts` populate while `fusion` + `agents` correlate the two events
  - optional `aisoc mcp serve --transport stdio` + `aisoc mcp install --host cursor|claude|continue` for IDE wiring
- Adds a single-screen **cheat sheet** at the bottom of Path C with every founder-flow command, so the page works as a live reference during the recording.

## What did **not** change

- No code touched. Path A (`pnpm aisoc:demo`) and Path B (raw `docker compose`) are unchanged.
- Existing console tour and "Next steps" sections are unchanged.

## Dependencies

- Depends on the commands shipped in **PR4** (#110, merged) — `aisoc serve`, `aisoc db upgrade`, `aisoc mcp serve`, `aisoc mcp install`.
- Depends on the command + fixture shipped in **PR5** (#111) — `aisoc submit` and `examples/alerts/lateral-movement.json`. Once PR5 merges, this PR's diff cleans up to docs-only on top of main.

## Verification

- Pure markdown edit. Existing Docusaurus build pipeline already covers `apps/docs/**`.
- Commands referenced are all tested in PR4 (`tests/test_ops_commands.py`, 12 cases) and PR5 (`tests/test_submit_command.py`, 14 cases). Full `aisoc-cli` suite (37 tests) is green locally.

## Risk

Low — docs-only, additive section, no edits to existing paths.

Made with [Cursor](https://cursor.com)