### PR TITLE
fix(security): resolve CodeQL alert #442 (waitlist log injection)

### DIFF
--- a/services/api/app/api/v1/endpoints/waitlist.py
+++ b/services/api/app/api/v1/endpoints/waitlist.py
@@ -420,20 +420,29 @@ async def patch_entry(
             detail="Could not update waitlist entry.",
         ) from exc
 
-    # CodeQL py/log-injection: sanitise inline so the taint tracker
-    # sees the .replace() chain directly at the call site. Both values
-    # are also Pydantic-validated against ``ALLOWED_WAITLIST_STATUSES``
-    # so they can only ever be short safe identifiers, but the inline
-    # sanitisation makes the property explicit for static analysis.
+    # CodeQL py/log-injection: sanitise every value inline so the taint
+    # tracker sees the .replace() chain directly at the call site.
+    #
+    # - ``previous`` / ``payload.status`` are Pydantic-validated against
+    #   ``ALLOWED_WAITLIST_STATUSES`` (short identifiers, no CR/LF), and
+    # - ``entry_id`` / ``user.user_id`` are typed as ``uuid.UUID`` so the
+    #   string form is always ``[0-9a-f-]{36}``,
+    #
+    # but CodeQL's taint tracker treats path params and DB-derived
+    # strings as user-controlled regardless. Making the cleansing
+    # explicit at the call site silences the alert without weakening
+    # any existing guarantee.
     safe_previous = (previous or "").replace("\r", "").replace("\n", " ")[:32]
     safe_next = (payload.status or "").replace("\r", "").replace("\n", " ")[:32]
+    safe_entry_id = str(entry_id).replace("\r", "").replace("\n", " ")[:36]
+    safe_actor = str(user.user_id).replace("\r", "").replace("\n", " ")[:36]
     logger.info(
         "waitlist_status_transition",
         extra={
-            "entry_id": str(entry_id),
+            "entry_id": safe_entry_id,
             "previous": safe_previous,
             "next": safe_next,
-            "actor": str(user.user_id),
+            "actor": safe_actor,
         },
     )
     return _to_wire(row)


### PR DESCRIPTION
## Summary

Resolves the last open CodeQL alert: [#442 `py/log-injection`](https://github.com/beenuar/AiSOC/security/code-scanning/442) in `services/api/app/api/v1/endpoints/waitlist.py`.

PR #136 already inlined `.replace()` sanitisation for `previous` / `payload.status` (the values flagged by alerts #413 / #441), but the next CodeQL scan surfaced a new sub-alert against the *same* `logger.info` call — this time tainting on `entry_id` (path param) and `user.user_id` (auth context), which also flow into the log `extra` dict.

Both values are typed as `uuid.UUID`, so their string form is always `[0-9a-f-]{36}` and cannot contain CR/LF. But CodeQL's taint tracker treats path params and auth-context values as user-controlled regardless of upstream validation, so the alert re-fired.

## Fix

Apply the same inline sanitisation pattern that already covered the status fields:

```python
safe_entry_id = str(entry_id).replace("\r", "").replace("\n", " ")[:36]
safe_actor    = str(user.user_id).replace("\r", "").replace("\n", " ")[:36]
```

and log `safe_entry_id` / `safe_actor` in place of `str(entry_id)` / `str(user.user_id)`. No behaviour change — these were already canonical UUID strings — but now the sanitiser is explicit at the call site, which is what CodeQL's static analyser needs.

## Verification

- `python3 -m py_compile services/api/app/api/v1/endpoints/waitlist.py` ✅
- `ruff format` ✅ (no changes)
- `ruff check` ✅

After merge, CodeQL re-runs on `main` and alert #442 should auto-close, bringing open alerts to **0**.

## Test plan

- [x] Local syntax + format + lint pass
- [ ] CI green on this PR (Python lint, tests, OpenAPI, etc.)
- [ ] Post-merge CodeQL scan closes #442
- [ ] No new alerts surface (verify open count == 0)

Made with [Cursor](https://cursor.com)