### PR TITLE
chore(security): resolve remaining round-2 CodeQL alerts

### DIFF
--- a/services/agents/app/context/bundle.py
+++ b/services/agents/app/context/bundle.py
@@ -237,10 +237,12 @@ class ThreatIntelMatch(BaseModel):
 
 # Allowed top-level keys in ``summary_for_llm`` — kept here (not in
 # ``app/llm/contract.py``) so the model is the source of truth and the
-# contract validator can import this whitelist.
-# Imported by tests (e.g. ``test_context_bundle.py``) and by contract
-# validators; CodeQL flags it as module-local-unused, suppress that.
-_LLM_SAFE_KEYS = (  # lgtm[py/unused-global-variable]
+# contract validator can import this whitelist. Public (no leading
+# underscore) because it is imported by tests and by external contract
+# validators; the previous private-with-suppression form tripped CodeQL
+# ``py/unused-global-variable`` because the inline suppression marker
+# was not honoured by the analyzer.
+LLM_SAFE_KEYS = (
     "incident_id",
     "alert_summary",
     "entity_count",
@@ -355,7 +357,7 @@ class ContextBundle(BaseModel):
     def summary_for_llm(self) -> dict[str, Any]:
         """Pre-digested, contract-safe summary for LLM prompts.
 
-        Every key returned here is on ``_LLM_SAFE_KEYS`` and contains either
+        Every key returned here is on ``LLM_SAFE_KEYS`` and contains either
         a scalar, a small list of scalars, or a list of short string summaries
         — never raw OCSF / log payloads. ``LLMInputContract`` (T2.3) treats
         the output of this method as the canonical safe shape.

--- a/services/agents/tests/test_context_bundle.py
+++ b/services/agents/tests/test_context_bundle.py
@@ -44,7 +44,7 @@ from app.context import (  # noqa: E402
     EntityRef,
     extract_entities,
 )
-from app.context.bundle import _LLM_SAFE_KEYS  # noqa: E402
+from app.context.bundle import LLM_SAFE_KEYS  # noqa: E402
 from app.models.state import InvestigationState  # noqa: E402
 
 _DATASET_PATH = _TESTS_DIR / "eval_data" / "synthetic_incidents.json"
@@ -202,7 +202,7 @@ class ContextBundleSummaryTests(unittest.TestCase):
         )
         summary = bundle.summary_for_llm()
         for key in summary:
-            self.assertIn(key, _LLM_SAFE_KEYS, f"unexpected key in summary_for_llm: {key}")
+            self.assertIn(key, LLM_SAFE_KEYS, f"unexpected key in summary_for_llm: {key}")
 
     def test_prompt_context_lines_empty_when_bundle_empty(self) -> None:
         bundle = ContextBundle(incident_id=uuid4())

--- a/services/api/app/api/v1/endpoints/waitlist.py
+++ b/services/api/app/api/v1/endpoints/waitlist.py
@@ -61,6 +61,7 @@ from app.db.database import get_db
 from app.models.waitlist import (
     ALLOWED_WAITLIST_STATUSES,
     WAITLIST_STATUS_CONTACTED,
+    WAITLIST_STATUS_DECLINED,
     WAITLIST_STATUS_NEW,
     WAITLIST_STATUS_ONBOARDED,
     WaitlistEntry,
@@ -87,6 +88,23 @@ _MAX_FIELD_LEN_MEDIUM: int = 255
 _MAX_MOTIVATION_LEN: int = 4000
 _MAX_SOC_STACK_ENTRIES: int = 20
 _MAX_LIST_LIMIT: int = 500
+
+
+# Maps a user-supplied / DB-stored status value to the *hardcoded literal*
+# that is safe to put into a log record. Looking up the value (rather than
+# echoing the raw status through ``status if status in ALLOWED... else
+# "<invalid>"``) breaks CodeQL's taint flow because the value side of the
+# mapping is never derived from the input — it is a compile-time string
+# literal. This satisfies ``py/log-injection`` without losing the
+# operational signal. The keys mirror ``ALLOWED_WAITLIST_STATUSES``; any
+# value outside that allowlist falls back to ``"<invalid>"`` at the call
+# site.
+_STATUS_LOG_TOKENS: dict[str, str] = {
+    WAITLIST_STATUS_NEW: "new",
+    WAITLIST_STATUS_CONTACTED: "contacted",
+    WAITLIST_STATUS_ONBOARDED: "onboarded",
+    WAITLIST_STATUS_DECLINED: "declined",
+}
 
 # RFC 5322 is famously permissive; we use a forgiving "addr@domain.tld"
 # regex that catches obvious typos without rejecting legitimate edge
@@ -432,18 +450,17 @@ async def patch_entry(
 
     # Both ``previous`` (DB enum) and ``payload.status`` (Pydantic-validated
     # against ``ALLOWED_WAITLIST_STATUSES``) are constrained to a known
-    # allowlist before we ever reach this point. Re-resolve them through
-    # the allowlist so the values we put into the log record cannot
-    # possibly carry log-injection-friendly payloads (newlines, ANSI
-    # escapes, log-spoofed key=value pairs) even if upstream validation
-    # is ever weakened. Anything outside the allowlist becomes the literal
-    # string ``"<invalid>"`` instead of being echoed verbatim. This
-    # silences CodeQL ``py/log-injection`` cleanly without losing the
-    # operational signal.
-    safe_previous = previous if previous in ALLOWED_WAITLIST_STATUSES else "<invalid>"
-    safe_next = (
-        payload.status if payload.status in ALLOWED_WAITLIST_STATUSES else "<invalid>"
-    )
+    # allowlist before we ever reach this point. We still look the values
+    # up via ``_STATUS_LOG_TOKENS`` so what lands in the log record is a
+    # hardcoded string literal (never the raw input). Any value outside
+    # the allowlist becomes ``"<invalid>"``. This breaks CodeQL's taint
+    # flow for ``py/log-injection``: the conditional ``x if x in
+    # ALLOWED... else "<invalid>"`` form was not enough because CodeQL
+    # still saw the True branch as carrying the original tainted value
+    # through to the logger. The dict-lookup form returns a value that
+    # is provably independent of the input string.
+    safe_previous = _STATUS_LOG_TOKENS.get(previous, "<invalid>")
+    safe_next = _STATUS_LOG_TOKENS.get(payload.status, "<invalid>")
     logger.info(
         "waitlist_status_transition",
         extra={

--- a/services/api/app/services/effective_permissions/service.py
+++ b/services/api/app/services/effective_permissions/service.py
@@ -50,6 +50,21 @@ SUPPORTED_PROVIDERS: dict[str, type[Resolver]] = {
 }
 
 
+# Maps a user-supplied provider name to the *hardcoded literal* that is safe
+# to log. Looking up the value (rather than passing the raw ``provider``
+# argument through a conditional ``if ... else "<unsupported>"`` expression)
+# breaks CodeQL's taint flow because the value side of the mapping is never
+# derived from the input — it is a compile-time string literal. This satisfies
+# ``py/log-injection`` without losing the operational signal.
+_PROVIDER_LOG_TOKENS: dict[str, str] = {
+    "aws": "aws",
+    "azure": "azure",
+    "gcp": "gcp",
+    "okta": "okta",
+    "gws": "gws",
+}
+
+
 SnapshotLoader = Callable[[str], dict[str, Any]]
 
 
@@ -67,11 +82,14 @@ def _default_snapshot_loader(provider: str) -> dict[str, Any]:
     # / query parameters). Even though the calling resolver only dispatches
     # on values in ``SUPPORTED_PROVIDERS``, the loader stub is reachable
     # before that dispatch, so we constrain what we put into the log
-    # record. Anything outside the known allowlist is logged as the
-    # literal ``"<unsupported>"`` so an attacker cannot smuggle control
-    # characters or fake log lines through this code path. Resolves
-    # CodeQL ``py/log-injection`` without losing the operational signal.
-    safe_provider = provider if provider in SUPPORTED_PROVIDERS else "<unsupported>"
+    # record. We look up a hardcoded literal from ``_PROVIDER_LOG_TOKENS``
+    # so the value that lands in the log line is provably independent of
+    # the input string — anything outside the known allowlist is logged as
+    # the literal ``"<unsupported>"``. This stops an attacker from smuggling
+    # control characters or fake log lines through this code path and
+    # resolves CodeQL ``py/log-injection`` without losing the operational
+    # signal.
+    safe_provider = _PROVIDER_LOG_TOKENS.get(provider, "<unsupported>")
     logger.warning(
         "no production snapshot loader wired for provider=%s — returning {}",
         safe_provider,

--- a/services/api/tests/test_business_context.py
+++ b/services/api/tests/test_business_context.py
@@ -75,7 +75,6 @@ from app.services.business_context.models import (
     ALLOWED_OPS,
     ALLOWED_ROUTES,
     ALLOWED_SEVERITIES,
-    BusinessContextRule,
     RuleAction,
     RuleCondition,
 )


### PR DESCRIPTION
## Summary

Closes the 4 CodeQL alerts that remained open on `main` after #156 landed and CodeQL re-scanned the branch.

| # | Rule | File | Fix |
|---|------|------|-----|
| 1 | `py/unused-global-variable` | `services/agents/app/context/bundle.py` | Rename `_LLM_SAFE_KEYS` → `LLM_SAFE_KEYS` (it is imported by tests + contract validators; the inline `lgtm` suppression was not honoured by the analyzer). |
| 2 | `py/unused-import` | `services/api/tests/test_business_context.py` | Drop the truly-unused `BusinessContextRule` import; keep `RuleAction` / `RuleCondition` (still used). |
| 3 | `py/log-injection` | `services/api/app/services/effective_permissions/service.py` | Replace conditional `provider if provider in SUPPORTED_PROVIDERS else "<unsupported>"` with a `_PROVIDER_LOG_TOKENS` dict lookup. CodeQL's taint analyzer still saw the True branch as carrying the tainted input through to the logger; the dict-lookup form returns a value that is provably a compile-time string literal. |
| 4 | `py/log-injection` | `services/api/app/api/v1/endpoints/waitlist.py` | Same shape: introduce `_STATUS_LOG_TOKENS` mapping every `ALLOWED_WAITLIST_STATUSES` value to a hardcoded literal, log via `.get(value, "<invalid>")`. |

These are the alerts visible at https://github.com/beenuar/AiSOC/security/code-scanning after #156 was merged.

## Why the conditional sanitizer wasn't enough (alerts 3 & 4)

The prior pattern looked like:

```python
safe = value if value in ALLOWED else "<placeholder>"
logger.info(..., safe)
```

CodeQL's Python `py/log-injection` query treats the `True` branch as still flowing the original tainted string into the logger — the membership check doesn't act as a sanitizer in the analyzer's data-flow model. Switching to a dict lookup:

```python
_TOKENS = {\"aws\": \"aws\", \"azure\": \"azure\", ...}
safe = _TOKENS.get(value, \"<placeholder>\")
```

…makes the logged value provably independent of the input string (it's the **value** side of the mapping, a compile-time literal), which breaks the taint flow without losing operational signal in logs.

## Verification

- `python3 -m py_compile` passes on all 5 modified files.
- `ruff` reports the **same 4 pre-existing violations** that already exist on `origin/main` for these files (`C413`, `UP041`, `UP037`, `I001`). No new ruff regressions introduced.
- The previous `F401` for the unused `BusinessContextRule` import is gone — confirmed by `ruff check` comparison against `origin/main`.

## Test plan

- [ ] CI `CodeQL / Analyze (python)` passes
- [ ] Existing tests in `services/agents/tests/test_context_bundle.py` continue to pass (renamed import)
- [ ] Existing tests in `services/api/tests/test_business_context.py` continue to pass (dropped unused import)
- [ ] Status-transition log line still emits a usable `previous` / `next` field
- [ ] Permissions snapshot-loader warning still emits a usable `provider=` field

Made with [Cursor](https://cursor.com)