### PR TITLE
fix(ueba): pick up docker-compose env vars instead of falling back to defaults

### DIFF
--- a/services/ueba/alembic/env.py
+++ b/services/ueba/alembic/env.py
@@ -17,7 +17,7 @@ if config.config_file_name is not None:
 
 target_metadata = Base.metadata
 
-DATABASE_URL = os.environ.get(
+DATABASE_URL = os.environ.get("DATABASE_URL") or os.environ.get(
     "UEBA_DATABASE_URL",
     "postgresql+asyncpg://aisoc:aisoc@localhost:5432/aisoc",
 )

--- a/services/ueba/app/core/config.py
+++ b/services/ueba/app/core/config.py
@@ -1,31 +1,71 @@
+from pydantic import AliasChoices, Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
 class Settings(BaseSettings):
-    model_config = SettingsConfigDict(env_prefix="UEBA_", env_file=".env", extra="ignore")
+    model_config = SettingsConfigDict(
+        env_file=".env",
+        env_file_encoding="utf-8",
+        populate_by_name=True,
+        extra="ignore",
+    )
 
-    # Database
-    database_url: str = "postgresql+asyncpg://aisoc:aisoc@localhost:5432/aisoc"
+    database_url: str = Field(
+        default="postgresql+asyncpg://aisoc:aisoc@localhost:5432/aisoc",
+        validation_alias=AliasChoices("DATABASE_URL", "UEBA_DATABASE_URL"),
+    )
 
-    # Kafka
-    kafka_bootstrap_servers: str = "localhost:9092"
-    kafka_input_topic: str = "security.events"
-    kafka_output_topic: str = "ueba.anomalies"
-    kafka_consumer_group: str = "ueba-service"
+    kafka_bootstrap_servers: str = Field(
+        default="localhost:9092",
+        validation_alias=AliasChoices("KAFKA_BOOTSTRAP_SERVERS", "UEBA_KAFKA_BOOTSTRAP_SERVERS"),
+    )
+    kafka_input_topic: str = Field(
+        default="security.events",
+        validation_alias=AliasChoices("KAFKA_INPUT_TOPIC", "UEBA_KAFKA_INPUT_TOPIC"),
+    )
+    kafka_output_topic: str = Field(
+        default="ueba.anomalies",
+        validation_alias=AliasChoices("KAFKA_OUTPUT_TOPIC", "UEBA_KAFKA_OUTPUT_TOPIC"),
+    )
+    kafka_consumer_group: str = Field(
+        default="ueba-service",
+        validation_alias=AliasChoices("KAFKA_CONSUMER_GROUP", "UEBA_KAFKA_CONSUMER_GROUP"),
+    )
 
-    # UEBA tuning
-    baseline_window_days: int = 30  # days of history for baseline computation
-    anomaly_threshold: float = 3.0  # z-score threshold for anomaly flagging
-    peer_group_min_size: int = 3  # minimum peers for peer-group analysis
-    scoring_batch_size: int = 100  # events processed per scoring batch
+    baseline_window_days: int = Field(
+        default=30,
+        validation_alias=AliasChoices("BASELINE_WINDOW_DAYS", "UEBA_BASELINE_WINDOW_DAYS"),
+    )
+    anomaly_threshold: float = Field(
+        default=3.0,
+        validation_alias=AliasChoices("ANOMALY_THRESHOLD", "UEBA_ANOMALY_THRESHOLD"),
+    )
+    peer_group_min_size: int = Field(
+        default=3,
+        validation_alias=AliasChoices("PEER_GROUP_MIN_SIZE", "UEBA_PEER_GROUP_MIN_SIZE"),
+    )
+    scoring_batch_size: int = Field(
+        default=100,
+        validation_alias=AliasChoices("SCORING_BATCH_SIZE", "UEBA_SCORING_BATCH_SIZE"),
+    )
 
-    # OTel
-    otel_endpoint: str = "http://localhost:4317"
-    service_name: str = "aisoc-ueba"
+    otel_endpoint: str = Field(
+        default="http://localhost:4317",
+        validation_alias=AliasChoices("OTEL_ENDPOINT", "UEBA_OTEL_ENDPOINT"),
+    )
+    service_name: str = Field(
+        default="aisoc-ueba",
+        validation_alias=AliasChoices("SERVICE_NAME", "UEBA_SERVICE_NAME"),
+    )
 
-    # API
-    host: str = "0.0.0.0"
-    port: int = 8004
+    host: str = Field(
+        default="0.0.0.0",
+        validation_alias=AliasChoices("HOST", "UEBA_HOST"),
+    )
+    port: int = Field(
+        default=8004,
+        validation_alias=AliasChoices("PORT", "UEBA_PORT"),
+    )
 
 
 settings = Settings()

--- a/services/ueba/tests/test_config.py
+++ b/services/ueba/tests/test_config.py
@@ -1,0 +1,60 @@
+"""Verify UEBA Settings picks up env vars with and without the legacy UEBA_ prefix."""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    for key in list(os.environ):
+        if key.startswith("UEBA_") or key in ("DATABASE_URL", "KAFKA_BOOTSTRAP_SERVERS"):
+            monkeypatch.delenv(key, raising=False)
+
+
+class TestDatabaseUrl:
+    def test_unprefixed_env_var(self, monkeypatch):
+        monkeypatch.setenv("DATABASE_URL", "postgresql+asyncpg://prod:secret@db:5432/prod")
+        from app.core.config import Settings
+
+        s = Settings()
+        assert s.database_url == "postgresql+asyncpg://prod:secret@db:5432/prod"
+
+    def test_legacy_prefixed_env_var(self, monkeypatch):
+        monkeypatch.setenv("UEBA_DATABASE_URL", "postgresql+asyncpg://legacy:pw@db:5432/legacy")
+        from app.core.config import Settings
+
+        s = Settings()
+        assert s.database_url == "postgresql+asyncpg://legacy:pw@db:5432/legacy"
+
+    def test_unprefixed_takes_precedence(self, monkeypatch):
+        monkeypatch.setenv("DATABASE_URL", "postgresql+asyncpg://winner:pw@db:5432/win")
+        monkeypatch.setenv("UEBA_DATABASE_URL", "postgresql+asyncpg://loser:pw@db:5432/lose")
+        from app.core.config import Settings
+
+        s = Settings()
+        assert s.database_url == "postgresql+asyncpg://winner:pw@db:5432/win"
+
+    def test_falls_back_to_default(self):
+        from app.core.config import Settings
+
+        s = Settings()
+        assert "localhost" in s.database_url
+
+
+class TestKafkaBootstrapServers:
+    def test_unprefixed_env_var(self, monkeypatch):
+        monkeypatch.setenv("KAFKA_BOOTSTRAP_SERVERS", "kafka:29092")
+        from app.core.config import Settings
+
+        s = Settings()
+        assert s.kafka_bootstrap_servers == "kafka:29092"
+
+    def test_legacy_prefixed_env_var(self, monkeypatch):
+        monkeypatch.setenv("UEBA_KAFKA_BOOTSTRAP_SERVERS", "kafka-legacy:9092")
+        from app.core.config import Settings
+
+        s = Settings()
+        assert s.kafka_bootstrap_servers == "kafka-legacy:9092"


### PR DESCRIPTION
## Summary

- **Bug**: The UEBA service's `Settings` class uses `env_prefix="UEBA_"`, causing it to silently ignore `DATABASE_URL` and `KAFKA_BOOTSTRAP_SERVERS` set by `docker-compose.yml` (which uses unprefixed names). The service falls back to hardcoded defaults (`localhost:9092`, `localhost:5432`) that don't resolve inside the container network.
- **Fix**: Replace `env_prefix` with per-field `AliasChoices` so both unprefixed names (matching docker-compose) and legacy `UEBA_`-prefixed names work. Follows the same pattern already used by the fusion service.
- **Also**: Update `alembic/env.py` to accept `DATABASE_URL` alongside `UEBA_DATABASE_URL`, and add unit tests covering both name forms.

Fixes #134

## Changes

| File | What changed |
|------|-------------|
| `services/ueba/app/core/config.py` | Remove `env_prefix="UEBA_"`, add `AliasChoices` per field for backward compat |
| `services/ueba/alembic/env.py` | Accept `DATABASE_URL` with fallback to `UEBA_DATABASE_URL` |
| `services/ueba/tests/test_config.py` | 6 unit tests: unprefixed, legacy-prefixed, precedence, and default fallback |

## Test plan

- [x] Unit tests pass locally (`pytest tests/test_config.py -v` — 6/6 passed)
- [x] Docker rebuild + restart: `docker compose build ueba && docker compose up -d ueba`
- [x] Verified env vars inside container: `docker exec aisoc-ueba env | grep DATABASE_URL` shows the docker-compose value
- [x] UEBA Kafka consumer connects successfully to `kafka:29092` (confirmed via container logs — consumer joins group `ueba-service`)
- [x] Backward compat: `UEBA_DATABASE_URL` still works via `AliasChoices` second alternative