### PR TITLE
fix(web): keep AnimatedBeam behind agent funnel cards (z-index/stacking-context)

### DIFF
--- a/apps/web/src/components/landing/sections/SolutionAgents.tsx
+++ b/apps/web/src/components/landing/sections/SolutionAgents.tsx
@@ -201,22 +201,28 @@ export function SolutionAgents() {
           </p>
         </div>
 
-        <div
-          ref={containerRef}
-          className="relative mt-12 grid gap-4 sm:gap-6 lg:mt-16 lg:grid-cols-4"
-        >
-          {AGENTS.map((agent, i) => (
-            <AgentCard
-              key={agent.id}
-              agent={agent}
-              index={i}
-              innerRef={cardRefs[i]}
-            />
-          ))}
+        <div ref={containerRef} className="relative mt-12 lg:mt-16">
+          {/* Cards live in their own z-10 wrapper; the AnimatedBeam SVG
+              siblings below sit at z-0 so the velvet-surface-raised cards
+              (which the framer-motion `transform` promotes to their own
+              stacking contexts, e.g. via `hover:-translate-y-1`) cleanly
+              occlude the beam. Without the explicit split, both cards and
+              beams resolved at z-auto and DOM order put the beams on top. */}
+          <div className="relative z-10 grid gap-4 sm:gap-6 lg:grid-cols-4">
+            {AGENTS.map((agent, i) => (
+              <AgentCard
+                key={agent.id}
+                agent={agent}
+                index={i}
+                innerRef={cardRefs[i]}
+              />
+            ))}
+          </div>
 
           {isHorizontal && !prefersReducedMotion && (
             <>
               <AnimatedBeam
+                className="z-0"
                 containerRef={containerRef}
                 fromRef={detectRef}
                 toRef={triageRef}
@@ -225,6 +231,7 @@ export function SolutionAgents() {
                 curvature={0}
               />
               <AnimatedBeam
+                className="z-0"
                 containerRef={containerRef}
                 fromRef={triageRef}
                 toRef={huntRef}
@@ -237,6 +244,7 @@ export function SolutionAgents() {
                 gradientStop="#34D399"
               />
               <AnimatedBeam
+                className="z-0"
                 containerRef={containerRef}
                 fromRef={huntRef}
                 toRef={respondRef}


### PR DESCRIPTION
## Summary

The four-agent flow beam in `SolutionAgents` was painting **on top** of the
Detect / Triage / Hunt / Respond cards instead of behind them, visually
overlaying the card titles and copy.

**Root cause.** Inside the `containerRef` div, the card grid and the three
`AnimatedBeam` SVGs were siblings without explicit z-indexes. Both groups
resolved to `z-auto`, so the CSS paint order fell through to DOM order — the
absolutely-positioned beam SVGs come last in the JSX, so they painted over
the framer-motion-transformed card stacking contexts.

**Fix.** Split the cards and beams into explicit z-layers inside the same
`relative` container:

- Cards now live in their own `relative z-10` grid wrapper.
- Each `AnimatedBeam` is pinned to `z-0` via the existing `className` prop.
- The outer `containerRef` div still spans **both** layers, so
  `AnimatedBeam.update()`'s `getBoundingClientRect` math against
  `containerRef` is unchanged and the curve geometry is preserved.
- Beam SVG already carries `pointer-events-none absolute inset-0` from
  `AnimatedBeam.tsx` itself — untouched.
- No `overflow-hidden` was introduced on any clipping ancestor.
- No layout, copy, gap, color, or animation-timing change.

Edit is scoped to `SolutionAgents.tsx`. `AnimatedBeam.tsx` was not modified.

## Diff stat

`git diff --stat main..HEAD`:

```
 .../components/landing/sections/SolutionAgents.tsx | 32 ++++++++++++++--------
 1 file changed, 20 insertions(+), 12 deletions(-)
```

## Verification

Per the task's strict constraints, verification was **static-only** — no dev
server, no headless browser, no screenshots:

- `pnpm --filter @aisoc/web type-check` — **clean** (`tsc --noEmit`, exit 0).
- `pnpm --filter @aisoc/web lint` — **no new errors**. The 5 warnings
  reported are all pre-existing (`CaseWorkspace.tsx`, `AddConnectorModal.tsx`,
  `PlaybooksView.tsx`, `SettingsView.tsx`, `lib/api.ts`) and unrelated to
  this change. The touched file produced zero lint output.
- Manual diff re-read confirms the stacking-context invariant: cards
  (`z-10`) > beams (`z-0`), beams remain `pointer-events-none`, no
  `overflow-hidden` clipping ancestor introduced.

> ⚠️ Per task brief: **no `pnpm dev` / Next dev server was run, and no
> browser / screenshot verification was performed.** Visual confirmation
> is deferred to the next reviewer with a running stack.