### PR TITLE
fix(api): import model_validator and rule_tuning so API boots

### DIFF
--- a/services/api/app/api/v1/router.py
+++ b/services/api/app/api/v1/router.py
@@ -61,6 +61,7 @@ from app.api.v1.endpoints import (
     rbac,
     remediation,
     reports,
+    rule_tuning,
     saved_hunts,
     saved_views,
     shifts,

--- a/services/api/app/core/config.py
+++ b/services/api/app/core/config.py
@@ -10,7 +10,7 @@ import warnings
 from functools import lru_cache
 from typing import Any, Final
 
-from pydantic import AliasChoices, Field, PostgresDsn, RedisDsn, field_validator
+from pydantic import AliasChoices, Field, PostgresDsn, RedisDsn, field_validator, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 # Default placeholders shipped in source. Anything matching these in a


### PR DESCRIPTION
## Summary
Two missing imports were crashing `aisoc-api` at boot on a fresh `docker compose -f docker-compose.demo.yml up -d`:

- `services/api/app/core/config.py:540` calls `@model_validator(mode="after")` inside `_reconcile_env_aliases`, but `model_validator` was never imported from `pydantic` — `NameError: name 'model_validator' is not defined`.
- `services/api/app/api/v1/router.py:107` wires `include_router(rule_tuning.router, ...)` for the v1.5 Rule Tuning workbench, but `rule_tuning` was missing from the alphabetised endpoint imports — `NameError: name 'rule_tuning' is not defined`.

Both fixes are single-line imports — no behaviour change.

## Why CI didn't catch this
Both errors only surface at app-startup time when the full v1 router is mounted; the existing API tests appear to exercise narrower paths that don't trip the imports.

## How it was found
During a clean end-to-end local bring-up of the slim demo profile. The api container repeatedly entered a crash loop with the two `NameError`s above; both stack traces were reproducible on a `docker compose -f docker-compose.demo.yml down -v && up -d` cycle. With these two fixes the demo profile boots cleanly: all 8 demo containers healthy, 43 cases (incl. `INC-RT-001`) and 25 alerts seeded, web UI live.

## Audit
- `core/config.py` — only `model_validator` was used-but-not-imported.
- `api/v1/router.py` — grepped every `include_router(X.router, ...)` against the import block; `rule_tuning` was the only orphan.

## Test plan
- [ ] `docker compose -f docker-compose.demo.yml down -v`
- [ ] `docker compose -f docker-compose.demo.yml up -d`
- [ ] `curl -fsS http://localhost:8000/health` returns 200
- [ ] `curl -fsS http://localhost:8000/api/v1/cases | jq '.[] | .id' | head` lists `INC-RT-001`
- [ ] `curl -fsS http://localhost:8000/api/v1/rule-tuning/...` (any rule-tuning endpoint) returns a non-500 (auth-gated 401/403 is fine — proves the router mounted)
- [ ] Existing api unit tests still pass

## Notes
Found alongside a small env/orchestration speedbump (host port 3000 collision with an unrelated sibling container); that's worked around with `AISOC_WEB_PORT=3010` and is **not** included in this PR — separate taste call about whether the orchestrator script should fall back automatically.