### PR TITLE
fix(ci): set deploy-api build context to services/api

### DIFF
--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -6,6 +6,10 @@ on:
     paths:
       - "services/api/**"
       - "packages/types/**"
+      - "marketplace/**"
+      - "plugins/**"
+      - "scripts/build_marketplace.py"
+      - "infra/fly/api/**"
       - ".github/workflows/deploy-api.yml"
   workflow_dispatch:
 
@@ -30,10 +34,32 @@ jobs:
       - name: Install flyctl
         uses: superfly/flyctl-actions/setup-flyctl@master
 
-      - name: Deploy to Fly
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      # Mirror infra/fly/fly-demo-deploy.sh::stage_marketplace_index. The api
+      # Dockerfile does `COPY . .` against services/api/, so anything outside
+      # that dir is invisible to the image. /api/v1/marketplace returns 503
+      # without index.json present at /app/marketplace/index.json in the image.
+      - name: Stage marketplace/index.json into services/api
+        run: |
+          python3 -m pip install --quiet pyyaml
+          python3 scripts/build_marketplace.py
+          mkdir -p services/api/marketplace
+          cp marketplace/index.json services/api/marketplace/index.json
+          ls -la services/api/marketplace/
+
+      # The api Dockerfile was written assuming build context = services/api/
+      # (it does `COPY pyproject.toml ./` and `COPY . .`). flyctl deploy uses
+      # its cwd as the build context, so we cd into services/api/ and pass an
+      # absolute path to the fly.toml so flyctl still finds it. This mirrors
+      # the deploy_app() helper in infra/fly/fly-demo-deploy.sh.
+      - name: Deploy to Fly (context=services/api)
+        working-directory: services/api
         run: |
           flyctl deploy \
             --remote-only \
-            --dockerfile services/api/Dockerfile \
-            --config infra/fly/api/fly.toml \
-            .
+            --config "${GITHUB_WORKSPACE}/infra/fly/api/fly.toml" \
+            --app aisoc-demo-api


### PR DESCRIPTION
## Summary

The `Deploy API to Fly` workflow added in #164 fails at the Docker build step:

```
ERROR: failed to calculate checksum of ref ... "/pyproject.toml": not found
```

Root cause: `services/api/Dockerfile` was written assuming the build context is `services/api/` (it does `COPY pyproject.toml ./` and later `COPY . .`). The previous workflow ran `flyctl deploy` from the repo root with `--dockerfile services/api/Dockerfile`, which sets the build context to the monorepo root — so Docker can't find `./pyproject.toml` and aborts before the rest of the image build runs.

This PR mirrors what `infra/fly/fly-demo-deploy.sh::deploy_app` already does for `aisoc-demo-api`:

- `cd services/api/` before `flyctl deploy` so the build context matches the Dockerfile's assumptions
- pass `--config` as an absolute path so flyctl still finds `infra/fly/api/fly.toml`
- stage `marketplace/index.json` into `services/api/marketplace/` before deploy so `/api/v1/marketplace` doesn't 503 inside the image (mirrors `stage_marketplace_index` in the shell script)
- install `pyyaml` (a `scripts/build_marketplace.py` requirement) and set up Python 3.11
- extend `paths:` to also retrigger on `marketplace/**`, `plugins/**`, `scripts/build_marketplace.py`, and `infra/fly/api/**`

## Why this unblocks the dashboard

PR #163 wired the `/api/v1/health/pipeline` router, and `/api/v1/metrics/funnel` was added earlier — but neither is live on `aisoc-demo-api` yet because the API hasn't been deployed since those changes merged. Once this workflow succeeds, the dashboard widgets in `https://tryaisoc.com/dashboard` (Pipeline Health, Operations Funnel) stop 404'ing and start rendering real data.

## Test plan

- [ ] Workflow runs to completion on merge (no `pyproject.toml not found`)
- [ ] `curl https://aisoc-demo-api.fly.dev/api/v1/health/pipeline` returns 200
- [ ] `curl https://aisoc-demo-api.fly.dev/api/v1/metrics/funnel?window=24h` returns 200
- [ ] `https://tryaisoc.com/dashboard` renders Pipeline Health + Operations Funnel widgets with real data instead of mock fallbacks

Made with [Cursor](https://cursor.com)