### PR TITLE
fix(web): point docs links to GitHub README

### DIFF
--- a/apps/web/src/app/benchmark/page.tsx
+++ b/apps/web/src/app/benchmark/page.tsx
@@ -169,7 +169,7 @@ export default async function BenchmarkPage() {
             append-only weekly history (substrate and wet-eval rows side-by-side
             with a MITRE-accuracy trend chart), see the{' '}
             <a
-              href="https://docs.tryaisoc.com/docs/benchmark-scoreboard"
+              href="https://github.com/beenuar/AiSOC#readme"
               target="_blank"
               rel="noreferrer"
               className="underline decoration-dotted hover:text-gray-300"

--- a/apps/web/src/components/landing/sections/BenchmarkBand.tsx
+++ b/apps/web/src/components/landing/sections/BenchmarkBand.tsx
@@ -135,7 +135,7 @@ export function BenchmarkBand() {
             />
           </Link>
           <Link
-            href="https://docs.tryaisoc.com/benchmark-scoreboard"
+            href="https://github.com/beenuar/AiSOC#readme"
             className="inline-flex items-center gap-1 text-sm font-medium text-velvet-content-tertiary transition-colors duration-200 hover:text-velvet-content-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-velvet-emerald-mint focus-visible:ring-offset-2 focus-visible:ring-offset-velvet-surface-base"
           >
             Open the public scoreboard

--- a/apps/web/src/components/landing/sections/ConnectorsMarquee.tsx
+++ b/apps/web/src/components/landing/sections/ConnectorsMarquee.tsx
@@ -203,7 +203,7 @@ export function ConnectorsMarquee() {
                 TypeScript, and Go.
               </p>
               <Link
-                href="https://docs.tryaisoc.com/connectors/sdk"
+                href="https://github.com/beenuar/AiSOC#readme"
                 className="group mt-5 inline-flex items-center gap-1 text-sm font-semibold text-velvet-emerald-mint transition-colors duration-200 hover:text-velvet-emerald-mint focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-velvet-emerald-mint focus-visible:ring-offset-2 focus-visible:ring-offset-velvet-surface-base"
               >
                 Read the connector SDK

--- a/apps/web/src/components/landing/sections/DemoEmbed.tsx
+++ b/apps/web/src/components/landing/sections/DemoEmbed.tsx
@@ -288,7 +288,7 @@ export function DemoEmbed() {
             />
           </Link>
           <Link
-            href="https://docs.tryaisoc.com/architecture"
+            href="https://github.com/beenuar/AiSOC#readme"
             className="inline-flex items-center gap-1 text-sm font-medium text-velvet-content-tertiary transition-colors duration-200 hover:text-velvet-content-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-velvet-emerald-mint focus-visible:ring-offset-2 focus-visible:ring-offset-velvet-surface-base"
           >
             Read the architecture

--- a/apps/web/src/components/landing/sections/Footer.tsx
+++ b/apps/web/src/components/landing/sections/Footer.tsx
@@ -41,8 +41,8 @@ const COLUMNS: ReadonlyArray<LinkColumn> = [
   {
     heading: 'Resources',
     links: [
-      { label: 'Docs', href: 'https://docs.tryaisoc.com' },
-      { label: 'Architecture', href: 'https://docs.tryaisoc.com/architecture' },
+      { label: 'Docs', href: 'https://github.com/beenuar/AiSOC#readme' },
+      { label: 'Architecture', href: 'https://github.com/beenuar/AiSOC#readme' },
       { label: 'Benchmark', href: '/benchmark' },
       { label: 'Blog', href: '/blog' },
       { label: 'Changelog', href: '/changelog' },

--- a/apps/web/src/components/landing/sections/Pillars.tsx
+++ b/apps/web/src/components/landing/sections/Pillars.tsx
@@ -55,7 +55,7 @@ const PILLARS: ReadonlyArray<Pillar> = [
       'The entity graph is written while events are normalised, not when an analyst clicks "show graph." Schema v1.0 is published.',
     stat: '17 + 14',
     statLabel: 'node labels · relationships',
-    href: 'https://docs.tryaisoc.com/architecture/graph-schema',
+    href: 'https://github.com/beenuar/AiSOC#readme',
     linkLabel: 'Read the graph schema',
   },
   {
@@ -66,7 +66,7 @@ const PILLARS: ReadonlyArray<Pillar> = [
       'Four named agents. Every prompt, tool call, and decision is logged. The LLM-input contract fails closed on malformed prompts.',
     stat: '4 / 100%',
     statLabel: 'agents · audited',
-    href: 'https://docs.tryaisoc.com/architecture/agents',
+    href: 'https://github.com/beenuar/AiSOC#readme',
     linkLabel: 'Read the agent contract',
   },
   {
@@ -77,7 +77,7 @@ const PILLARS: ReadonlyArray<Pillar> = [
       'Render, Fly.io, Kubernetes, AWS, your air-gapped rack — same code path. BYOK LLM credentials in the encrypted vault.',
     stat: '6 + 1',
     statLabel: 'deploy targets · air-gap overlay',
-    href: 'https://docs.tryaisoc.com/deployment',
+    href: 'https://github.com/beenuar/AiSOC#readme',
     linkLabel: 'Read the deployment guide',
   },
 ];

--- a/apps/web/src/components/landing/sections/StickyNav.tsx
+++ b/apps/web/src/components/landing/sections/StickyNav.tsx
@@ -27,7 +27,7 @@ const NAV_LINKS: ReadonlyArray<{ label: string; href: string }> = [
   { label: 'Connectors', href: '#connectors' },
   { label: 'Benchmark', href: '#benchmark' },
   { label: 'Pricing', href: '#pricing' },
-  { label: 'Docs', href: 'https://docs.tryaisoc.com' },
+  { label: 'Docs', href: 'https://github.com/beenuar/AiSOC#readme' },
 ];
 
 export function StickyNav() {


### PR DESCRIPTION
## Summary

Every `docs.tryaisoc.com` link on the landing page resolved to **NXDOMAIN** — that subdomain has no DNS record. Until docs are formally hosted, route the 10 docs CTAs to the canonical README on GitHub so visitors get real content instead of a dead host.

## Changes

10 link updates across 7 files, all pointing to `https://github.com/beenuar/AiSOC#readme`:

- `StickyNav.tsx` — top-nav Docs link
- `Footer.tsx` — footer Docs + Architecture links
- `Pillars.tsx` — Graph schema, Agents, Deployment cards
- `DemoEmbed.tsx` — Architecture link
- `ConnectorsMarquee.tsx` — Connectors SDK link
- `BenchmarkBand.tsx` — Benchmark scoreboard link
- `benchmark/page.tsx` — Benchmark scoreboard link

## Out of scope (intentionally deferred)

- **Signup CTA** (Hero.tsx → `/signup`) still 404s. Waiting on external form URL from product.
- **`app` / `www` subdomain DNS** — explicitly ignored for now per product call.

## Test plan

- [x] `grep -r "docs.tryaisoc.com" apps/web/src` returns nothing
- [ ] CI builds clean
- [ ] After merge, `curl -sI https://tryaisoc.com` still 200
- [ ] Click each docs link on the live landing page → lands on GitHub README


Made with [Cursor](https://cursor.com)