### PR TITLE
docs: refresh documentation for v7.3.0/v7.3.1 direct-write submit flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ An open-source, self-hostable AI SOC. The agent's prompts, tool calls, and ratio
 [![License: MIT](https://img.shields.io/badge/License-MIT-22c55e.svg?style=flat-square)](https://opensource.org/licenses/MIT)
 [![Public eval harness: CI-gated](https://img.shields.io/badge/eval%20harness-CI--gated-2563eb?style=flat-square)](apps/docs/docs/benchmark.md)
 [![PRs welcome](https://img.shields.io/badge/PRs-welcome-8b5cf6?style=flat-square)](CONTRIBUTING.md)
-[![Version](https://img.shields.io/badge/version-7.1.0-f59e0b?style=flat-square)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-7.3.1-f59e0b?style=flat-square)](CHANGELOG.md)
 
 [Live demo](https://tryaisoc.com) · [How AiSOC compares](#how-aisoc-compares) · [Public eval harness](apps/docs/docs/benchmark.md) · [Deploy in 60 seconds](#deploy-in-60-seconds) · [Deployment options](#deployment-options) · [Architecture](#architecture) · [Docs](apps/docs/)
 
@@ -921,12 +921,14 @@ terraform apply
 
 ## Roadmap
 
-The public roadmap lives in [ROADMAP.md](ROADMAP.md). All releases through **v7.1.0** have shipped, including:
+The public roadmap lives in [ROADMAP.md](ROADMAP.md). All releases through **v7.3.1** have shipped, including:
 
 - **v6.0 / v6.1** — Investigation Ledger, Ambient Copilot, Responder PWA, public eval harness, MCP server, one-shot demo, autonomous triage agents, investigation chat, coverage advisor, shifts, EASM, MSSP dashboard, STIX/TAXII publishing, automated compliance evidence, AI-generated incident reports.
 - **v7.0** — v1.0 buyer-value plan (16 workstreams): SBOM/SLSA supply chain, threat-intel attribution, executive digest PDF, BYOK per-tenant LLM credentials, air-gap appliance, WCAG 2.2 AA accessibility, ChatOps, telemetry/analytics opt-in, one-click Render deploy.
 - **v7.0.1 — v7.0.3** — Endpoint telemetry wave: `osctrl` and `FleetDM` connectors, `aisoc-osquery-tls` FastAPI service, `aisoc-direct` agent connector, 16 native osquery detections (`det-endpoint-281..296`), live-query playbook step, osquery packs + FIM pipeline, 5 custom osquery virtual tables; plus 42 CodeQL alert resolutions and the `ClientOnly`/font-preload hydration fixes.
 - **v7.1.0** — Cloud Security Coverage Wave: documentation backfill for Wiz, AWS Security Hub, and Lacework; two new CNAPP connectors (Prisma Cloud, Orca); three native AWS connectors (GuardDuty, CloudTrail, VPC Flow Logs); dual-mode Kubernetes audit log connector (apiserver webhook + file_tail) with a new `k8s-audit` ingest template.
+- **v7.3.0** — Founder-flow series (PR1–PR7): `docker-compose.dev.yml` alias, `.env.example` cleanup with a pre-filled `AISOC_CREDENTIAL_KEY`, `scripts/run_evals.py --suite` CLI contract, `aisoc serve` / `aisoc db upgrade` / `aisoc mcp serve|install`, the `aisoc submit` CLI command + canonical `examples/alerts/lateral-movement.json` fixture, and the Path C founder-style CLI walkthrough in [`apps/docs/docs/quickstart.md`](apps/docs/docs/quickstart.md). The recorded "fresh-clone to first alert" demo now runs verbatim on `main`.
+- **v7.3.1** — Smoke-test hotfix: idempotent migrations (`005_compliance.sql`, `025_connectors_click_and_connect.sql`, new `042_alerts_schema_drift_fix.sql` adding eleven missing `alerts` columns), and a new `POST /api/v1/alerts/submit` endpoint that synthesises an `Alert` row directly from a batch of OCSF events. `aisoc submit` now targets the new endpoint, so the web console at `/alerts` lights up immediately on a fresh clone without Kafka / Fusion in the loop.
 
 Next (**v8.0** — see [ROADMAP.md](ROADMAP.md)):
 

--- a/apps/docs/docs/api/rest.md
+++ b/apps/docs/docs/api/rest.md
@@ -72,6 +72,7 @@ The full spec is also committed at [`docs/openapi.yaml`](https://github.com/been
 | Method | Path | Description |
 |--------|------|-------------|
 | `GET/POST` | `/alerts` | List / ingest alerts |
+| `POST` | `/alerts/submit` | **Founder-flow direct-write submit** — synthesises an `Alert` row directly from a batch of OCSF events, bypassing Kafka / `services/ingest` / `services/fusion`. Powers `aisoc submit` and the fresh-clone demo so the console at `/alerts` lights up immediately. See [`packages/aisoc-cli`](https://github.com/aisoc-community/aisoc/tree/main/packages/aisoc-cli) and [`examples/alerts/lateral-movement.json`](https://github.com/aisoc-community/aisoc/tree/main/examples/alerts/lateral-movement.json) for the canonical payload. |
 | `GET/PATCH/DELETE` | `/alerts/{id}` | Alert detail / update / delete |
 | `POST` | `/alerts/{id}/assign` | Assign to analyst |
 | `GET/POST` | `/rules` | Detection rule catalog |

--- a/apps/docs/docs/architecture.md
+++ b/apps/docs/docs/architecture.md
@@ -117,6 +117,34 @@ services/ingest  POST /v1/ingest/batch  X-Tenant-ID: <uuid>
    Kafka spine ──▶ Fusion · UEBA · Detections (existing pipeline)
 ```
 
+### Founder-flow direct-write submit (v7.3.1+)
+
+For the fresh-clone demo and any flow where Kafka / Fusion / `services/ingest`
+is not required for the first alert, `services/api` exposes a dedicated
+direct-write endpoint:
+
+```
+POST /api/v1/alerts/submit   (X-Tenant-ID: <uuid>)
+    │
+    │ payload: { "events": [<OCSF event>, ...], "rule_id": "demo.lateral-movement" }
+    ▼
+services/api
+    │ 1. parse OCSF events (no Kafka, no services/ingest)
+    │ 2. _synthesise_alert_from_events()  ── derives entities, MITRE tags, severity
+    │ 3. INSERT INTO alerts(...)          ── single row, idempotent
+    │ 4. return { id, status: "new" }
+    ▼
+PostgreSQL  ──▶  /alerts console (lights up immediately)
+```
+
+This is the path used by the `aisoc submit` CLI command and the
+[`examples/alerts/lateral-movement.json`](https://github.com/beenuar/AiSOC/tree/main/examples/alerts/lateral-movement.json)
+canonical payload. The classic Kafka-fed pipeline above is still the
+**production** path; the direct-write endpoint exists so a fresh clone of
+the repo, an `aisoc serve` process, and a single `aisoc submit` call are
+enough to see an alert on `/alerts` — no broker, no schedulers, no
+connectors required.
+
 The `services/api` service holds the **encrypt** authority for the vault
 and is the only writer to `connectors.auth_config_encrypted`.
 `services/connectors` ships a vendored read-path `decrypt_dict()` that

--- a/apps/docs/docs/connectors/lacework.md
+++ b/apps/docs/docs/connectors/lacework.md
@@ -94,7 +94,7 @@ to that subaccount.
 
 ## Live actions
 
-The Lacework connector is **read-only** in v7.1.0. Containment for cloud
+The Lacework connector is **read-only** as of v7.3.1. Containment for cloud
 findings flows through the [AWS Security Hub](/docs/connectors/aws-security-hub),
 [Cloudflare](/docs/connectors/cloudflare), or
 [GCP Cloud Audit](/docs/connectors/gcp-cloud-audit) connectors.

--- a/apps/docs/docs/connectors/orca.md
+++ b/apps/docs/docs/connectors/orca.md
@@ -105,7 +105,7 @@ If a module isn't licensed on the tenant, no alerts of that type appear
 
 ## Live actions
 
-The Orca connector is **read-only** in v7.1.0. Containment for cloud
+The Orca connector is **read-only** as of v7.3.1. Containment for cloud
 findings flows through the
 [AWS Security Hub](/docs/connectors/aws-security-hub),
 [AWS GuardDuty](/docs/connectors/aws-guardduty),

--- a/apps/docs/docs/connectors/prisma-cloud.md
+++ b/apps/docs/docs/connectors/prisma-cloud.md
@@ -56,7 +56,7 @@ Prisma Cloud only shows it once.
 2. **API URL** — paste the region-specific value from
    **System → API Endpoints** (e.g. `https://api.prismacloud.io`).
 3. **Access Key ID** and **Secret Key** — paste from step 1.
-4. **Compute API URL** — leave blank. v7.1.0 only consumes the unified
+4. **Compute API URL** — leave blank. AiSOC only consumes the unified
    `/alert` endpoint, which already includes runtime findings collapsed
    in from Compute (Twistlock).
 5. **Test connection** — AiSOC exchanges the access keys for a
@@ -114,7 +114,7 @@ If a module isn't licensed on the tenant, no alerts of that type appear
 
 ## Live actions
 
-The Prisma Cloud connector is **read-only** in v7.1.0. Containment for
+The Prisma Cloud connector is **read-only** as of v7.3.1. Containment for
 cloud findings flows through the
 [AWS Security Hub](/docs/connectors/aws-security-hub),
 [AWS GuardDuty](/docs/connectors/aws-guardduty),

--- a/apps/docs/docs/connectors/wiz.md
+++ b/apps/docs/docs/connectors/wiz.md
@@ -78,13 +78,13 @@ The original Wiz severity is preserved verbatim under
 
 ## Live actions
 
-The Wiz connector is **read-only** in v7.1.0 — it pulls findings but
+The Wiz connector is **read-only** as of v7.3.1 — it pulls findings but
 does not push back into Wiz. Containment for cloud findings flows through
 the [AWS Security Hub](/docs/connectors/aws-security-hub) and
 [Cloudflare](/docs/connectors/cloudflare) connectors which expose
 `BLOCK_IP` / `ALLOW_IP` capabilities. A future `RESOLVE_ISSUE` capability
 that calls back into the Wiz GraphQL `updateIssue` mutation is on the
-v7.2 roadmap.
+roadmap.
 
 ## Troubleshooting
 

--- a/apps/docs/docs/deployment/docker.md
+++ b/apps/docs/docs/deployment/docker.md
@@ -149,7 +149,11 @@ ghcr.io/beenuar/aisoc-enrichment:<version>
 ghcr.io/beenuar/aisoc-web:<version>
 ```
 
-Each image is signed with Cosign — verify with:
+### Image provenance
+
+Each image is signed with [Cosign](https://docs.sigstore.dev/cosign/overview/)
+using keyless OIDC signatures issued through GitHub Actions. Verify any
+release artifact before deploying it into a sensitive environment:
 
 ```bash
 cosign verify \
@@ -157,6 +161,10 @@ cosign verify \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com \
   ghcr.io/beenuar/aisoc-api:<version>
 ```
+
+The certificate identity is bound to this repository's workflow, so a
+successful verification proves the image was produced by the official
+release pipeline and has not been tampered with in transit.
 
 ## Health checks
 

--- a/apps/docs/docs/detections/hello-hunt.md
+++ b/apps/docs/docs/detections/hello-hunt.md
@@ -297,6 +297,15 @@ curl -s "http://localhost:8000/v1/alerts?rule_id=community-aisoc-hello-hunt-aws-
 
 You should see one alert come back with `severity: "high"` and the original CloudTrail event embedded under `raw`. Drop the rule ID into the [Explain Drawer](/docs/api/rest) and you'll get the full lineage: which selection block matched, which field values, and which playbook template the rule recommends.
 
+:::tip Two ingestion paths — pick the right one for what you're testing
+
+- **`POST /v1/ingest/batch`** (above) — sends the event through the full pipeline (`services/ingest` → Kafka → `services/fusion` → rule engine → alert). This is the path you want for testing **detection rules**, because the rule engine is in the loop. Use it for `hello-hunt`.
+- **`POST /api/v1/alerts/submit`** ([v7.3.1+](../api/rest)) — synthesises an `Alert` row directly from a batch of OCSF events, bypassing Kafka / `services/ingest` / `services/fusion` / the rule engine. This is the founder-flow path used by `aisoc submit` and the fresh-clone demo. Use it when you want a row in `/alerts` immediately and don't care whether a rule actually fired.
+
+If you `aisoc submit` the positive fixture above, you'll see an alert in `/alerts` — but its `rule_id` will be whatever the submit payload carries, **not** `community-aisoc-hello-hunt-aws-root-login`. The direct-write path doesn't consult the detection corpus.
+
+:::
+
 ## Graduating from `community/` to `native/`
 
 When you've run the rule against a few weeks of real telemetry and you want it promoted into the curated v1.0 set:

--- a/apps/docs/docs/intro.md
+++ b/apps/docs/docs/intro.md
@@ -84,7 +84,7 @@ See the full [Architecture](./architecture) page for the detailed service map an
 ### Get started
 
 - [One-click install](./installation) — zero-prerequisite bootstrap for Linux, macOS, and Windows
-- [Quick Start](./quickstart) — `pnpm aisoc:demo`, under 5 minutes to a live investigation
+- [Quick Start](./quickstart) — `pnpm aisoc:demo`, under 5 minutes to a live investigation. The **Path C — founder-style CLI** flow (`docker compose -f docker-compose.dev.yml up -d` → `aisoc db upgrade` → `aisoc serve` → `aisoc submit examples/alerts/lateral-movement.json`) goes from fresh clone to a live alert at `http://localhost:3000/alerts` in under 90 seconds, with no Kafka / Fusion required for the first alert.
 - [Architecture](./architecture) — service map and data flow
 - [Glossary](./glossary) — security and AiSOC-specific terminology in one place
 - [FAQ](./operations/faq) — common questions about scope, deployment, data, and licensing

--- a/apps/docs/docs/operations/troubleshooting.md
+++ b/apps/docs/docs/operations/troubleshooting.md
@@ -153,6 +153,26 @@ docker compose logs --tail=200 fusion | grep "fused_alert"
 
 If ingest received events but Kafka has none → check `KAFKA_BOOTSTRAP_SERVERS` matches between ingest and Kafka. If Kafka has them but fusion ignored them → most likely no detection rule fired (which is normal — most events are not alerts). Check the **Detections** page for active rule count.
 
+### `aisoc submit` succeeds but `/alerts` is still empty (v7.3.1+)
+
+The `aisoc submit` CLI (and the [`POST /api/v1/alerts/submit`](../api/rest) endpoint behind it) writes a single `Alert` row directly to Postgres — it intentionally bypasses Kafka / `services/ingest` / `services/fusion`, so this path has a different failure surface than the connector pipeline above.
+
+In order of how often this is the cause:
+
+1. **Migrations weren't applied on a fresh clone.** The `alerts` table needs the v7.3.1 schema (eleven columns added by `042_alerts_schema_drift_fix.sql`). Run `aisoc db upgrade` — it's idempotent, so re-running on an already-migrated database is safe. If you see `column "..." of relation "alerts" does not exist` in `docker compose logs api`, this is the cause.
+2. **`AISOC_CREDENTIAL_KEY` mismatch.** The submit endpoint writes through the same vault decrypt path as the rest of the API. If the API service was started with a different key than the one in `.env`, the row inserts but downstream lookups (e.g. tenant resolution) fail silently. Stop the stack, set the key in `.env`, restart.
+3. **Wrong tenant filter in the UI.** The web console scopes `/alerts` to the currently selected tenant. `aisoc submit` defaults to the dev tenant. If you've switched tenants in the UI, you won't see the row. Switch back to the dev tenant or pass `--tenant` to `aisoc submit`.
+4. **API is on a port other than 8000.** `aisoc submit` reads `AISOC_API_URL` (default `http://localhost:8000`). If you remapped the port in `docker-compose.dev.yml`, set the env var.
+
+Confirm the row really landed:
+
+```bash
+docker compose exec postgres psql -U aisoc -d aisoc -c \
+  "select id, rule_id, severity, status, created_at from alerts order by created_at desc limit 5;"
+```
+
+If the row is there but the UI still shows empty, it's a tenant-filter issue (cause #3), not a submit issue.
+
 ---
 
 ## Agents (the AI investigator)

--- a/apps/docs/docs/operations/upgrades.md
+++ b/apps/docs/docs/operations/upgrades.md
@@ -64,14 +64,16 @@ The supported upgrade path is "stop, pull, migrate, start". Rolling upgrades acr
 
 cd /opt/aisoc                 # your install path
 git fetch --tags
-git checkout v6.1.0           # the target tag
+git checkout v7.3.1           # the target tag
 
 # 3. Pull dependencies.
 pnpm install --frozen-lockfile
 (cd services/api && uv sync)
 
 # 4. Run database migrations.
-(cd services/api && uv run alembic upgrade head)
+#    From v7.3.1 onwards you can use the CLI directly:
+aisoc db upgrade
+#    (Equivalent to: cd services/api && uv run alembic upgrade head)
 
 # 5. Start the API service back up.
 docker compose -f docker-compose.dev.yml up -d api
@@ -79,6 +81,16 @@ docker compose -f docker-compose.dev.yml up -d api
 # 6. Verify health and remove the maintenance gate.
 curl -fsS http://localhost:8000/healthz
 ```
+
+:::tip v7.3.1 migration idempotency
+The v7.3.1 release made the close-to-7.x migrations (`005_compliance.sql`,
+`025_connectors_click_and_connect.sql`, and the new
+`042_alerts_schema_drift_fix.sql`) idempotent. If a previous upgrade left
+your `alerts` table partially migrated, just re-run `aisoc db upgrade` —
+the migration only adds columns that are missing instead of failing on
+already-present ones. See the [CHANGELOG](https://github.com/beenuar/AiSOC/blob/main/CHANGELOG.md#731)
+for the full column list.
+:::
 
 For Kubernetes deployments, the same flow applies: scale the API deployment to zero, run the migration as a `Job`, then scale back up. The Helm chart in [`infra/helm/`](https://github.com/beenuar/AiSOC/tree/main/infra/helm) exposes this as `helm upgrade --set runMigrations=true`.
 
@@ -98,7 +110,7 @@ If any of those fail, see [Troubleshooting](./troubleshooting) — the upgrade c
 Patch and minor releases are designed to roll back cleanly. The procedure mirrors the upgrade:
 
 ```bash
-git checkout v6.0.0           # the previous tag
+git checkout v7.3.0           # the previous tag
 pnpm install --frozen-lockfile
 (cd services/api && uv sync)
 (cd services/api && uv run alembic downgrade <previous_revision>)
@@ -126,4 +138,4 @@ If your environment requires a longer support window, raise it in [Discussions](
 
 ## Pre-1.0 history
 
-Versions `1.0.0` through `5.x` shipped during the original feature build-out and are documented in the [CHANGELOG](https://github.com/beenuar/AiSOC/blob/main/CHANGELOG.md). The `6.0.0` release in May 2026 was the first version we consider production-ready; new deployments should start from the latest `6.x`.
+Versions `1.0.0` through `5.x` shipped during the original feature build-out and are documented in the [CHANGELOG](https://github.com/beenuar/AiSOC/blob/main/CHANGELOG.md). The `6.0.0` release in May 2026 was the first version we consider production-ready; new deployments should start from the latest tagged release (currently `v7.3.1`).


### PR DESCRIPTION
## Summary

Brings all user-facing documentation in line with the v7.3.0 / v7.3.1 release, which introduced the founder-flow direct-write submit endpoint (`POST /api/v1/alerts/submit`) and the `aisoc submit` CLI. No code changes — pure docs refresh.

- Bump README version badge to v7.3.1 and add v7.3.0/v7.3.1 to the roadmap so first-time visitors see the current release.
- Document `POST /api/v1/alerts/submit` in the REST API reference, architecture overview, intro path-C, and the hello-hunt detection walkthrough so the Kafka-bypass demo path is discoverable.
- Refresh `operations/upgrades.md` to use the v7.3.1 reference flow (`aisoc db upgrade`, idempotent migrations) and add a dedicated troubleshooting entry for the new submit endpoint.
- Update Wiz / Prisma Cloud / Orca / Lacework connector docs to drop stale "read-only in v7.1.0" wording in favour of the current v7.3.1 baseline.
- Add an explicit `### Image provenance` anchor in `deployment/docker.md` so `installation.md`'s deep link resolves during the Docusaurus build.

## Verification

- `pnpm --filter docs build` — clean build, zero warnings, zero broken links.
- `git diff --stat` — 12 files changed, +94 / -14, docs-only.

## Test plan

- [ ] Docusaurus build is clean (no broken links, no broken anchors).
- [ ] `POST /api/v1/alerts/submit` is documented in the REST API reference.
- [ ] `aisoc submit` direct-write flow is discoverable from intro, architecture, and hello-hunt.
- [ ] README badge and roadmap reflect v7.3.1.

Made with [Cursor](https://cursor.com)