### PR TITLE
fix(web): drop gradient washes from landing cards, restore body-copy contrast

### DIFF
--- a/apps/web/src/components/landing/sections/DeployOptions.tsx
+++ b/apps/web/src/components/landing/sections/DeployOptions.tsx
@@ -8,7 +8,8 @@
  *
  *   1. Managed (waitlist) — host on app.aisoc.dev.
  *   2. Self-host (recommended) — Render / Docker / Fly.io / Helm /
- *      AWS Terraform. The middle card is highlighted via `ShineBorder`.
+ *      AWS Terraform. The middle card is highlighted via a thicker
+ *      emerald border + the existing emerald shadow-glow.
  *   3. Sovereign / air-gap — `AISOC_AIRGAPPED=true`, Ollama sidecar.
  *
  * Each card exposes the same four-line stat strip (Time to live / LLM /
@@ -20,7 +21,6 @@ import Link from 'next/link';
 import { motion, useReducedMotion } from 'framer-motion';
 import { ArrowRight, Cloud, Lock, Server } from 'lucide-react';
 import type { ComponentType, SVGProps } from 'react';
-import { ShineBorder } from '@/components/magicui/ShineBorder';
 import { cn } from '@/lib/utils';
 
 interface DeployOption {
@@ -95,10 +95,9 @@ function OptionCard({
       className={cn(
         'relative flex flex-col gap-4 rounded-2xl border border-velvet-border bg-velvet-surface-raised/70 p-6 backdrop-blur-sm',
         option.recommended &&
-          'motion-safe:shadow-glow-emerald-lg',
+          'border-2 border-velvet-emerald/60 motion-safe:shadow-glow-emerald-lg',
       )}
     >
-      {option.recommended && <ShineBorder duration={14} borderWidth={1} />}
       <div className="relative flex items-center justify-between gap-3">
         <span
           aria-hidden="true"

--- a/apps/web/src/components/landing/sections/PricingTeaser.tsx
+++ b/apps/web/src/components/landing/sections/PricingTeaser.tsx
@@ -5,16 +5,15 @@
  * section from §6.13 of the brief.
  *
  * Three-column tier teaser (mobile: stacked). "Team" is the middle
- * card and carries the recommended treatment — `ShineBorder` plus the
- * brighter "Contact us — waitlist" CTA. The page links out to the full
- * pricing page for the bottom of the funnel; this section is the
- * scan-and-skim teaser.
+ * card and carries the recommended treatment — a thicker emerald
+ * border plus the brighter "Contact us — waitlist" CTA. The page
+ * links out to the full pricing page for the bottom of the funnel;
+ * this section is the scan-and-skim teaser.
  */
 
 import Link from 'next/link';
 import { motion, useReducedMotion } from 'framer-motion';
 import { ArrowRight, Check } from 'lucide-react';
-import { ShineBorder } from '@/components/magicui/ShineBorder';
 import { cn } from '@/lib/utils';
 
 interface Tier {
@@ -95,10 +94,9 @@ function TierCard({
       className={cn(
         'relative flex flex-col gap-6 rounded-md border border-velvet-border bg-velvet-surface-raised p-6 backdrop-blur-sm sm:p-8',
         tier.recommended &&
-          'border-velvet-emerald/60 sm:p-8 motion-safe:shadow-glow-emerald-md',
+          'border-2 border-velvet-emerald/60 sm:p-8 motion-safe:shadow-glow-emerald-md',
       )}
     >
-      {tier.recommended && <ShineBorder duration={14} borderWidth={1} />}
       <div className="relative">
         <div className="flex items-center justify-between gap-2">
           <h3 className="font-velvet-display font-normal text-lg text-velvet-content-primary">{tier.name}</h3>


### PR DESCRIPTION
## Summary

The `Team / Waitlist` tier on `PricingTeaser` and the `Self-host` option on `DeployOptions` were rendering a diagonal emerald→sapphire wash across the entire card body, drowning the bullet copy. Root cause: `<ShineBorder>` (in `apps/web/src/components/magicui/ShineBorder.tsx`) paints a `linear-gradient(135deg, #064E3B, #34D399, #1E3A8A)` on an `absolute inset-0` span and tries to mask out the content-box with a `mask-composite:exclude` arbitrary-value Tailwind utility — Tailwind's space-as-underscore parsing of the comma-separated multi-value \`mask\` shorthand isn't emitting the second mask layer with the expected \`content-box\` \`mask-clip\`, so the mask never subtracts and the gradient renders edge-to-edge.

Fix: drop the broken \`<ShineBorder>\` from both recommended tiers and replace with a single low-key emphasis signal — \`border-2\` on top of the existing \`border-velvet-emerald/60\` border. Kept the \`MOST ASKED FOR\` / \`Recommended\` badge, kept the emerald shadow-glow, kept the emerald-cta button gradient (spec-allowed), kept section-level Hero/FinalCta background washes.

## Changes

| File | +/- |
| --- | --- |
| \`apps/web/src/components/landing/sections/PricingTeaser.tsx\` | +5 / -7 |
| \`apps/web/src/components/landing/sections/DeployOptions.tsx\` | +3 / -4 |

**Total:** +8 / -11 across 2 files.

Sibling components swept but intentionally left alone:
- \`OpenSourceMoment\` + \`DemoEmbed\` \`<BorderBeam>\` — a 1px traveling comet, not a body wash; the design intent.
- Icon-tile decorative gradient backings on \`Testimonials\`, \`Problem\`, \`Pillars\`, \`DeployOptions\` — 10×10/12×12, not card-body washes.
- \`bg-velvet-hero-grad\` / \`bg-velvet-cta-grad\` page backgrounds.
- All emerald-cta button gradients.

## Verification

| Check | Result |
| --- | --- |
| \`pnpm --filter @aisoc/web type-check\` | clean (0 errors) |
| \`pnpm --filter @aisoc/web lint\` | 0 errors / 0 new warnings (5 pre-existing console-side warnings unchanged) |
| DOM proof on rendered \`/\` HTML | zero \`ShineBorder\` occurrences (was 2); zero forbidden gradient sources inside any \`<li>\` under \`#pricing\` or \`#deploy\` |
| Recommended Team tier \`<li>\` classes | \`border-2 border-velvet-emerald/60 motion-safe:shadow-glow-emerald-md\` on solid \`bg-velvet-surface-raised\` |
| All 5 Team-tier bullets present | yes |

Headless Chromium screenshots came back blank (Next.js streaming + slow hydration in headless) — DOM proof was used instead, which is explicitly allowed by the task spec. Visual delta on the live site post-deploy will be obvious: no diagonal wash, calmer card.

## Test plan

- [ ] Pull \`fix/landing-card-gradients\`, run \`pnpm --filter @aisoc/web dev\`, visit \`http://localhost:3000/#pricing\` and \`/#deploy\`, confirm no gradient wash on recommended tier; bullet copy readable.
- [ ] After merge, confirm post-deploy on \`https://aisoc-demo-web.fly.dev/\` (auto-deploy via \`deploy-web.yml\` once \`FLY_API_TOKEN\` secret is set; manual \`flyctl deploy\` otherwise).

## Notes

- Disjoint from PR (TBD) on \`fix/beam-behind-agent-cards\` (AnimatedBeam z-index in \`SolutionAgents.tsx\`). No file overlap.
- The underlying \`ShineBorder\` mask-composite bug is real but left unfixed in this PR — there are no remaining callers after this change. If a future caller needs a real animated border, switch the broken \`mask\` arbitrary utility to a clean \`mask-image\` + \`mask-clip\` pair, or use \`<BorderBeam>\` instead.