### PR TITLE
ci(api): add deploy-api.yml so /api/v1/* ships on main

### DIFF
--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -1,0 +1,39 @@
+name: Deploy API to Fly
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "services/api/**"
+      - "packages/types/**"
+      - ".github/workflows/deploy-api.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: deploy-api
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    name: Deploy aisoc-demo-api
+    runs-on: ubuntu-latest
+    env:
+      FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Install flyctl
+        uses: superfly/flyctl-actions/setup-flyctl@master
+
+      - name: Deploy to Fly
+        run: |
+          flyctl deploy \
+            --remote-only \
+            --dockerfile services/api/Dockerfile \
+            --config infra/fly/api/fly.toml \
+            .


### PR DESCRIPTION
## Summary

Adds a `deploy-api.yml` GitHub Actions workflow that deploys `aisoc-demo-api` to Fly on every push to `main` touching `services/api/**`. Mirrors the existing `deploy-web.yml` structure and uses the same `FLY_API_TOKEN` secret.

## Why

There was no automated deploy path for the API. Recently merged backend changes — including the routing fix for `/api/v1/health/pipeline` (PR #163) — landed on `main` but never shipped to https://api.tryaisoc.com, leaving the `/dashboard` Pipeline Health widget showing 404s.

## What it does

- Triggers on push to `main` when `services/api/**`, `packages/types/**`, or this workflow file changes
- Also supports `workflow_dispatch` for manual re-runs
- Concurrency group `deploy-api` cancels superseded runs
- Builds with `services/api/Dockerfile`, deploys with `infra/fly/api/fly.toml`

## Test plan

- [ ] CI passes (lint workflow files only — no code changes)
- [ ] After merge, manually dispatch the workflow to deploy current `main`
- [ ] Verify `curl https://api.tryaisoc.com/api/v1/health/pipeline` returns 200 with `PipelineHealth` payload
- [ ] Verify https://tryaisoc.com/dashboard Pipeline Health widget renders live status

Made with [Cursor](https://cursor.com)