### PR TITLE
fix(api): release_command runs SQL migrations, not alembic

### DIFF
--- a/infra/fly/api/fly.toml
+++ b/infra/fly/api/fly.toml
@@ -22,11 +22,15 @@ kill_timeout   = "5s"
 # deploy script cd's into services/api/ before invoking `flyctl deploy`, so
 # the right Dockerfile gets picked up automatically.
 
-# Run alembic migrations and re-seed the demo dataset on every deploy.
+# Run SQL migrations and re-seed the demo dataset on every deploy.
 # The release_command runs in a temporary VM with all production env vars
 # (Postgres URL, Redis URL, secrets) before any app machine accepts traffic,
 # which is exactly what we want for demo-tenant data lifecycle:
-#   1. `alembic upgrade head` keeps the schema in step with the image.
+#   1. `python -m app.scripts.run_migrations` applies the raw-SQL files under
+#      services/api/migrations/ and tracks them in aisoc_schema_migrations, so
+#      the schema stays in step with the image. (This service does not use
+#      Alembic — no alembic.ini / env.py exist here; the package is listed in
+#      pyproject only for integration tests.)
 #   2. `python -m app.scripts.seed_demo` is idempotent — it short-circuits
 #      when the canonical INC-RT-* case_numbers already exist, so it's safe
 #      to run on every deploy. First-run boot creates all 15 incidents
@@ -36,7 +40,7 @@ kill_timeout   = "5s"
 # users on an empty dashboard and breaks the < 5 min clone-to-investigation
 # acceptance criterion in the v1.0 plan.
 [deploy]
-  release_command = "/bin/sh -c 'alembic upgrade head && python -m app.scripts.seed_demo'"
+  release_command = "/bin/sh -c 'python -m app.scripts.run_migrations && python -m app.scripts.seed_demo'"
 
 [env]
   ENVIRONMENT      = "demo"


### PR DESCRIPTION
## Why

The first real \`Deploy API to Fly\` run (post-PR #165) succeeded at build + image push but failed at the Fly release step with:

\`\`\`
Error release_command failed running on machine ... with exit code 255.
FAILED: No 'script_location' key found in configuration.
\`\`\`

\`infra/fly/api/fly.toml\` was calling \`alembic upgrade head\`, but **\`services/api\` does not use Alembic**:

- no \`alembic.ini\` / no \`alembic/env.py\` in \`services/api/\`
- migrations live in \`services/api/migrations/\` as raw SQL
- they're applied by \`services/api/app/scripts/run_migrations.py\` (asyncpg, tracked in \`aisoc_schema_migrations\`, idempotent)
- \`app/main.py\` already invokes \`run_sql_migrations()\` at startup, **but only when \`settings.is_dev\`** — so in prod the release_command is the only opportunity

Net result: production migrations have never actually run through this path, and now that builds finally reach the release stage the latent bug surfaced.

## What

\`\`\`diff
-  release_command = "/bin/sh -c 'alembic upgrade head && python -m app.scripts.seed_demo'"
+  release_command = "/bin/sh -c 'python -m app.scripts.run_migrations && python -m app.scripts.seed_demo'"
\`\`\`

Plus a comment refresh so the next person doesn't repeat the mistake.

## Unblocks

- \`/api/v1/metrics/funnel\` and \`/api/v1/health/pipeline\` finally reaching production
- The dashboard widgets that depend on them (PR #163 wired the router, PR #164/#165 fixed the deploy workflow, this is the final blocker)

## Test plan

- [ ] CI green (or pre-existing failures only)
- [ ] After merge, watch \`Deploy API to Fly\` workflow reach the release_command step and exit 0
- [ ] \`curl https://api.tryaisoc.com/api/v1/health/pipeline\` → 200
- [ ] \`curl https://api.tryaisoc.com/api/v1/metrics/funnel\` → 200
- [ ] Load \`https://tryaisoc.com/dashboard\` — Operations Funnel + Pipeline Health render with live data

Made with [Cursor](https://cursor.com)