### PR TITLE
fix(api): scope detection-loop suggestion lookups to caller's tenant

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -743,6 +743,7 @@ paths:
             application/json:
               schema:
                 type: object
+                additionalProperties: true
                 title: Response Explain Alert Api V1 Alerts  Alert Id  Explain Post
         '422':
           description: Validation Error
@@ -1288,6 +1289,7 @@ paths:
             application/json:
               schema:
                 type: object
+                additionalProperties: true
                 title: Response Case Investigate Api V1 Cases  Case Id  Investigate
                   Post
         '422':
@@ -1324,6 +1326,7 @@ paths:
             application/json:
               schema:
                 type: object
+                additionalProperties: true
                 title: Response List Case Investigations Api V1 Cases  Case Id  Investigations
                   Get
         '422':
@@ -1360,6 +1363,7 @@ paths:
             application/json:
               schema:
                 type: object
+                additionalProperties: true
                 title: Response Case Investigation Run Api V1 Cases  Case Id  Investigations  Run
                   Id  Get
         '422':
@@ -1528,6 +1532,7 @@ paths:
             application/json:
               schema:
                 type: object
+                additionalProperties: true
                 title: Response List Related Cases Api V1 Cases  Case Id  Related
                   Get
         '422':
@@ -1581,6 +1586,7 @@ paths:
             application/json:
               schema:
                 type: object
+                additionalProperties: true
                 title: Response Get Attack Chain Api V1 Cases  Case Id  Attack Chain
                   Get
         '422':
@@ -1611,6 +1617,7 @@ paths:
           content:
             application/json:
               schema:
+                additionalProperties: true
                 type: object
                 title: Response List Catalog Api V1 Connectors Catalog Get
       security:
@@ -1668,6 +1675,7 @@ paths:
           content:
             application/json:
               schema:
+                additionalProperties: true
                 type: object
                 title: Response Test Connection Api V1 Connectors Test Post
         '422':
@@ -1913,6 +1921,7 @@ paths:
             application/json:
               schema:
                 type: object
+                additionalProperties: true
                 title: Response Test Existing Connector Api V1 Connectors  Connector
                   Id  Test Post
         '422':
@@ -4358,6 +4367,7 @@ paths:
           content:
             application/json:
               schema:
+                additionalProperties: true
                 type: object
                 title: Response Publish Plugin Api V1 Community Plugins Publish Post
       security:
@@ -4531,6 +4541,7 @@ paths:
             application/json:
               schema:
                 type: object
+                additionalProperties: true
                 title: Response Rate Community Plugin Api V1 Community Plugins  Plugin
                   Id  Rate Post
         '422':
@@ -4598,6 +4609,7 @@ paths:
           content:
             application/json:
               schema:
+                additionalProperties: true
                 type: object
                 title: Response Publish Detection Api V1 Community Detections Publish
                   Post
@@ -4681,6 +4693,7 @@ paths:
             application/json:
               schema:
                 type: object
+                additionalProperties: true
                 title: Response List Community Detections Api V1 Community Detections
                   Get
         '422':
@@ -4710,6 +4723,7 @@ paths:
             application/json:
               schema:
                 type: object
+                additionalProperties: true
                 title: Response Get Community Detection Api V1 Community Detections  Detection
                   Id  Get
         '422':
@@ -4762,6 +4776,7 @@ paths:
         content:
           application/json:
             schema:
+              additionalProperties: true
               type: object
               title: Definition
         required: true
@@ -4771,6 +4786,7 @@ paths:
           content:
             application/json:
               schema:
+                additionalProperties: true
                 type: object
                 title: Response Submit Playbook Api V1 Community Playbooks Submit
                   Post
@@ -4830,6 +4846,7 @@ paths:
             application/json:
               schema:
                 type: object
+                additionalProperties: true
                 title: Response List Community Playbooks Api V1 Community Playbooks
                   Get
         '422':
@@ -5074,6 +5091,7 @@ paths:
             application/json:
               schema:
                 type: object
+                additionalProperties: true
                 title: Response Uninstall Marketplace Item Api V1 Marketplace Install
                   Delete
         '422':
@@ -5095,6 +5113,7 @@ paths:
           content:
             application/json:
               schema:
+                additionalProperties: true
                 type: object
                 title: Response List Installed Api V1 Marketplace Installed Get
       security:
@@ -5117,6 +5136,7 @@ paths:
           content:
             application/json:
               schema:
+                additionalProperties: true
                 type: object
                 title: Response Mitre Coverage Api V1 Marketplace Mitre Get
       security:
@@ -5871,6 +5891,7 @@ paths:
             application/json:
               schema:
                 type: object
+                additionalProperties: true
                 title: Response Get Alert Trend Api V1 Metrics Alerts Trend Get
         '422':
           description: Validation Error
@@ -6663,6 +6684,7 @@ paths:
           content:
             application/json:
               schema:
+                additionalProperties: true
                 type: object
                 title: Response List Providers Api V1 Identity Effective Permissions
                   Providers Get
@@ -6716,6 +6738,7 @@ paths:
             application/json:
               schema:
                 type: object
+                additionalProperties: true
                 title: Response Get Effective Permissions Api V1 Identity  Principal
                   Id  Effective Permissions Get
         '422':
@@ -6796,6 +6819,7 @@ paths:
           content:
             application/json:
               schema:
+                additionalProperties: true
                 type: object
                 title: Response Get Public Key Api V1 Push Public Key Get
   /api/v1/push/subscribe:
@@ -6809,6 +6833,7 @@ paths:
         content:
           application/json:
             schema:
+              additionalProperties: true
               type: object
               title: Body
         required: true
@@ -6818,6 +6843,7 @@ paths:
           content:
             application/json:
               schema:
+                additionalProperties: true
                 type: object
                 title: Response Subscribe Api V1 Push Subscribe Post
         '422':
@@ -6839,6 +6865,7 @@ paths:
         content:
           application/json:
             schema:
+              additionalProperties: true
               type: object
               title: Body
         required: true
@@ -6848,6 +6875,7 @@ paths:
           content:
             application/json:
               schema:
+                additionalProperties: true
                 type: object
                 title: Response Unsubscribe Api V1 Push Unsubscribe Post
         '422':
@@ -6873,7 +6901,8 @@ paths:
           application/json:
             schema:
               anyOf:
-              - type: object
+              - additionalProperties: true
+                type: object
               - type: 'null'
               title: Body
       responses:
@@ -6882,6 +6911,7 @@ paths:
           content:
             application/json:
               schema:
+                additionalProperties: true
                 type: object
                 title: Response Test Notify Api V1 Push Test Post
         '422':
@@ -7192,6 +7222,7 @@ paths:
           content:
             application/json:
               schema:
+                additionalProperties: true
                 type: object
                 title: Response Passkey Register Begin Api V1 Passkeys Register Begin
                   Post
@@ -7259,6 +7290,7 @@ paths:
           content:
             application/json:
               schema:
+                additionalProperties: true
                 type: object
                 title: Response Passkey Authenticate Begin Api V1 Passkeys Authenticate
                   Begin Post
@@ -10780,6 +10812,7 @@ paths:
           content:
             application/json:
               schema:
+                additionalProperties: true
                 type: object
                 title: Response Trigger Easm Scan Api V1 Easm Scan Post
         '422':
@@ -10843,6 +10876,7 @@ paths:
                 type: array
                 items:
                   type: object
+                  additionalProperties: true
                 title: Response List External Assets Api V1 Easm Assets Get
         '422':
           description: Validation Error
@@ -10900,6 +10934,7 @@ paths:
                 type: array
                 items:
                   type: object
+                  additionalProperties: true
                 title: Response List External Asset Drift Api V1 Easm Drift Get
         '422':
           description: Validation Error
@@ -11481,6 +11516,7 @@ paths:
           content:
             application/json:
               schema:
+                additionalProperties: true
                 type: object
                 title: Response Get Airgap Status Api V1 Airgap Status Get
   /api/v1/llm/status:
@@ -11504,6 +11540,7 @@ paths:
           content:
             application/json:
               schema:
+                additionalProperties: true
                 type: object
                 title: Response Get Llm Status Api V1 Llm Status Get
   /api/v1/llm/credentials:
@@ -11992,6 +12029,7 @@ paths:
           content:
             application/json:
               schema:
+                additionalProperties: true
                 type: object
                 title: Response Fusion Health Api V1 Fusion Health Get
   /api/v1/fusion/metrics:
@@ -12006,6 +12044,7 @@ paths:
           content:
             application/json:
               schema:
+                additionalProperties: true
                 type: object
                 title: Response Fusion Metrics Api V1 Fusion Metrics Get
   /api/v1/fusion/ml/status:
@@ -12020,6 +12059,7 @@ paths:
           content:
             application/json:
               schema:
+                additionalProperties: true
                 type: object
                 title: Response Ml Status Api V1 Fusion Ml Status Get
   /api/v1/fusion/entity-risk/queue:
@@ -12059,6 +12099,7 @@ paths:
             application/json:
               schema:
                 type: object
+                additionalProperties: true
                 title: Response Entity Risk Queue Api V1 Fusion Entity Risk Queue
                   Get
         '422':
@@ -12088,6 +12129,7 @@ paths:
             application/json:
               schema:
                 type: object
+                additionalProperties: true
                 title: Response Entity Risk Stats Api V1 Fusion Entity Risk Stats
                   Get
         '422':
@@ -12129,6 +12171,7 @@ paths:
             application/json:
               schema:
                 type: object
+                additionalProperties: true
                 title: Response Entity Risk Detail Api V1 Fusion Entity Risk  Entity
                   Type   Entity Value  Get
         '422':
@@ -12868,6 +12911,7 @@ paths:
           content:
             application/json:
               schema:
+                additionalProperties: true
                 type: object
                 title: Response Health Check Health Get
   /metrics:
@@ -12980,6 +13024,7 @@ components:
       properties:
         findings:
           items:
+            additionalProperties: true
             type: object
           type: array
           minItems: 1
@@ -13053,6 +13098,7 @@ components:
           title: Description
           description: Human-readable summary of the verb, surfaced in tool prompts.
         input_schema:
+          additionalProperties: true
           type: object
           title: Input Schema
           description: JSON-Schema for the verb's arguments. Empty by default; concrete
@@ -13130,6 +13176,7 @@ components:
           title: Threat Intel Age Hours
         checks:
           items:
+            additionalProperties: true
             type: object
           type: array
           title: Checks
@@ -13732,6 +13779,7 @@ components:
       properties:
         events:
           items:
+            additionalProperties: true
             type: object
           type: array
           title: Events
@@ -13957,6 +14005,7 @@ components:
           title: Risk Level
           default: medium
         action:
+          additionalProperties: true
           type: object
           title: Action
         expires_at:
@@ -14066,6 +14115,7 @@ components:
           type: string
           title: Risk Level
         action:
+          additionalProperties: true
           type: object
           title: Action
         status:
@@ -14347,6 +14397,7 @@ components:
           - type: 'null'
           title: Owner Email
         metadata:
+          additionalProperties: true
           type: object
           title: Metadata
       type: object
@@ -14416,6 +14467,7 @@ components:
           - type: 'null'
           title: Owner Email
         metadata:
+          additionalProperties: true
           type: object
           title: Metadata
         id:
@@ -14439,6 +14491,7 @@ components:
           type: string
           title: First Seen
         asset_metadata:
