### PR TITLE
Fix: Wire prompt sanitizer into classification agents to prevent prompt injection

### DIFF
--- a/services/agents/app/agents/auto_triage_agent.py
+++ b/services/agents/app/agents/auto_triage_agent.py
@@ -112,11 +112,7 @@ def _build_alert_context(state: InvestigationState) -> str:
         "url": "URL",
         "hostname": "Hostname",
     }
-    present_iocs = {
-        label: sanitize_text(str(raw[key]))
-        for key, label in ioc_fields.items()
-        if raw.get(key)
-    }
+    present_iocs = {label: sanitize_text(str(raw[key])) for key, label in ioc_fields.items() if raw.get(key)}
     if present_iocs:
         parts.append("IOCs present: " + ", ".join(f"{k}={v}" for k, v in present_iocs.items()))
     else:

--- a/services/agents/app/agents/auto_triage_agent.py
+++ b/services/agents/app/agents/auto_triage_agent.py
@@ -21,6 +21,7 @@ import structlog
 from langchain_core.messages import HumanMessage, SystemMessage
 from langchain_openai import ChatOpenAI
 
+from app.investigator.prompt_sanitizer import sanitize_text, wrap_untrusted
 from app.llm import safe_ainvoke
 from app.models.state import AgentStatus, InvestigationState
 from app.prompt_serialization import format_extra_fields_for_llm
@@ -98,9 +99,9 @@ def _build_alert_context(state: InvestigationState) -> str:
     """Serialise the alert into a compact string the LLM can reason over."""
     raw = state.raw_alert
     parts = [
-        f"Alert Summary: {state.alert_summary}",
-        f"Severity (vendor): {raw.get('severity', 'unknown')}",
-        f"Risk Score (vendor): {raw.get('risk_score', 'N/A')}",
+        f"Alert Summary: {sanitize_text(state.alert_summary)}",
+        f"Severity (vendor): {sanitize_text(str(raw.get('severity', 'unknown')))}",
+        f"Risk Score (vendor): {sanitize_text(str(raw.get('risk_score', 'N/A')))}",
     ]
 
     ioc_fields = {
@@ -111,7 +112,11 @@ def _build_alert_context(state: InvestigationState) -> str:
         "url": "URL",
         "hostname": "Hostname",
     }
-    present_iocs = {label: raw[key] for key, label in ioc_fields.items() if raw.get(key)}
+    present_iocs = {
+        label: sanitize_text(str(raw[key]))
+        for key, label in ioc_fields.items()
+        if raw.get(key)
+    }
     if present_iocs:
         parts.append("IOCs present: " + ", ".join(f"{k}={v}" for k, v in present_iocs.items()))
     else:
@@ -119,14 +124,14 @@ def _build_alert_context(state: InvestigationState) -> str:
 
     techniques = raw.get("mitre_techniques", [])
     if techniques:
-        parts.append(f"MITRE Techniques: {', '.join(techniques)}")
+        parts.append(f"MITRE Techniques: {', '.join(sanitize_text(str(t)) for t in techniques)}")
 
     extra_keys = {k for k in raw if k not in {"severity", "risk_score", "mitre_techniques", *ioc_fields}}
     if extra_keys:
         extras = {k: raw[k] for k in sorted(extra_keys)[:10]}
         parts.append("Additional fields (summary, not raw JSON):\n" + format_extra_fields_for_llm(extras))
 
-    return "\n".join(parts)
+    return wrap_untrusted("\n".join(parts), label="alert_telemetry")
 
 
 def _parse_llm_response(text: str) -> dict[str, Any]:

