### PR TITLE
fix(deps): remove duplicate entries from pnpm-lock.yaml (unblock JS CI)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4447,17 +4447,6 @@ packages:
       react: 19.2.6
     dev: false
 
-  /@mdx-js/react@3.1.1(@types/react@19.2.15)(react@19.2.6):
-    resolution: {integrity: sha512-f++rKLQgUVYDAtECQ6fn/is15GkEH9+nZPM3MS0RcxVqoTfawHvDlSCH7JbMhAM6uJ32v3eXLvLmLvjGu7PTQw==}
-    peerDependencies:
-      '@types/react': '>=16'
-      react: '>=16'
-    dependencies:
-      '@types/mdx': 2.0.13
-      '@types/react': 19.2.15
-      react: 19.2.6
-    dev: false
-
   /@modelcontextprotocol/sdk@1.29.0(zod@3.25.76):
     resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
     engines: {node: '>=18'}
@@ -6287,11 +6276,6 @@ packages:
     resolution: {integrity: sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==}
     dependencies:
       '@types/prop-types': 15.7.15
-      csstype: 3.2.3
-
-  /@types/react@19.2.15:
-    resolution: {integrity: sha512-eRwcGNHve+E8qtEQSSRl6urh+rFop4v8gm6O8rGv25CodbvFdLjA1vVQ1KkiFE0w0UPOnb8tDiFKL5lp0rtY5Q==}
-    dependencies:
       csstype: 3.2.3
 
   /@types/react@19.2.15:


### PR DESCRIPTION
## Problem

All Node/TS CI jobs on `main` and on every open PR are failing during \`pnpm install\` with:

\`\`\`
ERR_PNPM_BROKEN_LOCKFILE  The lockfile at "/home/runner/work/AiSOC/AiSOC/pnpm-lock.yaml" is broken: duplicated mapping key (4450:3)
\`\`\`

Affected jobs:
- \`MCP — Type-check, Test & Build\`
- \`SDK — TypeScript (vitest)\`

This blocks every PR that touches anything CI-checked, including the Dependabot wave (#213 etc.) and #221.

## Root cause

\`pnpm-lock.yaml\` contained two identical duplicate top-level entries:

- \`/@mdx-js/react@3.1.1(@types/react@19.2.15)(react@19.2.6):\`  (lines 4439 and 4450 on the broken version)
- \`/@types/react@19.2.15:\` (lines 6281 and 6286)

Both copies were byte-identical (same resolution hash, same deps). The most likely source is a merge that re-applied the same insertion twice — consistent with the Dependabot bump of \`@types/react\` (#203) interleaving with the MDX-related dependency graph.

## Fix

Removed both duplicate blocks. \`python3 -c "import yaml; yaml.safe_load(open('pnpm-lock.yaml'))"\` now succeeds, and \`grep -E "^  /" pnpm-lock.yaml | sort | uniq -d\` returns no duplicates.

No installed version changes — duplicates were identical copies.

## Verification

- [x] YAML parses
- [x] No remaining duplicate package keys
- [x] Diff is purely deletions (16 lines removed, 0 added)
- [ ] CI: \`MCP — Type-check, Test & Build\` passes
- [ ] CI: \`SDK — TypeScript (vitest)\` passes

## Follow-up

Once this lands, the blocked PRs (#213 rebase, #221 if any leftover, the rest of the Dependabot wave) should be re-evaluated against the now-healthy CI.

Made with [Cursor](https://cursor.com)