+          additionalProperties: true
           type: object
           title: Asset Metadata
       type: object
@@ -14514,6 +14567,7 @@ components:
           - type: 'null'
           title: Owner Email
         metadata:
+          additionalProperties: true
           type: object
           title: Metadata
       type: object
@@ -14607,7 +14661,8 @@ components:
           title: Resource Id
         changes:
           anyOf:
-          - type: object
+          - additionalProperties: true
+            type: object
           - type: 'null'
           title: Changes
         created_at:
@@ -14728,6 +14783,7 @@ components:
           type: number
           title: Score
         payload:
+          additionalProperties: true
           type: object
           title: Payload
         is_active:
@@ -15037,10 +15093,12 @@ components:
           type: array
           title: Alert Ids
         observable_graph:
+          additionalProperties: true
           type: object
           title: Observable Graph
         evidence_chain:
           items:
+            additionalProperties: true
             type: object
           type: array
           title: Evidence Chain
@@ -15085,6 +15143,7 @@ components:
           - type: 'null'
           title: Created By
         tags:
+          additionalProperties: true
           type: object
           title: Tags
         sla_due_at:
@@ -15211,6 +15270,7 @@ components:
           minLength: 5
           title: Summary
         raw_payload:
+          additionalProperties: true
           type: object
           title: Raw Payload
         case_id:
@@ -15635,6 +15695,7 @@ components:
           type: boolean
           title: Is Enabled
         connector_config:
+          additionalProperties: true
           type: object
           title: Connector Config
         health_status:
@@ -15675,7 +15736,8 @@ components:
           title: Last Schema Drift At
         last_drift_details:
           anyOf:
-          - type: object
+          - additionalProperties: true
+            type: object
           - type: 'null'
           title: Last Drift Details
         last_event_at:
@@ -16098,6 +16160,7 @@ components:
           type: number
           title: Score
         payload:
+          additionalProperties: true
           type: object
           title: Payload
       type: object
@@ -16232,9 +16295,11 @@ components:
           title: Category
           description: Optional override; defaults to the catalog entry's category.
         auth_config:
+          additionalProperties: true
           type: object
           title: Auth Config
         connector_config:
+          additionalProperties: true
           type: object
           title: Connector Config
         tags:
@@ -16454,13 +16519,15 @@ components:
           minLength: 1
           title: Name
         filters:
+          additionalProperties: true
           type: object
           title: Filters
         columns:
           anyOf:
           - items: {}
             type: array
-          - type: object
+          - additionalProperties: true
+            type: object
           - type: 'null'
           title: Columns
         is_default:
@@ -17008,6 +17075,7 @@ components:
           - type: 'null'
           title: Valid Until
         evidence:
+          additionalProperties: true
           type: object
           title: Evidence
       type: object
@@ -17040,6 +17108,7 @@ components:
           - type: 'null'
           title: Valid Until
         evidence:
+          additionalProperties: true
           type: object
           title: Evidence
         id:
@@ -17140,6 +17209,7 @@ components:
           - type: 'null'
           title: Override Note
         parameter_overrides:
+          additionalProperties: true
           type: object
           title: Parameter Overrides
       type: object
@@ -17172,6 +17242,7 @@ components:
           - type: 'null'
         neighbors:
           items:
+            additionalProperties: true
             type: object
           type: array
           title: Neighbors
@@ -17189,6 +17260,7 @@ components:
     EvalAttachRequest:
       properties:
         eval_report:
