### PR TITLE
chore(deps-dev): update ruff requirement to >=0.4.4,<0.16.0 in /services/api

### DIFF
--- a/services/api/pyproject.toml
+++ b/services/api/pyproject.toml
@@ -51,7 +51,7 @@ pytest = ">=8.2,<10.0"
 pytest-asyncio = ">=0.23.6,<1.4.0"
 pytest-cov = ">=5,<8"
 httpx = ">=0.27,<0.29"
-ruff = "^0.4.4"
+ruff = ">=0.4.4,<0.16.0"
 mypy = ">=1.10,<3.0"
 
 [build-system]


### PR DESCRIPTION
## Summary
- Manual replacement of dependabot PR #187, which couldn't auto-merge due to adjacent pytest/mypy bumps already merged.
- Widens ruff dev-dep range so future dependabot bumps don't need to bump pyproject every time.

## Test plan
- [x] CI lint/type-check (Ruff 0.4.10 in CI still satisfies the new range).
- [ ] Wait for green CI, then squash-merge.

Closes #187.

Made with [Cursor](https://cursor.com)