### PR TITLE
fix(security): resolve final 2 CodeQL alerts (#440, #441)

### DIFF
--- a/services/api/app/api/v1/endpoints/waitlist.py
+++ b/services/api/app/api/v1/endpoints/waitlist.py
@@ -200,22 +200,6 @@ class WaitlistPatchRequest(BaseModel):
 # ---------------------------------------------------------------------------
 
 
-def _log_safe(value: str | None) -> str | None:
-    """Strip CR/LF from a user-supplied string before it enters a log record.
-
-    The waitlist status fields are validated upstream (Pydantic
-    ``field_validator`` against ``ALLOWED_WAITLIST_STATUSES``) and cannot in
-    practice contain newlines, but static analysis (CodeQL
-    ``py/log-injection``) does not recognise the validator as a sanitiser.
-    This helper makes the cleansing explicit so the taint tracker treats the
-    value as safe, while remaining a no-op for any well-formed input.
-    """
-
-    if value is None:
-        return None
-    return value.replace("\r", "").replace("\n", " ")
-
-
 def _client_ip(request: Request) -> str:
     """Resolve the source IP, trusting the proxy chain in front of us.
 
@@ -436,12 +420,19 @@ async def patch_entry(
             detail="Could not update waitlist entry.",
         ) from exc
 
+    # CodeQL py/log-injection: sanitise inline so the taint tracker
+    # sees the .replace() chain directly at the call site. Both values
+    # are also Pydantic-validated against ``ALLOWED_WAITLIST_STATUSES``
+    # so they can only ever be short safe identifiers, but the inline
+    # sanitisation makes the property explicit for static analysis.
+    safe_previous = (previous or "").replace("\r", "").replace("\n", " ")[:32]
+    safe_next = (payload.status or "").replace("\r", "").replace("\n", " ")[:32]
     logger.info(
         "waitlist_status_transition",
         extra={
             "entry_id": str(entry_id),
-            "previous": _log_safe(previous),
-            "next": _log_safe(payload.status),
+            "previous": safe_previous,
+            "next": safe_next,
             "actor": str(user.user_id),
         },
     )

--- a/services/connectors/tests/connectors/test_confluence_audit.py
+++ b/services/connectors/tests/connectors/test_confluence_audit.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-import app.connectors.confluence_audit as confluence_audit_module
 import httpx
 import pytest
 import respx
@@ -78,7 +77,10 @@ def test_normalize_creation_date_ms_to_iso(fixture):
 
 @pytest.mark.asyncio
 @respx.mock
-async def test_fetch_alerts_uses_pagination(fixture):
+async def test_fetch_alerts_uses_pagination(
+    fixture: dict,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     calls = 0
 
     def handler(request: httpx.Request) -> httpx.Response:
@@ -94,15 +96,12 @@ async def test_fetch_alerts_uses_pagination(fixture):
     respx.get(f"{_SITE}/wiki/rest/api/audit").mock(side_effect=handler)
 
     connector = ConfluenceAuditConnector(_SITE, _EMAIL, _TOKEN)
-    # Lower the page size to match the fixture. We reuse the module-level
-    # ``confluence_audit_module`` alias rather than re-importing inline so
-    # CodeQL (``py/import-and-import-from``) sees a single import style.
-    monkey_orig = confluence_audit_module._PAGE_SIZE  # noqa: SLF001
-    try:
-        confluence_audit_module._PAGE_SIZE = 4  # type: ignore[assignment]
-        events = await connector.fetch_alerts(since_seconds=10**9)
-    finally:
-        confluence_audit_module._PAGE_SIZE = monkey_orig  # type: ignore[assignment]
+    # Lower the page size to match the fixture. ``monkeypatch`` rewrites the
+    # module attribute and restores it automatically at teardown, so we keep
+    # a single import style for the connector module (CodeQL
+    # ``py/import-and-import-from``).
+    monkeypatch.setattr("app.connectors.confluence_audit._PAGE_SIZE", 4)
+    events = await connector.fetch_alerts(since_seconds=10**9)
 
     # First page returned 4 items, second page returned []; pagination
     # terminated cleanly.


### PR DESCRIPTION
## Summary

Two CodeQL alerts persisted on `main` after PR #133 because the previous fixes were not recognised by static analysis. This PR addresses them with patterns CodeQL definitely accepts.

- **Alert #441 — `py/log-injection` in `services/api/app/api/v1/endpoints/waitlist.py`**: the `_log_safe` helper was not recognised as a sanitiser when its input came from a database column. Inlined `.replace(\"\\r\",\"\").replace(\"\\n\",\" \")` with a 32-char cap at the `logger.info` call site so the taint tracker sees the cleansing directly. Removed the now-unused helper.
- **Alert #440 — `py/import-and-import-from` in `services/connectors/tests/connectors/test_confluence_audit.py`**: dropped the `confluence_audit_module` alias and switched the `_PAGE_SIZE` override to `pytest.MonkeyPatch.setattr`, giving a single import style and automatic restoration at teardown.

Both waitlist values are still Pydantic-validated against `ALLOWED_WAITLIST_STATUSES`, so this is defence in depth, not a behaviour change.

## Test plan
- [x] `python3 -m py_compile` on both files
- [x] `ruff format` + `ruff check` clean
- [ ] CI green
- [ ] CodeQL scan on `main` shows 0 open alerts after merge

Made with [Cursor](https://cursor.com)