+          additionalProperties: true
           type: object
           title: Eval Report
           description: Full JSON output of `python3 scripts/run_evals.py --baseline
@@ -17262,7 +17334,8 @@ components:
           title: Summary
         payload:
           anyOf:
-          - type: object
+          - additionalProperties: true
+            type: object
           - type: 'null'
           title: Payload
         input_hash:
@@ -17322,6 +17395,7 @@ components:
           title: Compliance Frameworks
         evidence_chain:
           items:
+            additionalProperties: true
             type: object
           type: array
           title: Evidence Chain
@@ -17371,6 +17445,7 @@ components:
           type: string
           title: Summary
         raw_payload:
+          additionalProperties: true
           type: object
           title: Raw Payload
         payload_hash:
@@ -17427,6 +17502,7 @@ components:
       properties:
         events:
           items:
+            additionalProperties: true
             type: object
           type: array
           maxItems: 1000
@@ -17459,6 +17535,7 @@ components:
           title: Match Count
         matched_events:
           items:
+            additionalProperties: true
             type: object
           type: array
           title: Matched Events
@@ -17685,6 +17762,7 @@ components:
       properties:
         rows:
           items:
+            additionalProperties: true
             type: object
           type: array
           title: Rows
@@ -17731,6 +17809,7 @@ components:
           title: Poll Interval
           default: 3600
         config:
+          additionalProperties: true
           type: object
           title: Config
       type: object
@@ -17761,6 +17840,7 @@ components:
           title: Poll Interval
           default: 3600
         config:
+          additionalProperties: true
           type: object
           title: Config
         id:
@@ -17847,6 +17927,7 @@ components:
           - type: 'null'
           title: Control Ids
         evidence:
+          additionalProperties: true
           type: object
           title: Evidence
         remediation_guide:
@@ -17918,6 +17999,7 @@ components:
           - type: 'null'
           title: Control Ids
         evidence:
+          additionalProperties: true
           type: object
           title: Evidence
         remediation_guide:
@@ -17967,6 +18049,7 @@ components:
     FinishRequest:
       properties:
         credential:
+          additionalProperties: true
           type: object
           title: Credential
         challenge:
@@ -18306,6 +18389,7 @@ components:
           type: string
           title: Label
         properties:
+          additionalProperties: true
           type: object
           title: Properties
       type: object
@@ -18354,6 +18438,7 @@ components:
           - type: 'null'
           title: Severity
         fields:
+          additionalProperties: true
           type: object
           title: Fields
       type: object
@@ -18381,6 +18466,7 @@ components:
           description: Filter rules by language (sigma, yara, kql, eql)
         events:
           items:
+            additionalProperties: true
             type: object
           type: array
           maxItems: 5000
@@ -18418,6 +18504,7 @@ components:
           title: Hit Count
         result_sample:
           items:
+            additionalProperties: true
             type: object
           type: array
           title: Result Sample
@@ -18511,6 +18598,7 @@ components:
           - type: 'null'
           title: Linked Alerts
         context:
+          additionalProperties: true
           type: object
           title: Context
       type: object
@@ -18586,6 +18674,7 @@ components:
           - type: 'null'
           title: Linked Alerts
         context:
+          additionalProperties: true
           type: object
           title: Context
         id:
@@ -18894,6 +18983,7 @@ components:
           - type: 'null'
           title: Source Alert Id
         evidence:
+          additionalProperties: true
           type: object
           title: Evidence
         occurred_at:
@@ -18953,6 +19043,7 @@ components:
           - type: 'null'
           title: Source Alert Id
         evidence:
+          additionalProperties: true
           type: object
           title: Evidence
         occurred_at:
@@ -19598,7 +19689,8 @@ components:
           title: Api Key
         settings:
           anyOf:
-          - type: object
+          - additionalProperties: true
+            type: object
           - type: 'null'
           title: Settings
         enabled:
@@ -19650,6 +19742,7 @@ components:
           type: boolean
           title: Has Api Key
         settings:
+          additionalProperties: true
           type: object
           title: Settings
         enabled:
@@ -19844,9 +19937,11 @@ components:
           type: integer
           title: Total
         stats:
+          additionalProperties: true
           type: object
           title: Stats
         mitre_coverage:
+          additionalProperties: true
           type: object
           title: Mitre Coverage
         items:
@@ -19875,6 +19970,7 @@ components:
           minimum: 0.0
           title: Maturity Tier
         action_overrides:
+          additionalProperties: true
           type: object
           title: Action Overrides
       type: object
@@ -19895,6 +19991,7 @@ components:
           type: integer
           title: Maturity Tier
         action_overrides:
+          additionalProperties: true
           type: object
           title: Action Overrides
         changed_at:
@@ -19981,7 +20078,8 @@ components:
           description: One-line description, plain text
         payload:
           anyOf:
-          - type: object
+          - additionalProperties: true
+            type: object
           - type: 'null'
           title: Payload
         duration_ms:
@@ -20045,6 +20143,7 @@ components:
     MispDryRunResponse:
       properties:
         event:
+          additionalProperties: true
           type: object
           title: Event
         attribute_count:
@@ -20617,6 +20716,7 @@ components:
           - type: 'null'
           title: Last Activity
         attributes:
+          additionalProperties: true
           type: object
           title: Attributes
       type: object
@@ -20656,6 +20756,7 @@ components:
           - type: 'null'
           title: Last Activity
         attributes:
+          additionalProperties: true
           type: object
           title: Attributes
         id:
@@ -20950,6 +21051,7 @@ components:
           - type: 'null'
           title: Created At
         value:
+          additionalProperties: true
           type: object
           title: Value
       type: object
@@ -20996,6 +21098,7 @@ components:
           title: Enabled
           default: true
         parameter_overrides:
+          additionalProperties: true
           type: object
           title: Parameter Overrides
           default: {}
@@ -21021,6 +21124,7 @@ components:
           type: boolean
           title: Enabled
         parameter_overrides:
+          additionalProperties: true
           type: object
           title: Parameter Overrides
         created_at:
@@ -21082,6 +21186,7 @@ components:
           - type: 'null'
           title: Description
         criteria:
+          additionalProperties: true
           type: object
           title: Criteria
       type: object
@@ -21099,6 +21204,7 @@ components:
           - type: 'null'
           title: Description
         criteria:
+          additionalProperties: true
           type: object
           title: Criteria
         id:
@@ -21231,6 +21337,7 @@ components:
           type: array
           title: Tags
         config_schema:
+          additionalProperties: true
           type: object
           title: Config Schema
       type: object
@@ -21310,6 +21417,7 @@ components:
     PreferencesPatch:
       properties:
         preferences:
+          additionalProperties: true
           type: object
           title: Preferences
       type: object
@@ -21325,6 +21433,7 @@ components:
           title: Yaml
         alerts:
           items:
+            additionalProperties: true
             type: object
           type: array
           title: Alerts
@@ -21370,9 +21479,11 @@ components:
           type: array
           title: Matched Rule Ids
         before:
+          additionalProperties: true
           type: object
           title: Before
         after:
+          additionalProperties: true
           type: object
           title: After
         suppressed:
@@ -21453,6 +21564,7 @@ components:
           type: string
           title: Status
         eval_result:
+          additionalProperties: true
           type: object
           title: Eval Result
         review_comments:
@@ -22283,6 +22395,7 @@ components:
           - type: 'null'
           title: Severity Override
         parameter_overrides:
+          additionalProperties: true
           type: object
           title: Parameter Overrides
           default: {}
@@ -22324,6 +22437,7 @@ components:
           - type: 'null'
           title: Severity Override
         parameter_overrides:
+          additionalProperties: true
           type: object
           title: Parameter Overrides
         created_at:
@@ -22623,6 +22737,7 @@ components:
     RunEvalResponse:
       properties:
         report:
+          additionalProperties: true
           type: object
           title: Report
         exit_code:
@@ -22662,10 +22777,12 @@ components:
     RunRequest:
       properties:
         payload:
+          additionalProperties: true
           type: object
           title: Payload
           default: {}
         context:
+          additionalProperties: true
           type: object
           title: Context
           default: {}
@@ -22677,6 +22794,7 @@ components:
           type: string
           title: Plugin Id
         result:
+          additionalProperties: true
           type: object
           title: Result
       type: object
@@ -22851,6 +22969,7 @@ components:
           - type: 'null'
           title: Occurred At
         metadata:
+          additionalProperties: true
           type: object
           title: Metadata
       type: object
@@ -22880,6 +22999,7 @@ components:
           format: date-time
           title: Occurred At
         metadata:
+          additionalProperties: true
           type: object
           title: Metadata
       type: object
@@ -23004,6 +23124,7 @@ components:
           title: Created
         objects:
           items:
+            additionalProperties: true
             type: object
           type: array
           title: Objects
@@ -23017,6 +23138,7 @@ components:
       properties:
         objects:
           items:
+            additionalProperties: true
             type: object
           type: array
           title: Objects
@@ -23042,6 +23164,7 @@ components:
           title: Created
         objects:
           items:
+            additionalProperties: true
             type: object
           type: array
           title: Objects
@@ -23314,13 +23437,15 @@ components:
           type: string
           title: Name
         filters:
+          additionalProperties: true
           type: object
           title: Filters
         columns:
           anyOf:
           - items: {}
             type: array
-          - type: object
+          - additionalProperties: true
+            type: object
           - type: 'null'
           title: Columns
         is_default:
@@ -23614,6 +23739,7 @@ components:
           title: Confidence
         indicators:
           items:
+            additionalProperties: true
             type: object
           type: array
           title: Indicators
@@ -23910,6 +24036,7 @@ components:
           default: UTC
         sections:
           items:
+            additionalProperties: true
             type: object
           type: array
           title: Sections
@@ -23948,6 +24075,7 @@ components:
           default: UTC
         sections:
           items:
+            additionalProperties: true
             type: object
           type: array
           title: Sections
@@ -24231,9 +24359,11 @@ components:
           type: boolean
           title: Is Active
         settings:
+          additionalProperties: true
           type: object
           title: Settings
         limits:
+          additionalProperties: true
           type: object
           title: Limits
         mssp_role:
@@ -24288,9 +24418,11 @@ components:
           minLength: 1
           title: Connector Type
         auth_config:
+          additionalProperties: true
           type: object
           title: Auth Config
         connector_config:
+          additionalProperties: true
           type: object
           title: Connector Config
       type: object
@@ -24383,6 +24515,7 @@ components:
           - type: 'null'
           title: Last Activity
         context:
+          additionalProperties: true
           type: object
           title: Context
       type: object
@@ -24448,6 +24581,7 @@ components:
           - type: 'null'
           title: Last Activity
         context:
+          additionalProperties: true
           type: object
           title: Context
         id:
@@ -24573,7 +24707,8 @@ components:
           title: Tool Name
         tool_args:
           anyOf:
-          - type: object
+          - additionalProperties: true
+            type: object
           - type: 'null'
           title: Tool Args
         tool_result_summary:
@@ -25295,12 +25430,14 @@ components:
           title: Is Enabled
         auth_config:
           anyOf:
-          - type: object
+          - additionalProperties: true
+            type: object
           - type: 'null'
           title: Auth Config
         connector_config:
           anyOf:
-          - type: object
+          - additionalProperties: true
+            type: object
           - type: 'null'
           title: Connector Config
         tags:
@@ -25408,14 +25545,16 @@ components:
           title: Name
         filters:
           anyOf:
-          - type: object
+          - additionalProperties: true
+            type: object
           - type: 'null'
           title: Filters
         columns:
           anyOf:
           - items: {}
             type: array
-          - type: object
+          - additionalProperties: true
+            type: object
           - type: 'null'
           title: Columns
         is_default:
@@ -25468,6 +25607,7 @@ components:
     UpdateTenantSettingsRequest:
       properties:
         settings:
+          additionalProperties: true
           type: object
           title: Settings
           default: {}
@@ -25624,6 +25764,7 @@ components:
           type: boolean
           title: Is Active
         preferences:
+          additionalProperties: true
           type: object
           title: Preferences
           default: {}
@@ -25728,6 +25869,11 @@ components:
         type:
           type: string
           title: Error Type
+        input:
+          title: Input
+        ctx:
+          type: object
+          title: Context
       type: object
       required:
       - loc
@@ -25785,6 +25931,7 @@ components:
           - type: 'null'
           title: External Id
         metadata:
+          additionalProperties: true
           type: object
           title: Metadata
       type: object
@@ -25844,6 +25991,7 @@ components:
           - type: 'null'
           title: External Id
         metadata:
+          additionalProperties: true
           type: object
           title: Metadata
         id:
@@ -25866,6 +26014,7 @@ components:
           - type: 'null'
           title: Remediated At
         asset_metadata:
+          additionalProperties: true
           type: object
           title: Asset Metadata
       type: object
@@ -26044,6 +26193,7 @@ components:
           type: string
           title: Blast Radius
         constraints:
+          additionalProperties: true
           type: object
           title: Constraints
         expires_at:
@@ -26066,6 +26216,7 @@ components:
           type: string
           title: Blast Radius
         constraints:
+          additionalProperties: true
           type: object
           title: Constraints
         expires_at:
@@ -26169,11 +26320,13 @@ components:
           title: Total Events Scanned
         matched_events:
           items:
+            additionalProperties: true
             type: object
           type: array
           title: Matched Events
         match_summary:
           items:
+            additionalProperties: true
             type: object
           type: array
           title: Match Summary
@@ -26282,6 +26435,7 @@ components:
           title: Query Kql
         findings:
           items:
+            additionalProperties: true
             type: object
           type: array
           title: Findings
@@ -26378,7 +26532,8 @@ components:
           title: Mitre Technique
         raw:
           anyOf:
-          - type: object
+          - additionalProperties: true
+            type: object
           - type: 'null'
           title: Raw
       type: object

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -743,7 +743,6 @@ paths:
             application/json:
               schema:
                 type: object
-                additionalProperties: true
                 title: Response Explain Alert Api V1 Alerts  Alert Id  Explain Post
         '422':
           description: Validation Error
@@ -1289,7 +1288,6 @@ paths:
             application/json:
               schema:
                 type: object
-                additionalProperties: true
                 title: Response Case Investigate Api V1 Cases  Case Id  Investigate
                   Post
         '422':
@@ -1326,7 +1324,6 @@ paths:
             application/json:
               schema:
                 type: object
-                additionalProperties: true
                 title: Response List Case Investigations Api V1 Cases  Case Id  Investigations
                   Get
         '422':
@@ -1363,7 +1360,6 @@ paths:
             application/json:
               schema:
                 type: object
-                additionalProperties: true
                 title: Response Case Investigation Run Api V1 Cases  Case Id  Investigations  Run
                   Id  Get
         '422':
@@ -1532,7 +1528,6 @@ paths:
             application/json:
               schema:
                 type: object
-                additionalProperties: true
                 title: Response List Related Cases Api V1 Cases  Case Id  Related
                   Get
         '422':
@@ -1586,7 +1581,6 @@ paths:
             application/json:
               schema:
                 type: object
-                additionalProperties: true
                 title: Response Get Attack Chain Api V1 Cases  Case Id  Attack Chain
                   Get
         '422':
@@ -1617,7 +1611,6 @@ paths:
           content:
             application/json:
               schema:
-                additionalProperties: true
                 type: object
                 title: Response List Catalog Api V1 Connectors Catalog Get
       security:
@@ -1675,7 +1668,6 @@ paths:
           content:
             application/json:
               schema:
-                additionalProperties: true
                 type: object
                 title: Response Test Connection Api V1 Connectors Test Post
         '422':
@@ -1921,7 +1913,6 @@ paths:
             application/json:
               schema:
                 type: object
-                additionalProperties: true
                 title: Response Test Existing Connector Api V1 Connectors  Connector
                   Id  Test Post
         '422':
@@ -4367,7 +4358,6 @@ paths:
           content:
             application/json:
               schema:
-                additionalProperties: true
                 type: object
                 title: Response Publish Plugin Api V1 Community Plugins Publish Post
       security:
@@ -4541,7 +4531,6 @@ paths:
             application/json:
               schema:
                 type: object
-                additionalProperties: true
                 title: Response Rate Community Plugin Api V1 Community Plugins  Plugin
                   Id  Rate Post
         '422':
@@ -4609,7 +4598,6 @@ paths:
           content:
             application/json:
               schema:
-                additionalProperties: true
                 type: object
                 title: Response Publish Detection Api V1 Community Detections Publish
                   Post
@@ -4693,7 +4681,6 @@ paths:
             application/json:
               schema:
                 type: object
-                additionalProperties: true
                 title: Response List Community Detections Api V1 Community Detections
                   Get
         '422':
@@ -4723,7 +4710,6 @@ paths:
             application/json:
               schema:
                 type: object
-                additionalProperties: true
                 title: Response Get Community Detection Api V1 Community Detections  Detection
                   Id  Get
         '422':
@@ -4776,7 +4762,6 @@ paths:
         content:
           application/json:
             schema:
-              additionalProperties: true
               type: object
               title: Definition
         required: true
@@ -4786,7 +4771,6 @@ paths:
           content:
             application/json:
               schema:
-                additionalProperties: true
                 type: object
                 title: Response Submit Playbook Api V1 Community Playbooks Submit
                   Post
@@ -4846,7 +4830,6 @@ paths:
             application/json:
               schema:
                 type: object
-                additionalProperties: true
                 title: Response List Community Playbooks Api V1 Community Playbooks
                   Get
         '422':
@@ -5091,7 +5074,6 @@ paths:
             application/json:
               schema:
                 type: object
-                additionalProperties: true
                 title: Response Uninstall Marketplace Item Api V1 Marketplace Install
                   Delete
         '422':
@@ -5113,7 +5095,6 @@ paths:
           content:
             application/json:
               schema:
-                additionalProperties: true
                 type: object
                 title: Response List Installed Api V1 Marketplace Installed Get
       security:
@@ -5136,7 +5117,6 @@ paths:
           content:
             application/json:
               schema:
-                additionalProperties: true
                 type: object
                 title: Response Mitre Coverage Api V1 Marketplace Mitre Get
       security:
@@ -5891,7 +5871,6 @@ paths:
             application/json:
               schema:
                 type: object
-                additionalProperties: true
                 title: Response Get Alert Trend Api V1 Metrics Alerts Trend Get
         '422':
           description: Validation Error
@@ -6684,7 +6663,6 @@ paths:
           content:
             application/json:
               schema:
-                additionalProperties: true
                 type: object
                 title: Response List Providers Api V1 Identity Effective Permissions
                   Providers Get
@@ -6738,7 +6716,6 @@ paths:
             application/json:
               schema:
                 type: object
-                additionalProperties: true
                 title: Response Get Effective Permissions Api V1 Identity  Principal
                   Id  Effective Permissions Get
         '422':
@@ -6819,7 +6796,6 @@ paths:
           content:
             application/json:
               schema:
-                additionalProperties: true
                 type: object
                 title: Response Get Public Key Api V1 Push Public Key Get
   /api/v1/push/subscribe:
@@ -6833,7 +6809,6 @@ paths:
         content:
           application/json:
             schema:
-              additionalProperties: true
               type: object
               title: Body
         required: true
@@ -6843,7 +6818,6 @@ paths:
           content:
             application/json:
               schema:
-                additionalProperties: true
                 type: object
                 title: Response Subscribe Api V1 Push Subscribe Post
         '422':
@@ -6865,7 +6839,6 @@ paths:
         content:
           application/json:
             schema:
-              additionalProperties: true
               type: object
               title: Body
         required: true
@@ -6875,7 +6848,6 @@ paths:
           content:
             application/json:
               schema:
-                additionalProperties: true
                 type: object
                 title: Response Unsubscribe Api V1 Push Unsubscribe Post
         '422':
@@ -6901,8 +6873,7 @@ paths:
           application/json:
             schema:
               anyOf:
-              - additionalProperties: true
-                type: object
+              - type: object
               - type: 'null'
               title: Body
       responses:
@@ -6911,7 +6882,6 @@ paths:
           content:
             application/json:
               schema:
-                additionalProperties: true
                 type: object
                 title: Response Test Notify Api V1 Push Test Post
         '422':
@@ -7222,7 +7192,6 @@ paths:
           content:
             application/json:
               schema:
-                additionalProperties: true
                 type: object
                 title: Response Passkey Register Begin Api V1 Passkeys Register Begin
                   Post
@@ -7290,7 +7259,6 @@ paths:
           content:
             application/json:
               schema:
-                additionalProperties: true
                 type: object
                 title: Response Passkey Authenticate Begin Api V1 Passkeys Authenticate
                   Begin Post
@@ -9317,8 +9285,15 @@ paths:
       - detection_rules
       - detection_loop
       summary: Draft Sigma improvement for a FP alert
-      description: Retrieve the triggering rule + alert evidence, then draft a Sigma
+      description: 'Retrieve the triggering rule + alert evidence, then draft a Sigma
         improvement.
+
+
+        Tenant isolation: the alert and rule lookups are scoped to ``user.tenant_id``
+
+        so a caller cannot pull another tenant''s evidence by guessing an ``alert_id``.
+
+        ``TenantDBSession`` also sets the Postgres RLS context for defense in depth.'
       operationId: suggest_fp_fix_api_v1_detection_loop_suggest_post
       requestBody:
         content:
@@ -9347,6 +9322,14 @@ paths:
       - detection_rules
       - detection_loop
       summary: List LLM-drafted Sigma suggestions
+      description: 'List suggestions drafted by *this* tenant only.
+
+
+        Tenant isolation: ``_SUGGESTIONS`` is process-wide and shared across all
+
+        tenants. Filtering on the stored ``tenant_id`` ensures one tenant never
+
+        sees another tenant''s drafts, rule names, or evidence-derived rationale.'
       operationId: list_suggestions_api_v1_detection_loop_suggestions_get
       responses:
         '200':
@@ -9363,6 +9346,13 @@ paths:
       - detection_rules
       - detection_loop
       summary: Get one Sigma suggestion
+      description: 'Return one suggestion if and only if it belongs to the caller''s
+        tenant.
+
+
+        Tenant isolation: a cross-tenant lookup returns 404 (not 403) to avoid
+
+        leaking the existence of a suggestion that belongs to another tenant.'
       operationId: get_suggestion_api_v1_detection_loop_suggestions__suggestion_id__get
       security:
       - HTTPBearer: []
@@ -10790,7 +10780,6 @@ paths:
           content:
             application/json:
               schema:
-                additionalProperties: true
                 type: object
                 title: Response Trigger Easm Scan Api V1 Easm Scan Post
         '422':
@@ -10854,7 +10843,6 @@ paths:
                 type: array
                 items:
                   type: object
-                  additionalProperties: true
                 title: Response List External Assets Api V1 Easm Assets Get
         '422':
           description: Validation Error
@@ -10912,7 +10900,6 @@ paths:
                 type: array
                 items:
                   type: object
-                  additionalProperties: true
                 title: Response List External Asset Drift Api V1 Easm Drift Get
         '422':
           description: Validation Error
@@ -11494,7 +11481,6 @@ paths:
           content:
             application/json:
               schema:
-                additionalProperties: true
                 type: object
                 title: Response Get Airgap Status Api V1 Airgap Status Get
   /api/v1/llm/status:
@@ -11518,7 +11504,6 @@ paths:
           content:
             application/json:
               schema:
-                additionalProperties: true
                 type: object
                 title: Response Get Llm Status Api V1 Llm Status Get
   /api/v1/llm/credentials:
@@ -12007,7 +11992,6 @@ paths:
           content:
             application/json:
               schema:
-                additionalProperties: true
                 type: object
                 title: Response Fusion Health Api V1 Fusion Health Get
   /api/v1/fusion/metrics:
@@ -12022,7 +12006,6 @@ paths:
           content:
             application/json:
               schema:
-                additionalProperties: true
                 type: object
                 title: Response Fusion Metrics Api V1 Fusion Metrics Get
   /api/v1/fusion/ml/status:
@@ -12037,7 +12020,6 @@ paths:
           content:
             application/json:
               schema:
-                additionalProperties: true
                 type: object
                 title: Response Ml Status Api V1 Fusion Ml Status Get
   /api/v1/fusion/entity-risk/queue:
@@ -12077,7 +12059,6 @@ paths:
             application/json:
               schema:
                 type: object
-                additionalProperties: true
                 title: Response Entity Risk Queue Api V1 Fusion Entity Risk Queue
                   Get
         '422':
@@ -12107,7 +12088,6 @@ paths:
             application/json:
               schema:
                 type: object
-                additionalProperties: true
                 title: Response Entity Risk Stats Api V1 Fusion Entity Risk Stats
                   Get
         '422':
@@ -12149,7 +12129,6 @@ paths:
             application/json:
               schema:
                 type: object
-                additionalProperties: true
                 title: Response Entity Risk Detail Api V1 Fusion Entity Risk  Entity
                   Type   Entity Value  Get
         '422':
@@ -12889,7 +12868,6 @@ paths:
           content:
             application/json:
               schema:
-                additionalProperties: true
                 type: object
                 title: Response Health Check Health Get
   /metrics:
@@ -13002,7 +12980,6 @@ components:
       properties:
         findings:
           items:
-            additionalProperties: true
             type: object
           type: array
           minItems: 1
@@ -13076,7 +13053,6 @@ components:
           title: Description
           description: Human-readable summary of the verb, surfaced in tool prompts.
         input_schema:
-          additionalProperties: true
           type: object
           title: Input Schema
           description: JSON-Schema for the verb's arguments. Empty by default; concrete
@@ -13154,7 +13130,6 @@ components:
           title: Threat Intel Age Hours
         checks:
           items:
-            additionalProperties: true
             type: object
           type: array
           title: Checks
@@ -13757,7 +13732,6 @@ components:
       properties:
         events:
           items:
-            additionalProperties: true
             type: object
           type: array
           title: Events
@@ -13983,7 +13957,6 @@ components:
           title: Risk Level
           default: medium
         action:
-          additionalProperties: true
           type: object
           title: Action
         expires_at:
@@ -14093,7 +14066,6 @@ components:
           type: string
           title: Risk Level
         action:
-          additionalProperties: true
           type: object
           title: Action
         status:
@@ -14375,7 +14347,6 @@ components:
           - type: 'null'
           title: Owner Email
         metadata:
-          additionalProperties: true
           type: object
           title: Metadata
       type: object
@@ -14445,7 +14416,6 @@ components:
           - type: 'null'
           title: Owner Email
         metadata:
-          additionalProperties: true
           type: object
           title: Metadata
         id:
@@ -14469,7 +14439,6 @@ components:
           type: string
           title: First Seen
         asset_metadata:
-          additionalProperties: true
           type: object
           title: Asset Metadata
       type: object
@@ -14545,7 +14514,6 @@ components:
           - type: 'null'
           title: Owner Email
         metadata:
-          additionalProperties: true
           type: object
           title: Metadata
       type: object
@@ -14639,8 +14607,7 @@ components:
           title: Resource Id
         changes:
           anyOf:
-          - additionalProperties: true
-            type: object
+          - type: object
           - type: 'null'
           title: Changes
         created_at:
@@ -14761,7 +14728,6 @@ components:
           type: number
           title: Score
         payload:
-          additionalProperties: true
           type: object
           title: Payload
         is_active:
@@ -15071,12 +15037,10 @@ components:
           type: array
           title: Alert Ids
         observable_graph:
-          additionalProperties: true
           type: object
           title: Observable Graph
         evidence_chain:
           items:
-            additionalProperties: true
             type: object
           type: array
           title: Evidence Chain
@@ -15121,7 +15085,6 @@ components:
           - type: 'null'
           title: Created By
         tags:
-          additionalProperties: true
           type: object
           title: Tags
         sla_due_at:
@@ -15248,7 +15211,6 @@ components:
           minLength: 5
           title: Summary
         raw_payload:
-          additionalProperties: true
           type: object
           title: Raw Payload
         case_id:
@@ -15673,7 +15635,6 @@ components:
           type: boolean
           title: Is Enabled
         connector_config:
-          additionalProperties: true
           type: object
           title: Connector Config
         health_status:
@@ -15714,8 +15675,7 @@ components:
           title: Last Schema Drift At
         last_drift_details:
           anyOf:
-          - additionalProperties: true
-            type: object
+          - type: object
           - type: 'null'
           title: Last Drift Details
         last_event_at:
@@ -16138,7 +16098,6 @@ components:
           type: number
           title: Score
         payload:
-          additionalProperties: true
           type: object
           title: Payload
       type: object
@@ -16273,11 +16232,9 @@ components:
           title: Category
           description: Optional override; defaults to the catalog entry's category.
         auth_config:
-          additionalProperties: true
           type: object
           title: Auth Config
         connector_config:
-          additionalProperties: true
           type: object
           title: Connector Config
         tags:
@@ -16497,15 +16454,13 @@ components:
           minLength: 1
           title: Name
         filters:
-          additionalProperties: true
           type: object
           title: Filters
         columns:
           anyOf:
           - items: {}
             type: array
-          - additionalProperties: true
-            type: object
+          - type: object
           - type: 'null'
           title: Columns
         is_default:
@@ -17053,7 +17008,6 @@ components:
           - type: 'null'
           title: Valid Until
         evidence:
-          additionalProperties: true
           type: object
           title: Evidence
       type: object
@@ -17086,7 +17040,6 @@ components:
           - type: 'null'
           title: Valid Until
         evidence:
-          additionalProperties: true
           type: object
           title: Evidence
         id:
@@ -17187,7 +17140,6 @@ components:
           - type: 'null'
           title: Override Note
         parameter_overrides:
-          additionalProperties: true
           type: object
           title: Parameter Overrides
       type: object
@@ -17220,7 +17172,6 @@ components:
           - type: 'null'
         neighbors:
           items:
-            additionalProperties: true
             type: object
           type: array
           title: Neighbors
@@ -17238,7 +17189,6 @@ components:
     EvalAttachRequest:
       properties:
         eval_report:
-          additionalProperties: true
           type: object
           title: Eval Report
           description: Full JSON output of `python3 scripts/run_evals.py --baseline