--- a/services/agents/app/agents/cloud_agent.py
+++ b/services/agents/app/agents/cloud_agent.py
@@ -91,34 +91,21 @@ def _build_cloud_context(state: InvestigationState) -> str:
         parts.append(f"Bucket ACL: {sanitize_text(str(raw.get('bucket_acl', 'N/A')))}")
         if raw.get("bucket_policy"):
             parts.append(
-                "Bucket Policy:\n"
-                + summarize_structure_for_llm(
-                    raw["bucket_policy"], label="bucket_policy", max_lines=28, max_depth=3
-                )
+                "Bucket Policy:\n" + summarize_structure_for_llm(raw["bucket_policy"], label="bucket_policy", max_lines=28, max_depth=3)
             )
 
     if raw.get("security_group_rules"):
         parts.append(
             "SG Rules:\n"
-            + summarize_structure_for_llm(
-                raw["security_group_rules"], label="security_group_rules", max_lines=28, max_depth=3
-            )
+            + summarize_structure_for_llm(raw["security_group_rules"], label="security_group_rules", max_lines=28, max_depth=3)
         )
 
     if raw.get("iam_policy") or raw.get("permissions"):
         val = raw.get("iam_policy") or raw.get("permissions")
-        parts.append(
-            "IAM/Permissions:\n"
-            + summarize_structure_for_llm(val, label="iam_permissions", max_lines=28, max_depth=3)
-        )
+        parts.append("IAM/Permissions:\n" + summarize_structure_for_llm(val, label="iam_permissions", max_lines=28, max_depth=3))
 
     if raw.get("api_calls"):
-        parts.append(
-            "API calls:\n"
-            + summarize_structure_for_llm(
-                raw["api_calls"], label="api_calls", max_lines=28, max_depth=2
-            )
-        )
+        parts.append("API calls:\n" + summarize_structure_for_llm(raw["api_calls"], label="api_calls", max_lines=28, max_depth=2))
 
     if raw.get("is_public") is not None:
         parts.append(f"Public access: {raw['is_public']}")

--- a/services/agents/app/agents/cloud_agent.py
+++ b/services/agents/app/agents/cloud_agent.py
@@ -19,6 +19,7 @@ from langchain_core.messages import HumanMessage, SystemMessage
 from langchain_openai import ChatOpenAI
 
 from app.context import ContextBundle
+from app.investigator.prompt_sanitizer import sanitize_text, wrap_untrusted
 from app.llm import safe_ainvoke
 from app.models.state import AgentStatus, InvestigationState
 from app.prompt_serialization import format_extra_fields_for_llm, summarize_structure_for_llm
@@ -63,8 +64,8 @@ def _build_cloud_context(state: InvestigationState) -> str:
     """Serialise alert data into a cloud-focused analysis prompt."""
     raw = state.raw_alert
     parts = [
-        f"Alert Summary: {state.alert_summary}",
-        f"Severity: {raw.get('severity', 'unknown')}",
+        f"Alert Summary: {sanitize_text(state.alert_summary)}",
+        f"Severity: {sanitize_text(str(raw.get('severity', 'unknown')))}",
     ]
 
     cloud_fields = {
@@ -84,33 +85,46 @@ def _build_cloud_context(state: InvestigationState) -> str:
     }
     for key, label in cloud_fields.items():
         if raw.get(key):
-            parts.append(f"{label}: {raw[key]}")
+            parts.append(f"{label}: {sanitize_text(str(raw[key]))}")
 
     if raw.get("bucket_acl") or raw.get("bucket_policy"):
-        parts.append(f"Bucket ACL: {raw.get('bucket_acl', 'N/A')}")
+        parts.append(f"Bucket ACL: {sanitize_text(str(raw.get('bucket_acl', 'N/A')))}")
         if raw.get("bucket_policy"):
             parts.append(
-                "Bucket Policy:\n" + summarize_structure_for_llm(raw["bucket_policy"], label="bucket_policy", max_lines=28, max_depth=3)
+                "Bucket Policy:\n"
+                + summarize_structure_for_llm(
+                    raw["bucket_policy"], label="bucket_policy", max_lines=28, max_depth=3
+                )
             )
 
     if raw.get("security_group_rules"):
         parts.append(
             "SG Rules:\n"
-            + summarize_structure_for_llm(raw["security_group_rules"], label="security_group_rules", max_lines=28, max_depth=3)
+            + summarize_structure_for_llm(
+                raw["security_group_rules"], label="security_group_rules", max_lines=28, max_depth=3
+            )
         )
 
     if raw.get("iam_policy") or raw.get("permissions"):
         val = raw.get("iam_policy") or raw.get("permissions")
