### PR TITLE
fix(web): render real /metrics/dashboard data on /dashboard

### DIFF
--- a/apps/web/src/components/dashboard/DashboardView.tsx
+++ b/apps/web/src/components/dashboard/DashboardView.tsx
@@ -385,8 +385,33 @@ export function DashboardView() {
     }
   );
 
-  const isValidMetrics = rawMetrics && typeof rawMetrics.alerts?.total === "number" && Array.isArray(rawMetrics.alertsTrend);
-  const metrics = isValidMetrics ? rawMetrics : MOCK_METRICS;
+  // Hybrid: prefer real API fields when present, fall back to mock for missing
+  // sections (e.g. /metrics/dashboard currently returns alertsTrend: [] and no
+  // threatsBySource yet, so the charts would render empty without this merge).
+  const apiData = rawMetrics as Partial<DashboardMetrics> | undefined;
+  const hasRealAlerts = !!apiData && typeof apiData.alerts?.total === 'number';
+  const metrics: DashboardMetrics = hasRealAlerts
+    ? {
+        alerts: apiData!.alerts as DashboardMetrics['alerts'],
+        cases: apiData!.cases ?? MOCK_METRICS.cases,
+        sources:
+          Array.isArray(apiData!.sources) && apiData!.sources!.length
+            ? apiData!.sources!
+            : MOCK_METRICS.sources,
+        topMitre:
+          Array.isArray(apiData!.topMitre) && apiData!.topMitre!.length
+            ? apiData!.topMitre!
+            : MOCK_METRICS.topMitre,
+        alertsTrend:
+          Array.isArray(apiData!.alertsTrend) && apiData!.alertsTrend!.length
+            ? apiData!.alertsTrend!
+            : MOCK_METRICS.alertsTrend,
+        threatsBySource:
+          Array.isArray(apiData!.threatsBySource) && apiData!.threatsBySource!.length
+            ? apiData!.threatsBySource!
+            : MOCK_METRICS.threatsBySource,
+      }
+    : MOCK_METRICS;
 
   const trendData = metrics.alertsTrend.map((d) => ({
     time: format(new Date(d.timestamp), 'HH:mm'),
@@ -426,9 +451,10 @@ export function DashboardView() {
         {/* Section header */}
         <div className="flex items-center justify-between mb-4">
           <div>
-            <h1 className="text-xl font-semibold text-gray-100">Security Operations Center</h1>
+            <h2 className="text-xl font-semibold text-gray-100">Security Operations Center</h2>
             <p className="text-sm text-gray-500 mt-0.5">
-              Entity-risk alerting, confidence-scored triage, and 26 connected sources
+              Entity-risk alerting, confidence-scored triage, and{' '}
+              {metrics.sources.filter((s) => s.status === 'active').length} connected sources
             </p>
           </div>
         </div>

--- a/apps/web/src/components/dashboard/FunnelKpiBar.tsx
+++ b/apps/web/src/components/dashboard/FunnelKpiBar.tsx
@@ -143,6 +143,17 @@ export function FunnelKpiBar({
     },
   );
 
+  // Error takes priority over loading. SWR with shouldRetryOnError: false leaves
+  // `data` undefined on failure, so without this ordering the loading branch wins
+  // forever and the user stares at skeleton tiles.
+  if (error) {
+    return (
+      <div className="bg-gray-900/60 border border-gray-800/60 rounded-xl p-4 text-sm text-gray-400">
+        Funnel metrics unavailable.
+      </div>
+    );
+  }
+
   if (isLoading || !data) {
     return (
       <div>
@@ -155,14 +166,6 @@ export function FunnelKpiBar({
             <LoadingTile key={l} label={l} />
           ))}
         </div>
-      </div>
-    );
-  }
-
-  if (error) {
-    return (
-      <div className="bg-gray-900/60 border border-gray-800/60 rounded-xl p-4 text-sm text-gray-400">
-        Funnel metrics unavailable.
       </div>
     );
   }


### PR DESCRIPTION
## Summary

Closes the loop on the **\"so many broken items on /dashboard\"** report.

The dashboard was rendering entirely mocked numbers (1,247 alerts, hardcoded \"26 connected sources\") even when `/api/v1/metrics/dashboard` returned real tenant data (120 alerts, 6 active sources), and the Operations Funnel sat in a loading skeleton forever whenever `/api/v1/metrics/funnel` returned 404.

This PR is **frontend-only** — no API redeploy required. The decision (per the dashboard triage) was \"real numbers + mock charts\": surface real tenant data on the SOC overview cards, keep mock chart data until the backend payload is extended.

### Changes

- **`DashboardView.tsx`** — replace the strict `isValidMetrics` boolean gate with a hybrid merge:
  - Use real API fields when present (`alerts`, `cases`, `sources`, `topMitre`).
  - Fall back to `MOCK_METRICS` for sections the API doesn't yet return (`alertsTrend: []`, `threatsBySource` missing) so the charts still render.
- **`DashboardView.tsx`** — derive the \"N connected sources\" subtitle from `sources.filter(s => s.status === 'active').length` instead of the hardcoded \"26\".
- **`DashboardView.tsx`** — demote the duplicate `<h1>Security Operations Center</h1>` to `<h2>` (the page layout already provides the primary `<h1>`).
- **`FunnelKpiBar.tsx`** — reorder the conditional so `error` is checked **before** `isLoading || !data`. SWR is configured with `shouldRetryOnError: false`, which leaves `data` undefined on failure; without this ordering the loading branch wins forever and the user stares at skeleton tiles.

### What still 404s (tracked separately, BE PR)

- `GET /api/v1/metrics/funnel` — endpoint exists in `services/api` (added PR #154) but the API service hasn't been redeployed since 2026-05-09, so production still 404s. After this FE PR ships, the FunnelKpiBar will at least surface \"Funnel metrics unavailable.\" instead of a stuck skeleton.
- `GET /api/v1/health/pipeline` — endpoint exists in `services/api/app/api/v1/endpoints/health.py` but `health.router` is not included in `services/api/app/api/v1/router.py`. Needs both the include + a redeploy.
- `/api/v1/metrics/dashboard` returns `alertsTrend: []` and no `threatsBySource` — the hybrid merge papers over this; backend will need to fill those fields for charts to reflect reality.

## Test plan

Local checks (all green except 2 pre-existing failures on `main`):

- [x] `pnpm run type-check` — passes
- [x] `pnpm run lint` — 0 errors (5 warnings, all pre-existing)
- [x] `pnpm vitest run src/components/dashboard` — 7/7 pass (FunnelKpiBar incl. error path)
- [x] Full `pnpm run test` — 2 failures in `SOCInsightsView.test.tsx`, **verified pre-existing on `main`** (identical 2 failed / 339 passed when temporarily reverting this diff)

Post-merge manual verification:

- [ ] CI green, deploy lands on `aisoc-demo-web`
- [ ] `https://tryaisoc.com/dashboard` shows real numbers on the SOC overview cards (Active Alerts ≈ 120, Connected Sources count matches `/api/v1/metrics/dashboard`)
- [ ] Operations Funnel shows \"Funnel metrics unavailable.\" instead of a stuck loading skeleton
- [ ] No duplicate H1 in DOM under the dashboard route

Made with [Cursor](https://cursor.com)