@@ -17312,8 +17262,7 @@ components:
           title: Summary
         payload:
           anyOf:
-          - additionalProperties: true
-            type: object
+          - type: object
           - type: 'null'
           title: Payload
         input_hash:
@@ -17373,7 +17322,6 @@ components:
           title: Compliance Frameworks
         evidence_chain:
           items:
-            additionalProperties: true
             type: object
           type: array
           title: Evidence Chain
@@ -17423,7 +17371,6 @@ components:
           type: string
           title: Summary
         raw_payload:
-          additionalProperties: true
           type: object
           title: Raw Payload
         payload_hash:
@@ -17480,7 +17427,6 @@ components:
       properties:
         events:
           items:
-            additionalProperties: true
             type: object
           type: array
           maxItems: 1000
@@ -17513,7 +17459,6 @@ components:
           title: Match Count
         matched_events:
           items:
-            additionalProperties: true
             type: object
           type: array
           title: Matched Events
@@ -17740,7 +17685,6 @@ components:
       properties:
         rows:
           items:
-            additionalProperties: true
             type: object
           type: array
           title: Rows
@@ -17787,7 +17731,6 @@ components:
           title: Poll Interval
           default: 3600
         config:
-          additionalProperties: true
           type: object
           title: Config
       type: object
@@ -17818,7 +17761,6 @@ components:
           title: Poll Interval
           default: 3600
         config:
-          additionalProperties: true
           type: object
           title: Config
         id:
@@ -17905,7 +17847,6 @@ components:
           - type: 'null'
           title: Control Ids
         evidence:
-          additionalProperties: true
           type: object
           title: Evidence
         remediation_guide:
@@ -17977,7 +17918,6 @@ components:
           - type: 'null'
           title: Control Ids
         evidence:
-          additionalProperties: true
           type: object
           title: Evidence
         remediation_guide:
@@ -18027,7 +17967,6 @@ components:
     FinishRequest:
       properties:
         credential:
-          additionalProperties: true
           type: object
           title: Credential
         challenge:
@@ -18367,7 +18306,6 @@ components:
           type: string
           title: Label
         properties:
-          additionalProperties: true
           type: object
           title: Properties
       type: object
@@ -18416,7 +18354,6 @@ components:
           - type: 'null'
           title: Severity
         fields:
-          additionalProperties: true
           type: object
           title: Fields
       type: object
@@ -18444,7 +18381,6 @@ components:
           description: Filter rules by language (sigma, yara, kql, eql)
         events:
           items:
-            additionalProperties: true
             type: object
           type: array
           maxItems: 5000
@@ -18482,7 +18418,6 @@ components:
           title: Hit Count
         result_sample:
           items:
-            additionalProperties: true
             type: object
           type: array
           title: Result Sample
@@ -18576,7 +18511,6 @@ components:
           - type: 'null'
           title: Linked Alerts
         context:
-          additionalProperties: true
           type: object
           title: Context
       type: object
@@ -18652,7 +18586,6 @@ components:
           - type: 'null'
           title: Linked Alerts
         context:
-          additionalProperties: true
           type: object
           title: Context
         id:
@@ -18961,7 +18894,6 @@ components:
           - type: 'null'
           title: Source Alert Id
         evidence:
-          additionalProperties: true
           type: object
           title: Evidence
         occurred_at:
@@ -19021,7 +18953,6 @@ components:
           - type: 'null'
           title: Source Alert Id
         evidence:
-          additionalProperties: true
           type: object
           title: Evidence
         occurred_at:
@@ -19667,8 +19598,7 @@ components:
           title: Api Key
         settings:
           anyOf:
-          - additionalProperties: true
-            type: object
+          - type: object
           - type: 'null'
           title: Settings
         enabled:
@@ -19720,7 +19650,6 @@ components:
           type: boolean
           title: Has Api Key
         settings:
-          additionalProperties: true
           type: object
           title: Settings
         enabled:
@@ -19915,11 +19844,9 @@ components:
           type: integer
           title: Total
         stats:
-          additionalProperties: true
           type: object
           title: Stats
         mitre_coverage:
-          additionalProperties: true
           type: object
           title: Mitre Coverage
         items:
@@ -19948,7 +19875,6 @@ components:
           minimum: 0.0
           title: Maturity Tier
         action_overrides:
-          additionalProperties: true
           type: object
           title: Action Overrides
       type: object
@@ -19969,7 +19895,6 @@ components:
           type: integer
           title: Maturity Tier
         action_overrides:
-          additionalProperties: true
           type: object
           title: Action Overrides
         changed_at:
@@ -20056,8 +19981,7 @@ components:
           description: One-line description, plain text
         payload:
           anyOf:
-          - additionalProperties: true
-            type: object
+          - type: object
           - type: 'null'
           title: Payload
         duration_ms:
@@ -20121,7 +20045,6 @@ components:
     MispDryRunResponse:
       properties:
         event:
-          additionalProperties: true
           type: object
           title: Event
         attribute_count:
@@ -20694,7 +20617,6 @@ components:
           - type: 'null'
           title: Last Activity
         attributes:
-          additionalProperties: true
           type: object
           title: Attributes
       type: object
@@ -20734,7 +20656,6 @@ components:
           - type: 'null'
           title: Last Activity
         attributes:
-          additionalProperties: true
           type: object
           title: Attributes
         id:
@@ -21029,7 +20950,6 @@ components:
           - type: 'null'
           title: Created At
         value:
-          additionalProperties: true
           type: object
           title: Value
       type: object
@@ -21076,7 +20996,6 @@ components:
           title: Enabled
           default: true
         parameter_overrides:
-          additionalProperties: true
           type: object
           title: Parameter Overrides
           default: {}
@@ -21102,7 +21021,6 @@ components:
           type: boolean
           title: Enabled
         parameter_overrides:
-          additionalProperties: true
           type: object
           title: Parameter Overrides
         created_at:
@@ -21164,7 +21082,6 @@ components:
           - type: 'null'
           title: Description
         criteria:
-          additionalProperties: true
           type: object
           title: Criteria
       type: object
@@ -21182,7 +21099,6 @@ components:
           - type: 'null'
           title: Description
         criteria:
-          additionalProperties: true
           type: object
           title: Criteria
         id:
@@ -21315,7 +21231,6 @@ components:
           type: array
           title: Tags
         config_schema:
-          additionalProperties: true
           type: object
           title: Config Schema
       type: object
@@ -21395,7 +21310,6 @@ components:
     PreferencesPatch:
       properties:
         preferences:
-          additionalProperties: true
           type: object
           title: Preferences
       type: object
@@ -21411,7 +21325,6 @@ components:
           title: Yaml
         alerts:
           items:
-            additionalProperties: true
             type: object
           type: array
           title: Alerts
@@ -21457,11 +21370,9 @@ components:
           type: array
           title: Matched Rule Ids
         before:
-          additionalProperties: true
           type: object
           title: Before
         after:
-          additionalProperties: true
           type: object
           title: After
         suppressed:
@@ -21542,7 +21453,6 @@ components:
           type: string
           title: Status
         eval_result:
-          additionalProperties: true
           type: object
           title: Eval Result
         review_comments:
@@ -22373,7 +22283,6 @@ components:
           - type: 'null'
           title: Severity Override
         parameter_overrides:
-          additionalProperties: true
           type: object
           title: Parameter Overrides
           default: {}
@@ -22415,7 +22324,6 @@ components:
           - type: 'null'
           title: Severity Override
         parameter_overrides:
-          additionalProperties: true
           type: object
           title: Parameter Overrides
         created_at:
@@ -22715,7 +22623,6 @@ components:
     RunEvalResponse:
       properties:
         report:
-          additionalProperties: true
           type: object
           title: Report
         exit_code:
@@ -22755,12 +22662,10 @@ components:
     RunRequest:
       properties:
         payload:
-          additionalProperties: true
           type: object
           title: Payload
           default: {}
         context:
-          additionalProperties: true
           type: object
           title: Context
           default: {}
@@ -22772,7 +22677,6 @@ components:
           type: string
           title: Plugin Id
         result:
-          additionalProperties: true
           type: object
           title: Result
       type: object
@@ -22947,7 +22851,6 @@ components:
           - type: 'null'
           title: Occurred At
         metadata:
-          additionalProperties: true
           type: object
           title: Metadata
       type: object
@@ -22977,7 +22880,6 @@ components:
           format: date-time
           title: Occurred At
         metadata:
-          additionalProperties: true
           type: object
           title: Metadata
       type: object
@@ -23102,7 +23004,6 @@ components:
           title: Created
         objects:
           items:
-            additionalProperties: true
             type: object
           type: array
           title: Objects
@@ -23116,7 +23017,6 @@ components:
       properties:
         objects:
           items:
-            additionalProperties: true
             type: object
           type: array
           title: Objects
@@ -23142,7 +23042,6 @@ components:
           title: Created
         objects:
           items:
-            additionalProperties: true
             type: object
           type: array
           title: Objects
@@ -23415,15 +23314,13 @@ components:
           type: string
           title: Name
         filters:
-          additionalProperties: true
           type: object
           title: Filters
         columns:
           anyOf:
           - items: {}
             type: array
-          - additionalProperties: true
-            type: object
+          - type: object
           - type: 'null'
           title: Columns
         is_default:
@@ -23717,7 +23614,6 @@ components:
           title: Confidence
         indicators:
           items:
-            additionalProperties: true
             type: object
           type: array
           title: Indicators
@@ -24014,7 +23910,6 @@ components:
           default: UTC
         sections:
           items:
-            additionalProperties: true
             type: object
           type: array
           title: Sections
@@ -24053,7 +23948,6 @@ components:
           default: UTC
         sections:
           items:
-            additionalProperties: true
             type: object
           type: array
           title: Sections
@@ -24337,11 +24231,9 @@ components:
           type: boolean
           title: Is Active
         settings:
-          additionalProperties: true
           type: object
           title: Settings
         limits:
-          additionalProperties: true
           type: object
           title: Limits
         mssp_role:
@@ -24396,11 +24288,9 @@ components:
           minLength: 1
           title: Connector Type
         auth_config:
-          additionalProperties: true
           type: object
           title: Auth Config
         connector_config:
-          additionalProperties: true
           type: object
           title: Connector Config
       type: object
@@ -24493,7 +24383,6 @@ components:
           - type: 'null'
           title: Last Activity
         context:
-          additionalProperties: true
           type: object
           title: Context
       type: object
@@ -24559,7 +24448,6 @@ components:
           - type: 'null'
           title: Last Activity
         context:
-          additionalProperties: true
           type: object
           title: Context
         id:
@@ -24685,8 +24573,7 @@ components:
           title: Tool Name
         tool_args:
           anyOf:
-          - additionalProperties: true
-            type: object
+          - type: object
           - type: 'null'
           title: Tool Args
         tool_result_summary:
@@ -25408,14 +25295,12 @@ components:
           title: Is Enabled
         auth_config:
           anyOf:
-          - additionalProperties: true
-            type: object
+          - type: object
           - type: 'null'
           title: Auth Config
         connector_config:
           anyOf:
-          - additionalProperties: true
-            type: object
+          - type: object
           - type: 'null'
           title: Connector Config
         tags:
@@ -25523,16 +25408,14 @@ components:
           title: Name
         filters:
           anyOf:
-          - additionalProperties: true
-            type: object
+          - type: object
           - type: 'null'
           title: Filters
         columns:
           anyOf:
           - items: {}
             type: array