-        parts.append("IAM/Permissions:\n" + summarize_structure_for_llm(val, label="iam_permissions", max_lines=28, max_depth=3))
+        parts.append(
+            "IAM/Permissions:\n"
+            + summarize_structure_for_llm(val, label="iam_permissions", max_lines=28, max_depth=3)
+        )
 
     if raw.get("api_calls"):
-        parts.append("API calls:\n" + summarize_structure_for_llm(raw["api_calls"], label="api_calls", max_lines=28, max_depth=2))
+        parts.append(
+            "API calls:\n"
+            + summarize_structure_for_llm(
+                raw["api_calls"], label="api_calls", max_lines=28, max_depth=2
+            )
+        )
 
     if raw.get("is_public") is not None:
         parts.append(f"Public access: {raw['is_public']}")
 
     if raw.get("finding_type"):
-        parts.append(f"Finding type: {raw['finding_type']}")
+        parts.append(f"Finding type: {sanitize_text(str(raw['finding_type']))}")
 
     extra_keys = {
         k
@@ -134,7 +148,7 @@ def _build_cloud_context(state: InvestigationState) -> str:
         extras = {k: raw[k] for k in sorted(extra_keys)[:8]}
         parts.append("Additional fields:\n" + format_extra_fields_for_llm(extras, max_keys=8))
 
-    return "\n".join(parts)
+    return wrap_untrusted("\n".join(parts), label="cloud_telemetry")
 
 
 def _parse_response(text: str) -> dict[str, Any]:

--- a/services/agents/app/agents/identity_agent.py
+++ b/services/agents/app/agents/identity_agent.py
@@ -86,10 +86,7 @@ def _build_identity_context(state: InvestigationState) -> str:
 
     if raw.get("login_attempts"):
         parts.append(
-            "Login attempts:\n"
-            + summarize_structure_for_llm(
-                raw["login_attempts"], label="login_attempts", max_lines=24, max_depth=2
-            )
+            "Login attempts:\n" + summarize_structure_for_llm(raw["login_attempts"], label="login_attempts", max_lines=24, max_depth=2)
         )
     if raw.get("failed_count"):
         parts.append(f"Failed attempt count: {raw['failed_count']}")
@@ -97,10 +94,7 @@ def _build_identity_context(state: InvestigationState) -> str:
     geo_fields = ["login_locations", "geo_locations"]
     for gf in geo_fields:
         if raw.get(gf):
-            parts.append(
-                f"Geo locations ({gf}):\n"
-                + summarize_structure_for_llm(raw[gf], label=gf, max_lines=20, max_depth=2)
-            )
+            parts.append(f"Geo locations ({gf}):\n" + summarize_structure_for_llm(raw[gf], label=gf, max_lines=20, max_depth=2))
 
     priv_fields = ["role_change", "group_added", "permissions_changed", "privilege_level"]
     priv_parts = []
@@ -114,10 +108,7 @@ def _build_identity_context(state: InvestigationState) -> str:
         parts.append(f"Event time: {raw['timestamp']}")
     if raw.get("previous_login"):
         parts.append(
-            "Previous login:\n"
-            + summarize_structure_for_llm(
-                raw["previous_login"], label="previous_login", max_lines=16, max_depth=2
-            )
+            "Previous login:\n" + summarize_structure_for_llm(raw["previous_login"], label="previous_login", max_lines=16, max_depth=2)
         )
 
     extra_keys = {

--- a/services/agents/app/agents/identity_agent.py
+++ b/services/agents/app/agents/identity_agent.py
@@ -20,8 +20,8 @@ from langchain_openai import ChatOpenAI
 from app.context import ContextBundle
 from app.investigator.prompt_sanitizer import sanitize_text, wrap_untrusted
 from app.llm import safe_ainvoke
-from app.prompt_serialization import format_extra_fields_for_llm, summarize_structure_for_llm
 from app.models.state import AgentStatus, InvestigationState
+from app.prompt_serialization import format_extra_fields_for_llm, summarize_structure_for_llm
 
 logger = structlog.get_logger()
 

--- a/services/agents/app/agents/identity_agent.py
+++ b/services/agents/app/agents/identity_agent.py
@@ -18,9 +18,10 @@ from langchain_core.messages import HumanMessage, SystemMessage
 from langchain_openai import ChatOpenAI
 
 from app.context import ContextBundle
+from app.investigator.prompt_sanitizer import sanitize_text, wrap_untrusted
 from app.llm import safe_ainvoke
-from app.models.state import AgentStatus, InvestigationState
 from app.prompt_serialization import format_extra_fields_for_llm, summarize_structure_for_llm
+from app.models.state import AgentStatus, InvestigationState
 
 logger = structlog.get_logger()
 
@@ -62,8 +63,8 @@ def _build_identity_context(state: InvestigationState) -> str:
     """Serialise alert data into an identity-focused analysis prompt."""
     raw = state.raw_alert
     parts = [
-        f"Alert Summary: {state.alert_summary}",
-        f"Severity: {raw.get('severity', 'unknown')}",
+        f"Alert Summary: {sanitize_text(state.alert_summary)}",
+        f"Severity: {sanitize_text(str(raw.get('severity', 'unknown')))}",
     ]
 
     identity_fields = {
@@ -81,11 +82,14 @@ def _build_identity_context(state: InvestigationState) -> str:
     }
     for key, label in identity_fields.items():
         if raw.get(key):
-            parts.append(f"{label}: {raw[key]}")
+            parts.append(f"{label}: {sanitize_text(str(raw[key]))}")
 
     if raw.get("login_attempts"):
         parts.append(
-            "Login attempts:\n" + summarize_structure_for_llm(raw["login_attempts"], label="login_attempts", max_lines=24, max_depth=2)
+            "Login attempts:\n"
+            + summarize_structure_for_llm(
+                raw["login_attempts"], label="login_attempts", max_lines=24, max_depth=2
+            )
         )
     if raw.get("failed_count"):
         parts.append(f"Failed attempt count: {raw['failed_count']}")
@@ -93,7 +97,10 @@ def _build_identity_context(state: InvestigationState) -> str:
     geo_fields = ["login_locations", "geo_locations"]
     for gf in geo_fields:
         if raw.get(gf):
-            parts.append(f"Geo locations ({gf}):\n" + summarize_structure_for_llm(raw[gf], label=gf, max_lines=20, max_depth=2))
+            parts.append(
+                f"Geo locations ({gf}):\n"
+                + summarize_structure_for_llm(raw[gf], label=gf, max_lines=20, max_depth=2)
+            )
 
     priv_fields = ["role_change", "group_added", "permissions_changed", "privilege_level"]
     priv_parts = []
@@ -107,7 +114,10 @@ def _build_identity_context(state: InvestigationState) -> str:
         parts.append(f"Event time: {raw['timestamp']}")
     if raw.get("previous_login"):
         parts.append(
-            "Previous login:\n" + summarize_structure_for_llm(raw["previous_login"], label="previous_login", max_lines=16, max_depth=2)
+            "Previous login:\n"
+            + summarize_structure_for_llm(
+                raw["previous_login"], label="previous_login", max_lines=16, max_depth=2
+            )
         )
 
     extra_keys = {
@@ -130,7 +140,7 @@ def _build_identity_context(state: InvestigationState) -> str:
         extras = {k: raw[k] for k in sorted(extra_keys)[:8]}
         parts.append("Additional fields:\n" + format_extra_fields_for_llm(extras, max_keys=8))
 
-    return "\n".join(parts)
+    return wrap_untrusted("\n".join(parts), label="identity_telemetry")
 
 
 def _parse_response(text: str) -> dict[str, Any]:

--- a/services/agents/app/agents/insider_threat_agent.py
+++ b/services/agents/app/agents/insider_threat_agent.py
@@ -116,19 +116,11 @@ def _build_insider_context(state: InvestigationState) -> str:
         parts.append(f"Destination domain: {raw['destination_domain']}")
 
     if raw.get("usb_events"):
-        parts.append(
-            "USB events:\n"
-            + summarize_structure_for_llm(
-                raw["usb_events"], label="usb_events", max_lines=24, max_depth=2
-            )
-        )
+        parts.append("USB events:\n" + summarize_structure_for_llm(raw["usb_events"], label="usb_events", max_lines=24, max_depth=2))
 
     if raw.get("recent_activity"):
         parts.append(
-            "Recent activity:\n"
-            + summarize_structure_for_llm(
-                raw["recent_activity"], label="recent_activity", max_lines=24, max_depth=2
-            )
+            "Recent activity:\n" + summarize_structure_for_llm(raw["recent_activity"], label="recent_activity", max_lines=24, max_depth=2)
         )
 
     if raw.get("baseline_deviation"):

--- a/services/agents/app/agents/insider_threat_agent.py
+++ b/services/agents/app/agents/insider_threat_agent.py
@@ -19,6 +19,7 @@ from langchain_core.messages import HumanMessage, SystemMessage
 from langchain_openai import ChatOpenAI
 
 from app.context import ContextBundle
+from app.investigator.prompt_sanitizer import sanitize_text, wrap_untrusted
 from app.llm import safe_ainvoke
 from app.models.state import AgentStatus, InvestigationState
 from app.prompt_serialization import format_extra_fields_for_llm, summarize_structure_for_llm
@@ -66,8 +67,8 @@ def _build_insider_context(state: InvestigationState) -> str:
     """Serialise alert data into an insider-threat focused analysis prompt."""
     raw = state.raw_alert
     parts = [
-        f"Alert Summary: {state.alert_summary}",
-        f"Severity: {raw.get('severity', 'unknown')}",
+        f"Alert Summary: {sanitize_text(state.alert_summary)}",
+        f"Severity: {sanitize_text(str(raw.get('severity', 'unknown')))}",
     ]
 
     user_fields = {
@@ -82,7 +83,7 @@ def _build_insider_context(state: InvestigationState) -> str:
     }
     for key, label in user_fields.items():
         if raw.get(key):
-            parts.append(f"{label}: {raw[key]}")
+            parts.append(f"{label}: {sanitize_text(str(raw[key]))}")
 
     activity_fields = {
         "action": "Action",
@@ -97,7 +98,7 @@ def _build_insider_context(state: InvestigationState) -> str:
     }
     for key, label in activity_fields.items():
         if raw.get(key):
-            parts.append(f"{label}: {raw[key]}")
+            parts.append(f"{label}: {sanitize_text(str(raw[key]))}")
 
     if raw.get("access_time") or raw.get("timestamp"):
         parts.append(f"Access time: {raw.get('access_time') or raw.get('timestamp')}")
@@ -115,11 +116,19 @@ def _build_insider_context(state: InvestigationState) -> str:
         parts.append(f"Destination domain: {raw['destination_domain']}")
 
     if raw.get("usb_events"):
-        parts.append("USB events:\n" + summarize_structure_for_llm(raw["usb_events"], label="usb_events", max_lines=24, max_depth=2))
+        parts.append(
+            "USB events:\n"
+            + summarize_structure_for_llm(
+                raw["usb_events"], label="usb_events", max_lines=24, max_depth=2
+            )
+        )
 
     if raw.get("recent_activity"):
         parts.append(
-            "Recent activity:\n" + summarize_structure_for_llm(raw["recent_activity"], label="recent_activity", max_lines=24, max_depth=2)
+            "Recent activity:\n"
+            + summarize_structure_for_llm(
+                raw["recent_activity"], label="recent_activity", max_lines=24, max_depth=2
+            )
         )
 
     if raw.get("baseline_deviation"):
@@ -150,7 +159,7 @@ def _build_insider_context(state: InvestigationState) -> str:
         extras = {k: raw[k] for k in sorted(extra_keys)[:8]}
         parts.append("Additional fields:\n" + format_extra_fields_for_llm(extras, max_keys=8))
 
-    return "\n".join(parts)
+    return wrap_untrusted("\n".join(parts), label="insider_threat_telemetry")
 
 
 def _parse_response(text: str) -> dict[str, Any]:

--- a/services/agents/app/agents/phishing_agent.py
+++ b/services/agents/app/agents/phishing_agent.py
@@ -21,8 +21,8 @@ from langchain_openai import ChatOpenAI
 from app.context import ContextBundle
 from app.investigator.prompt_sanitizer import sanitize_text, wrap_untrusted
 from app.llm import safe_ainvoke
-from app.prompt_serialization import format_extra_fields_for_llm, summarize_structure_for_llm
 from app.models.state import AgentStatus, InvestigationState
+from app.prompt_serialization import format_extra_fields_for_llm, summarize_structure_for_llm
 
 logger = structlog.get_logger()
 

--- a/services/agents/app/agents/phishing_agent.py
+++ b/services/agents/app/agents/phishing_agent.py
@@ -73,10 +73,7 @@ def _build_phishing_context(state: InvestigationState) -> str:
             parts.append(f"{label}: {sanitize_text(str(raw[key]))}")
 
     if raw.get("urls"):
-        parts.append(
-            "URLs found:\n"
-            + summarize_structure_for_llm(raw["urls"], label="urls", max_lines=24, max_depth=2)
-        )
+        parts.append("URLs found:\n" + summarize_structure_for_llm(raw["urls"], label="urls", max_lines=24, max_depth=2))
     if raw.get("url"):
         parts.append(f"Primary URL: {sanitize_text(str(raw['url']))}")
     if raw.get("domain"):
@@ -85,9 +82,7 @@ def _build_phishing_context(state: InvestigationState) -> str:
     if raw.get("attachment_hashes"):
         parts.append(
             "Attachment hashes:\n"
-            + summarize_structure_for_llm(
-                raw["attachment_hashes"], label="attachment_hashes", max_lines=16, max_depth=1
-            )
+            + summarize_structure_for_llm(raw["attachment_hashes"], label="attachment_hashes", max_lines=16, max_depth=1)
         )
     if raw.get("file_hash"):
         parts.append(f"File hash: {sanitize_text(str(raw['file_hash']))}")

--- a/services/agents/app/agents/phishing_agent.py
+++ b/services/agents/app/agents/phishing_agent.py
@@ -19,9 +19,10 @@ from langchain_core.messages import HumanMessage, SystemMessage
 from langchain_openai import ChatOpenAI
 
 from app.context import ContextBundle
+from app.investigator.prompt_sanitizer import sanitize_text, wrap_untrusted
 from app.llm import safe_ainvoke
-from app.models.state import AgentStatus, InvestigationState
 from app.prompt_serialization import format_extra_fields_for_llm, summarize_structure_for_llm
+from app.models.state import AgentStatus, InvestigationState
 
 logger = structlog.get_logger()
 
@@ -55,8 +56,8 @@ def _build_phishing_context(state: InvestigationState) -> str:
     """Serialise alert data into a phishing-focused analysis prompt."""
     raw = state.raw_alert
     parts = [
-        f"Alert Summary: {state.alert_summary}",
-        f"Severity: {raw.get('severity', 'unknown')}",
+        f"Alert Summary: {sanitize_text(state.alert_summary)}",
+        f"Severity: {sanitize_text(str(raw.get('severity', 'unknown')))}",
     ]
 
     email_fields = {
@@ -69,22 +70,27 @@ def _build_phishing_context(state: InvestigationState) -> str:
     }
     for key, label in email_fields.items():
         if raw.get(key):
-            parts.append(f"{label}: {raw[key]}")
+            parts.append(f"{label}: {sanitize_text(str(raw[key]))}")
 
     if raw.get("urls"):
-        parts.append("URLs found:\n" + summarize_structure_for_llm(raw["urls"], label="urls", max_lines=24, max_depth=2))
+        parts.append(
+            "URLs found:\n"
+            + summarize_structure_for_llm(raw["urls"], label="urls", max_lines=24, max_depth=2)
+        )
     if raw.get("url"):
-        parts.append(f"Primary URL: {raw['url']}")
+        parts.append(f"Primary URL: {sanitize_text(str(raw['url']))}")
     if raw.get("domain"):
-        parts.append(f"Domain: {raw['domain']}")
+        parts.append(f"Domain: {sanitize_text(str(raw['domain']))}")
 
     if raw.get("attachment_hashes"):
         parts.append(
             "Attachment hashes:\n"
-            + summarize_structure_for_llm(raw["attachment_hashes"], label="attachment_hashes", max_lines=16, max_depth=1)
+            + summarize_structure_for_llm(
+                raw["attachment_hashes"], label="attachment_hashes", max_lines=16, max_depth=1
+            )
         )
     if raw.get("file_hash"):
-        parts.append(f"File hash: {raw['file_hash']}")
+        parts.append(f"File hash: {sanitize_text(str(raw['file_hash']))}")
 
     auth_results = {
         "spf_result": "SPF",
@@ -94,12 +100,12 @@ def _build_phishing_context(state: InvestigationState) -> str:
     auth_parts = []
     for key, label in auth_results.items():
         if raw.get(key):
-            auth_parts.append(f"{label}={raw[key]}")
+            auth_parts.append(f"{label}={sanitize_text(str(raw[key]))}")
     if auth_parts:
         parts.append(f"Email auth: {', '.join(auth_parts)}")
 
     if raw.get("body_snippet"):
-        parts.append(f"Body snippet: {raw['body_snippet'][:500]}")
+        parts.append(f"Body snippet: {sanitize_text(str(raw['body_snippet']), max_len=500)}")
 
     extra_keys = {
         k
@@ -124,7 +130,7 @@ def _build_phishing_context(state: InvestigationState) -> str:
         extras = {k: raw[k] for k in sorted(extra_keys)[:8]}
         parts.append("Additional fields:\n" + format_extra_fields_for_llm(extras, max_keys=8))
 
-    return "\n".join(parts)
+    return wrap_untrusted("\n".join(parts), label="phishing_telemetry")
 
 
 def _parse_response(text: str) -> dict[str, Any]:


### PR DESCRIPTION
### Summary
This PR addresses a critical prompt injection vulnerability where attacker-controlled telemetry could hijack the classification agents (`auto_triage`, `phishing`, `cloud`, `identity`, `insider_threat`) and trick them into auto-closing legitimate high-severity alerts.

While the investigator agents were already correctly using the `prompt_sanitizer` module, the 5 classification agents bypassed it, pasting raw alert fields directly into the LLM prompt.

### Changes
- **Input Sanitization:** Wired the existing `sanitize_text()` function into the context-building functions for all 5 classification agents.
- **Trust Boundary Enforcement:** Wrapped the final alert telemetry context in `<UNTRUSTED_DATA>` tags via `wrap_untrusted()` so the LLM treats it as inert data rather than instructions.

### Verification
- Tested with a malicious injection payload locally. The injection payload is now successfully stripped by `sanitize_text` (redacted to `[REDACTED:INJECTION]`) and the LLM correctly evaluates the underlying alert as a `true_positive`.
- Validated that the `needs_human_review` fallback works safely if the LLM errors.

### Eval Harness Results
- **Alert Reduction:** No regression (CI verified)
- **Investigation Completeness:** No regression (CI verified)
- **Response Quality:** No regression (CI verified)
- **MITRE Accuracy:** No regression (CI verified)
_Note: Because this only adds a sanitization layer around existing LLM contexts, substrate self-consistency and agent accuracy metrics remain unchanged against the synthetic eval corpus._

Fixes #220 