-          - additionalProperties: true
-            type: object
+          - type: object
           - type: 'null'
           title: Columns
         is_default:
@@ -25585,7 +25468,6 @@ components:
     UpdateTenantSettingsRequest:
       properties:
         settings:
-          additionalProperties: true
           type: object
           title: Settings
           default: {}
@@ -25742,7 +25624,6 @@ components:
           type: boolean
           title: Is Active
         preferences:
-          additionalProperties: true
           type: object
           title: Preferences
           default: {}
@@ -25847,11 +25728,6 @@ components:
         type:
           type: string
           title: Error Type
-        input:
-          title: Input
-        ctx:
-          type: object
-          title: Context
       type: object
       required:
       - loc
@@ -25909,7 +25785,6 @@ components:
           - type: 'null'
           title: External Id
         metadata:
-          additionalProperties: true
           type: object
           title: Metadata
       type: object
@@ -25969,7 +25844,6 @@ components:
           - type: 'null'
           title: External Id
         metadata:
-          additionalProperties: true
           type: object
           title: Metadata
         id:
@@ -25992,7 +25866,6 @@ components:
           - type: 'null'
           title: Remediated At
         asset_metadata:
-          additionalProperties: true
           type: object
           title: Asset Metadata
       type: object
@@ -26171,7 +26044,6 @@ components:
           type: string
           title: Blast Radius
         constraints:
-          additionalProperties: true
           type: object
           title: Constraints
         expires_at:
@@ -26194,7 +26066,6 @@ components:
           type: string
           title: Blast Radius
         constraints:
-          additionalProperties: true
           type: object
           title: Constraints
         expires_at:
@@ -26298,13 +26169,11 @@ components:
           title: Total Events Scanned
         matched_events:
           items:
-            additionalProperties: true
             type: object
           type: array
           title: Matched Events
         match_summary:
           items:
-            additionalProperties: true
             type: object
           type: array
           title: Match Summary
@@ -26413,7 +26282,6 @@ components:
           title: Query Kql
         findings:
           items:
-            additionalProperties: true
             type: object
           type: array
           title: Findings
@@ -26510,8 +26378,7 @@ components:
           title: Mitre Technique
         raw:
           anyOf:
-          - additionalProperties: true
-            type: object
+          - type: object
           - type: 'null'
           title: Raw
       type: object

--- a/services/api/app/api/v1/endpoints/detection_loop.py
+++ b/services/api/app/api/v1/endpoints/detection_loop.py
@@ -29,8 +29,9 @@ from fastapi import APIRouter, HTTPException, status
 from pydantic import BaseModel, Field
 from sqlalchemy import text
 
-from app.api.v1.deps import AuthUser, DBSession
+from app.api.v1.deps import AuthUser
 from app.core.config import settings
+from app.db.rls import TenantDBSession
 
 router = APIRouter(prefix="/detection-loop", tags=["detection_rules", "detection_loop"])
 
@@ -174,24 +175,43 @@ _SUGGESTIONS: dict[uuid.UUID, dict[str, Any]] = {}
 )
 async def suggest_fp_fix(
     body: SuggestRequest,
-    db: DBSession,
+    db: TenantDBSession,
     user: AuthUser,
 ) -> SuggestionResponse:
-    """Retrieve the triggering rule + alert evidence, then draft a Sigma improvement."""
-    # 1. Load alert
-    row = await db.execute(text("SELECT rule_id, evidence, tenant_id FROM aisoc_alerts WHERE id = :aid").bindparams(aid=body.alert_id))
+    """Retrieve the triggering rule + alert evidence, then draft a Sigma improvement.
+
+    Tenant isolation: the alert and rule lookups are scoped to ``user.tenant_id``
+    so a caller cannot pull another tenant's evidence by guessing an ``alert_id``.
+    ``TenantDBSession`` also sets the Postgres RLS context for defense in depth.
+    """
+    # 1. Load alert — scoped to caller's tenant. A cross-tenant alert_id 404s
+    # before any evidence or rule body is read.
+    row = await db.execute(
+        text(
+            "SELECT rule_id, evidence, tenant_id FROM aisoc_alerts "
+            "WHERE id = :aid AND tenant_id = :tenant_id"
+        ).bindparams(aid=body.alert_id, tenant_id=user.tenant_id)
+    )
     alert_row = row.fetchone()
     if not alert_row:
         raise HTTPException(status_code=404, detail="Alert not found")
 
     rule_id = alert_row.rule_id
     evidence: dict[str, Any] = alert_row.evidence or {}
-    tenant_id: uuid.UUID | None = alert_row.tenant_id
+    # Trust the caller's tenant for downstream writes — never echo a value
+    # read from the database back into an authorization decision.
+    tenant_id: uuid.UUID = user.tenant_id
 
-    # 2. Load rule body if available
+    # 2. Load rule body if available — also tenant-scoped so an alert in tenant
+    # A can never resolve a rule body owned by tenant B (e.g. via stale data).
     current_sigma = "# Rule body not found\n"
     if rule_id:
-        rule_row = await db.execute(text("SELECT rule_body FROM aisoc_detection_rules WHERE id = :rid").bindparams(rid=rule_id))
+        rule_row = await db.execute(
+            text(
+                "SELECT rule_body FROM aisoc_detection_rules "
+                "WHERE id = :rid AND tenant_id = :tenant_id"
+            ).bindparams(rid=rule_id, tenant_id=user.tenant_id)
+        )
         rule_data = rule_row.fetchone()
         if rule_data:
             current_sigma = rule_data.rule_body
@@ -247,7 +267,12 @@ async def suggest_fp_fix(
         proposal_id=proposal_id,
         created_at=now,
     )
-    _SUGGESTIONS[suggestion_id] = result.model_dump()
+    # Tag the in-memory record with the caller's tenant so list/detail reads
+    # can filter cross-tenant access. ``tenant_id`` is *not* part of the
+    # response schema — it is internal metadata used only for isolation.
+    stored = result.model_dump()
+    stored["tenant_id"] = tenant_id
+    _SUGGESTIONS[suggestion_id] = stored
     return result
 
 
@@ -257,7 +282,17 @@ async def suggest_fp_fix(
     summary="List LLM-drafted Sigma suggestions",
 )
 async def list_suggestions(user: AuthUser) -> SuggestionListResponse:
-    items = [SuggestionResponse(**v) for v in _SUGGESTIONS.values()]
+    """List suggestions drafted by *this* tenant only.
+
+    Tenant isolation: ``_SUGGESTIONS`` is process-wide and shared across all
+    tenants. Filtering on the stored ``tenant_id`` ensures one tenant never
+    sees another tenant's drafts, rule names, or evidence-derived rationale.
+    """
+    items = [
+        SuggestionResponse(**{k: v for k, v in stored.items() if k != "tenant_id"})
+        for stored in _SUGGESTIONS.values()
+        if str(stored.get("tenant_id")) == str(user.tenant_id)
+    ]
     return SuggestionListResponse(suggestions=items, total=len(items))
 
 
@@ -270,7 +305,12 @@ async def get_suggestion(
     suggestion_id: uuid.UUID,
     user: AuthUser,
 ) -> SuggestionResponse:
+    """Return one suggestion if and only if it belongs to the caller's tenant.
+
+    Tenant isolation: a cross-tenant lookup returns 404 (not 403) to avoid
+    leaking the existence of a suggestion that belongs to another tenant.
+    """
     item = _SUGGESTIONS.get(suggestion_id)
-    if not item:
+    if not item or str(item.get("tenant_id")) != str(user.tenant_id):
         raise HTTPException(status_code=404, detail="Suggestion not found")
-    return SuggestionResponse(**item)
+    return SuggestionResponse(**{k: v for k, v in item.items() if k != "tenant_id"})

--- a/services/api/app/api/v1/endpoints/detection_loop.py
+++ b/services/api/app/api/v1/endpoints/detection_loop.py
@@ -187,10 +187,9 @@ async def suggest_fp_fix(
     # 1. Load alert — scoped to caller's tenant. A cross-tenant alert_id 404s
     # before any evidence or rule body is read.
     row = await db.execute(
-        text(
-            "SELECT rule_id, evidence, tenant_id FROM aisoc_alerts "
-            "WHERE id = :aid AND tenant_id = :tenant_id"
-        ).bindparams(aid=body.alert_id, tenant_id=user.tenant_id)
+        text("SELECT rule_id, evidence, tenant_id FROM aisoc_alerts " "WHERE id = :aid AND tenant_id = :tenant_id").bindparams(
+            aid=body.alert_id, tenant_id=user.tenant_id
+        )
     )
     alert_row = row.fetchone()
     if not alert_row:
@@ -207,10 +206,9 @@ async def suggest_fp_fix(
     current_sigma = "# Rule body not found\n"
     if rule_id:
         rule_row = await db.execute(
-            text(
-                "SELECT rule_body FROM aisoc_detection_rules "
-                "WHERE id = :rid AND tenant_id = :tenant_id"
-            ).bindparams(rid=rule_id, tenant_id=user.tenant_id)
+            text("SELECT rule_body FROM aisoc_detection_rules " "WHERE id = :rid AND tenant_id = :tenant_id").bindparams(
+                rid=rule_id, tenant_id=user.tenant_id
+            )
         )
         rule_data = rule_row.fetchone()
         if rule_data:

--- a/services/api/tests/test_detection_loop_tenant_isolation.py
+++ b/services/api/tests/test_detection_loop_tenant_isolation.py
@@ -38,8 +38,8 @@ import pytest
 from app.api.v1.deps import CurrentUser
 from app.api.v1.endpoints import detection_loop as detection_loop_module
 from app.api.v1.endpoints.detection_loop import (
-    SuggestRequest,
     SuggestionResponse,
+    SuggestRequest,
     get_suggestion,
     list_suggestions,
     suggest_fp_fix,

--- a/services/api/tests/test_detection_loop_tenant_isolation.py
+++ b/services/api/tests/test_detection_loop_tenant_isolation.py
@@ -196,17 +196,13 @@ async def test_suggest_cross_tenant_alert_id_returns_404(_stub_llm: dict[str, An
     assert alert_select is not None, "expected a SELECT against aisoc_alerts"
     sql, params = alert_select
     assert "tenant_id" in re.sub(r"\s+", " ", sql).lower(), f"alert SELECT not tenant-scoped: {sql}"
-    assert params.get("tenant_id") == tenant_a.tenant_id, (
-        f"alert SELECT did not bind the caller's tenant_id; params={params}; expected={tenant_a.tenant_id}"
-    )
+    assert (
+        params.get("tenant_id") == tenant_a.tenant_id
+    ), f"alert SELECT did not bind the caller's tenant_id; params={params}; expected={tenant_a.tenant_id}"
 
     # Critical: no rule lookup and no proposal INSERT must have run.
-    assert _find_select(db.executed, "aisoc_detection_rules") is None, (
-        "rule body lookup must not run when the alert lookup 404s"
-    )
-    assert _find_insert(db.executed, "aisoc_detection_rule_proposals") is None, (
-        "no proposal must be inserted when the alert lookup 404s"
-    )
+    assert _find_select(db.executed, "aisoc_detection_rules") is None, "rule body lookup must not run when the alert lookup 404s"
+    assert _find_insert(db.executed, "aisoc_detection_rule_proposals") is None, "no proposal must be inserted when the alert lookup 404s"
     # And nothing must land in the in-memory store.
     assert detection_loop_module._SUGGESTIONS == {}
 
@@ -247,9 +243,9 @@ async def test_suggest_same_tenant_scopes_alert_rule_and_proposal(_stub_llm: dic
     proposal_insert = _find_insert(db.executed, "aisoc_detection_rule_proposals")
     assert proposal_insert is not None, "expected an INSERT into aisoc_detection_rule_proposals"
     _sql, params = proposal_insert
-    assert params.get("tid") == user.tenant_id, (
-        f"proposal INSERT did not bind the caller's tenant; params={params}; expected={user.tenant_id}"
-    )
+    assert (
+        params.get("tid") == user.tenant_id
+    ), f"proposal INSERT did not bind the caller's tenant; params={params}; expected={user.tenant_id}"
 
     # The in-memory record must be tagged with the caller's tenant
     # (used by list/get for cross-tenant filtering) and must hold the

--- a/services/api/tests/test_detection_loop_tenant_isolation.py
+++ b/services/api/tests/test_detection_loop_tenant_isolation.py
@@ -1,0 +1,434 @@
+"""Tenant-isolation tests for /detection-loop (security fix).
+
+Sibling of :mod:`tests.test_alerts_tenant_isolation` — exercises the
+detection-loop endpoints exposed by
+:mod:`app.api.v1.endpoints.detection_loop` and asserts that the
+cross-tenant attack vectors closed by the security fix stay closed.
+
+The contract being protected
+----------------------------
+* ``POST /detection-loop/suggest`` must scope the **alert lookup** and
+  the **rule body lookup** on the caller's ``tenant_id``. A cross-tenant
+  ``alert_id`` must 404 *before* any evidence or rule body is read, and
+  no detection-rule-proposal row may be inserted.
+* The auto-created ``aisoc_detection_rule_proposals`` row must bind the
+  **caller's** ``tenant_id`` — never one derived from a database read,
+  so a poisoned ``aisoc_alerts.tenant_id`` cannot redirect the write.
+* ``GET /detection-loop/suggestions`` and
+  ``GET /detection-loop/suggestions/{id}`` operate over a process-wide
+  in-memory ``_SUGGESTIONS`` dict. Filtering on the stored ``tenant_id``
+  must hide other tenants' drafts. A cross-tenant GET-by-id must 404
+  (not 403) so we don't leak existence.
+* The ``tenant_id`` we tag onto the in-memory record is *internal
+  metadata* — it must not appear in any response body.
+
+These tests call the endpoint functions directly with a mocked
+:class:`AsyncSession`, the same pattern used in
+:mod:`tests.test_alerts_tenant_isolation`.
+"""
+
+from __future__ import annotations
+
+import re
+import uuid
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from app.api.v1.deps import CurrentUser
+from app.api.v1.endpoints import detection_loop as detection_loop_module
+from app.api.v1.endpoints.detection_loop import (
+    SuggestRequest,
+    SuggestionResponse,
+    get_suggestion,
+    list_suggestions,
+    suggest_fp_fix,
+)
+from fastapi import HTTPException
+
+# ────────────────────────────────────────────────────────────────────────────
+# Fixtures / helpers
+# ────────────────────────────────────────────────────────────────────────────
+
+
+def _user(tenant_id: uuid.UUID | None = None) -> CurrentUser:
+    """Build a CurrentUser without touching JWT plumbing or the DB."""
+    return CurrentUser(
+        user_id=uuid.uuid4(),
+        tenant_id=tenant_id or uuid.uuid4(),
+        role="soc_analyst",
+        email="analyst@example.com",
+    )
+
+
+def _alert_row(tenant_id: uuid.UUID, rule_id: uuid.UUID | None = None, evidence: dict[str, Any] | None = None) -> MagicMock:
+    """Build a fake ``aisoc_alerts`` row exposing the columns the endpoint reads."""
+    row = MagicMock()
+    row.rule_id = rule_id
+    row.evidence = evidence or {"process_name": "powershell.exe", "User": "svc-ci"}
+    row.tenant_id = tenant_id
+    return row
+
+
+def _rule_row(body: str = "title: Stub\nlogsource:\n  product: windows\n") -> MagicMock:
+    row = MagicMock()
+    row.rule_body = body
+    return row
+
+
+def _mk_db(rows: list[Any]) -> MagicMock:
+    """Mock AsyncSession that returns queued rows one execute() at a time.
+
+    Mirrors the helper in ``test_alerts_tenant_isolation`` so SQL + bind
+    parameter assertions work the same way: each ``execute(clause)`` call
+    pushes ``(str(clause), clause.compile().params)`` onto ``db.executed``.
+
+    The queued payloads serve as ``result.fetchone()`` returns — the
+    detection-loop endpoint uses ``row.fetchone()`` rather than
+    ``scalars().all()``, so the mock returns the raw payload (``None`` for
+    the cross-tenant 404 path).
+    """
+    db = MagicMock()
+    db.executed: list[tuple[str, dict[str, Any]]] = []
+    iterator = iter(rows)
+
+    async def _execute(clause: Any, *args: Any, **kwargs: Any) -> MagicMock:
+        sql = str(clause)
+        try:
+            params = dict(clause.compile().params) if hasattr(clause, "compile") else {}
+        except Exception:  # pragma: no cover — defensive: never crash the mock.
+            params = {}
+        db.executed.append((sql, params))
+        try:
+            payload = next(iterator)
+        except StopIteration:
+            payload = None
+        result = MagicMock()
+        result.fetchone = MagicMock(return_value=payload)
+        return result
+
+    db.execute = AsyncMock(side_effect=_execute)
+    db.commit = AsyncMock()
+    db.rollback = AsyncMock()
+    return db
+
+
+def _find_select(executed: list[tuple[str, dict[str, Any]]], table: str) -> tuple[str, dict[str, Any]] | None:
+    """Return the first executed SELECT against ``table`` (case-insensitive), or None."""
+    for sql, params in executed:
+        normalized = re.sub(r"\s+", " ", sql).lower()
+        if normalized.startswith("select") and table.lower() in normalized:
+            return sql, params
+    return None
+
+
+def _find_insert(executed: list[tuple[str, dict[str, Any]]], table: str) -> tuple[str, dict[str, Any]] | None:
+    """Return the first executed INSERT into ``table``, or None."""
+    for sql, params in executed:
+        normalized = re.sub(r"\s+", " ", sql).lower()
+        if "insert into" in normalized and table.lower() in normalized:
+            return sql, params
+    return None
+
+
+@pytest.fixture(autouse=True)
+def _clear_suggestions_store() -> Any:
+    """The ``_SUGGESTIONS`` dict is process-wide; reset it per test."""
+    detection_loop_module._SUGGESTIONS.clear()
+    yield
+    detection_loop_module._SUGGESTIONS.clear()
+
+
+@pytest.fixture
+def _stub_llm(monkeypatch: pytest.MonkeyPatch) -> Any:
+    """Replace the LLM call so tests stay hermetic and fast.
+
+    The endpoint dispatches to ``_llm_draft_sigma`` which, in the
+    template-fallback path, would still need ``alert_fields`` to be a
+    real dict. Returning the canned dict here keeps the assertion
+    surface focused on tenant scoping rather than LLM contract drift.
+    """
+    canned = {
+        "rule_name": "fp-exclusion-draft",
+        "sigma_yaml": "filter:\n  - process_name: 'powershell.exe'\ncondition: selection and not filter\n",
+        "rationale": "Auto-generated exclusion for the FP analyst flagged.",
+    }
+    monkeypatch.setattr(
+        detection_loop_module,
+        "_llm_draft_sigma",
+        AsyncMock(return_value=canned),
+    )
+    return canned
+
+
+# ────────────────────────────────────────────────────────────────────────────
+# POST /detection-loop/suggest
+# ────────────────────────────────────────────────────────────────────────────
+
+
+async def test_suggest_cross_tenant_alert_id_returns_404(_stub_llm: dict[str, Any]) -> None:
+    """A caller in tenant A cannot pull tenant B's alert evidence by id.
+
+    Pre-fix: ``SELECT ... WHERE id = :aid`` returned the row regardless
+    of tenant, then the endpoint echoed ``evidence`` (and a rule_id
+    that resolved against ``aisoc_detection_rules`` cross-tenant).
+
+    Post-fix: the SELECT is scoped to ``user.tenant_id``, so a
+    cross-tenant id returns no row and we 404 before any other read
+    or any proposal INSERT runs.
+    """
+    tenant_a = _user()
+    # SELECT scoped to tenant A's id returns nothing — the row exists in
+    # tenant B but our WHERE clause now filters it out.
+    db = _mk_db([None])
+
+    with pytest.raises(HTTPException) as exc:
+        await suggest_fp_fix(
+            body=SuggestRequest(alert_id=uuid.uuid4()),
+            db=db,
+            user=tenant_a,
+        )
+
+    assert exc.value.status_code == 404
+
+    # The alert SELECT must have been tenant-scoped.
+    alert_select = _find_select(db.executed, "aisoc_alerts")
+    assert alert_select is not None, "expected a SELECT against aisoc_alerts"
+    sql, params = alert_select
+    assert "tenant_id" in re.sub(r"\s+", " ", sql).lower(), f"alert SELECT not tenant-scoped: {sql}"
+    assert params.get("tenant_id") == tenant_a.tenant_id, (
+        f"alert SELECT did not bind the caller's tenant_id; params={params}; expected={tenant_a.tenant_id}"
+    )
+
+    # Critical: no rule lookup and no proposal INSERT must have run.
+    assert _find_select(db.executed, "aisoc_detection_rules") is None, (
+        "rule body lookup must not run when the alert lookup 404s"
+    )
+    assert _find_insert(db.executed, "aisoc_detection_rule_proposals") is None, (
+        "no proposal must be inserted when the alert lookup 404s"
+    )
+    # And nothing must land in the in-memory store.
+    assert detection_loop_module._SUGGESTIONS == {}
+
+
+async def test_suggest_same_tenant_scopes_alert_rule_and_proposal(_stub_llm: dict[str, Any]) -> None:
+    """Same-tenant suggest: alert + rule SELECTs and the proposal INSERT all bind the caller's tenant."""
+    user = _user()
+    rule_id = uuid.uuid4()
+    alert = _alert_row(user.tenant_id, rule_id=rule_id)
+    rule = _rule_row()
+    # Three executes: alert SELECT, rule SELECT, proposal INSERT.
+    db = _mk_db([alert, rule, None])
+
+    response = await suggest_fp_fix(
+        body=SuggestRequest(alert_id=uuid.uuid4(), analyst_note="benign automation"),
+        db=db,
+        user=user,
+    )
+
+    assert isinstance(response, SuggestionResponse)
+    assert response.base_rule_id == rule_id
+
+    # Alert SELECT — tenant-scoped on caller's tenant.
+    alert_select = _find_select(db.executed, "aisoc_alerts")
+    assert alert_select is not None
+    sql, params = alert_select
+    assert "tenant_id" in re.sub(r"\s+", " ", sql).lower()
+    assert params.get("tenant_id") == user.tenant_id
+
+    # Rule SELECT — also tenant-scoped on caller's tenant.
+    rule_select = _find_select(db.executed, "aisoc_detection_rules")
+    assert rule_select is not None, "expected a SELECT against aisoc_detection_rules"
+    sql, params = rule_select
+    assert "tenant_id" in re.sub(r"\s+", " ", sql).lower()
+    assert params.get("tenant_id") == user.tenant_id
+
+    # Proposal INSERT — the ``tid`` bind must equal the *caller's* tenant.
+    proposal_insert = _find_insert(db.executed, "aisoc_detection_rule_proposals")
+    assert proposal_insert is not None, "expected an INSERT into aisoc_detection_rule_proposals"
+    _sql, params = proposal_insert
+    assert params.get("tid") == user.tenant_id, (
+        f"proposal INSERT did not bind the caller's tenant; params={params}; expected={user.tenant_id}"
+    )
+
+    # The in-memory record must be tagged with the caller's tenant
+    # (used by list/get for cross-tenant filtering) and must hold the
+    # full response.
+    stored = detection_loop_module._SUGGESTIONS[response.suggestion_id]
+    assert stored["tenant_id"] == user.tenant_id
+
+
+async def test_suggest_proposal_insert_binds_caller_tenant_not_db_row_tenant(_stub_llm: dict[str, Any]) -> None:
+    """Defence in depth: even if a poisoned alert row leaks past RLS, the proposal binds caller's tenant.
+
+    The fix replaces ``tid=alert_row.tenant_id`` with ``tid=user.tenant_id``.
+    This test forges an alert row whose ``tenant_id`` differs from the
+    caller's (a hypothetical "RLS bypassed" scenario), confirms the
+    endpoint still reaches the INSERT (because we mocked the SELECT to
+    return the row), and asserts the INSERT binds the *caller's*
+    tenant — not the value read from the database.
+    """
+    user = _user()
+    poisoned_row_tenant = uuid.uuid4()
+    rule_id = uuid.uuid4()
+    forged_alert = _alert_row(poisoned_row_tenant, rule_id=rule_id)
+    rule = _rule_row()
+    db = _mk_db([forged_alert, rule, None])
+
+    response = await suggest_fp_fix(
+        body=SuggestRequest(alert_id=uuid.uuid4()),
+        db=db,
+        user=user,
+    )
+
+    proposal_insert = _find_insert(db.executed, "aisoc_detection_rule_proposals")
+    assert proposal_insert is not None
+    _sql, params = proposal_insert
+    # The critical assertion: never trust a value we read back from the DB
+    # for an authorization decision on a write.
+    assert params.get("tid") == user.tenant_id
+    assert params.get("tid") != poisoned_row_tenant
+
+    # And the in-memory tag also follows the caller, not the row.
+    stored = detection_loop_module._SUGGESTIONS[response.suggestion_id]
+    assert stored["tenant_id"] == user.tenant_id
+
+
+async def test_suggest_alert_without_rule_id_skips_rule_select(_stub_llm: dict[str, Any]) -> None:
+    """If the alert has no ``rule_id`` we must not blindly query the rules table.
+
+    Guards against a regression where someone adds a tenant_id-less
+    rule lookup back. Also locks down that the proposal INSERT still
+    fires (with ``base_rule_id=NULL``) so suggest_fp_fix remains usable
+    for orphan alerts.
+    """
+    user = _user()
+    alert = _alert_row(user.tenant_id, rule_id=None)
+    # Only two executes: alert SELECT and proposal INSERT.
+    db = _mk_db([alert, None])
+
+    response = await suggest_fp_fix(
+        body=SuggestRequest(alert_id=uuid.uuid4()),
+        db=db,
+        user=user,
+    )
+
+    assert response.base_rule_id is None
+    assert _find_select(db.executed, "aisoc_detection_rules") is None
+    proposal_insert = _find_insert(db.executed, "aisoc_detection_rule_proposals")
+    assert proposal_insert is not None
+    assert proposal_insert[1].get("tid") == user.tenant_id
+
+
+# ────────────────────────────────────────────────────────────────────────────
+# GET /detection-loop/suggestions
+# ────────────────────────────────────────────────────────────────────────────
+
+
+def _seed_suggestion(tenant_id: uuid.UUID, rule_name: str = "fp-fix-draft") -> uuid.UUID:
+    """Insert a stub row directly into ``_SUGGESTIONS`` for list/get tests."""
+    sid = uuid.uuid4()
+    from datetime import UTC, datetime  # noqa: PLC0415 — keep helper hermetic.
+
+    detection_loop_module._SUGGESTIONS[sid] = {
+        "suggestion_id": sid,
+        "alert_id": uuid.uuid4(),
+        "base_rule_id": uuid.uuid4(),
+        "draft_rule_name": rule_name,
+        "draft_sigma_yaml": "filter:\n  - User: 'svc-ci'\n",
+        "rationale": "test",
+        "proposal_id": uuid.uuid4(),
+        "created_at": datetime.now(UTC),
+        "tenant_id": tenant_id,
+    }
+    return sid
+
+
+async def test_list_suggestions_only_returns_caller_tenant() -> None:
+    """A list call must return only the caller-tenant's suggestions, never others'."""
+    tenant_a = _user()
+    tenant_b = _user()
+    a1 = _seed_suggestion(tenant_a.tenant_id, "a-1")
+    a2 = _seed_suggestion(tenant_a.tenant_id, "a-2")
+    _b1 = _seed_suggestion(tenant_b.tenant_id, "b-1")
+
+    resp = await list_suggestions(user=tenant_a)
+
+    assert resp.total == 2
+    returned_ids = {item.suggestion_id for item in resp.suggestions}
+    assert returned_ids == {a1, a2}, "tenant A's list returned the wrong set — possible cross-tenant leak"
+
+
+async def test_list_suggestions_does_not_leak_internal_tenant_id_field() -> None:
+    """The internal ``tenant_id`` tag must not appear in the response body."""
+    user = _user()
+    _seed_suggestion(user.tenant_id)
+
+    resp = await list_suggestions(user=user)
+
+    assert resp.total == 1
+    item = resp.suggestions[0]
+    # ``SuggestionResponse`` does not declare ``tenant_id`` and pydantic
+    # will not expose attributes that aren't declared. Verify defensively
+    # in case someone adds the field to the schema later.
+    assert not hasattr(item, "tenant_id"), "internal tenant_id metadata must not be part of the API response"
+    dumped = item.model_dump()
+    assert "tenant_id" not in dumped
+
+
+async def test_list_suggestions_empty_when_no_caller_tenant_rows() -> None:
+    """A caller in a fresh tenant must see an empty list — not other tenants' work."""
+    tenant_a = _user()
+    other = _user()
+    _seed_suggestion(other.tenant_id, "other-1")
+    _seed_suggestion(other.tenant_id, "other-2")
+
+    resp = await list_suggestions(user=tenant_a)
+
+    assert resp.total == 0
+    assert resp.suggestions == []
+
+
+# ────────────────────────────────────────────────────────────────────────────
+# GET /detection-loop/suggestions/{id}
+# ────────────────────────────────────────────────────────────────────────────
+
+
+async def test_get_suggestion_cross_tenant_returns_404() -> None:
+    """Looking up another tenant's suggestion by id must 404 — not 403, not 200."""
+    tenant_a = _user()
+    tenant_b = _user()
+    target = _seed_suggestion(tenant_b.tenant_id, "b-only")
+
+    with pytest.raises(HTTPException) as exc:
+        await get_suggestion(suggestion_id=target, user=tenant_a)
+
+    # 404 (not 403) avoids leaking the existence of suggestions owned
+    # by other tenants.
+    assert exc.value.status_code == 404
+
+
+async def test_get_suggestion_unknown_id_returns_404() -> None:
+    """A non-existent suggestion id must 404, not 500 or 200."""
+    user = _user()
+    # Store contains rows for *other* tenants — exercise the "key missing"
+    # branch separately from the "wrong tenant" branch.
+    _seed_suggestion(uuid.uuid4())
+
+    with pytest.raises(HTTPException) as exc:
+        await get_suggestion(suggestion_id=uuid.uuid4(), user=user)
+
+    assert exc.value.status_code == 404
+
+
+async def test_get_suggestion_same_tenant_returns_item() -> None:
+    """A caller can read its own suggestion and the response excludes ``tenant_id``."""
+    user = _user()
+    sid = _seed_suggestion(user.tenant_id, "mine")
+
+    resp = await get_suggestion(suggestion_id=sid, user=user)
+
+    assert resp.suggestion_id == sid
+    assert resp.draft_rule_name == "mine"
+    dumped = resp.model_dump()
+    assert "tenant_id" not in dumped


### PR DESCRIPTION
## Summary

Tighten authorization on the detection-loop suggestion surface so that
alert and rule lookups, and the in-memory suggestion store, can only be
read or written within the authenticated user's tenant.

> Reported privately via a CVE-style report. This PR is intentionally
> low on exploit detail — see the linked GitHub security advisory (or
> contact the maintainer privately) for the full write-up, repro steps,
> and impact analysis.

## What changes

- `POST /api/v1/detection-loop/suggest` now uses `TenantDBSession`, so DB
  reads execute under the per-request RLS context for the caller's
  tenant.
- The alert and detection-rule `SELECT`s in `suggest_fp_fix` get explicit
  `tenant_id = :tenant_id` predicates, bound to `user.tenant_id`. A
  foreign `alert_id` or `rule_id` now returns `404 Not Found` instead of
  succeeding.
- The in-memory `_SUGGESTIONS` store is tagged with the caller's
  `tenant_id` on insert. `GET /api/v1/detection-loop/suggestions` and
  `GET /api/v1/detection-loop/suggestions/{id}` filter by that
  `tenant_id`, so listings and direct lookups never cross tenants. The
  internal `tenant_id` field is stripped before returning rows to the
  client.

## Tests

New: `services/api/tests/test_detection_loop_tenant_isolation.py` (10
tests). Covers:

- cross-tenant alert / rule access on `POST /suggest` returns 404 and
  performs no INSERT
- alert and rule `SELECT`s are tenant-scoped and bind the caller's
  `tenant_id`
- the persisted suggestion's `tenant_id` is bound from the caller, not
  from any client input
- `GET /suggestions` only returns rows for the caller's tenant and does
  not leak the internal `tenant_id` field
- `GET /suggestions/{id}` returns 404 for another tenant's id and for
  unknown ids, and returns the row for the owning tenant

Also re-ran `tests/test_alerts_tenant_isolation.py` to confirm no
regressions in the broader tenant-isolation suite.

```
$ PYTHONPATH=. poetry run pytest \
    tests/test_detection_loop_tenant_isolation.py \
    tests/test_alerts_tenant_isolation.py
... 27 passed
```

## Test plan

- [x] New tenant-isolation tests pass locally
- [x] Existing `test_alerts_tenant_isolation.py` still passes
- [ ] CI green on this branch
- [ ] Manual smoke check against a two-tenant fixture (cross-tenant
      `alert_id` / `rule_id` / suggestion `id` all return 404)

## Notes for review

- No public API shape changes. Response models are unchanged; only the
  set of rows visible to a caller is narrowed to their own tenant.
- The in-memory store remains an implementation detail; this PR only
  tightens its access rules. A persistent, RLS-backed store is a
  separate follow-up.
- Once this lands, recommend publishing a GitHub Security Advisory
  crediting the reporter and noting the fixed commit / release.


Made with [Cursor](https://cursor.com)