### PR TITLE
docs: add Credits section thanking contributors and security researchers

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -1,0 +1,74 @@
+# Credits
+
+AiSOC is built and improved by a growing community of contributors, security researchers, and operators. This page exists to thank them.
+
+If you've contributed and your name is missing, please open a PR against this file — we'd rather over-credit than miss someone.
+
+---
+
+## Security researchers
+
+We deeply appreciate everyone who takes the time to report a security issue responsibly. Reporters listed here have made AiSOC measurably safer for everyone running it.
+
+| Reporter | Contribution |
+| --- | --- |
+| [**@TanmayZade**](https://github.com/TanmayZade) | Reported [#220](https://github.com/beenuar/AiSOC/issues/220) — prompt injection in classification agents leading to alert auto-close bypass. Also authored the fix in [PR #219](https://github.com/beenuar/AiSOC/pull/219) (prompt sanitiser + untrusted-content wrapping across the five classification agents). |
+| [**@mangod12**](https://github.com/mangod12) | Reported [#159](https://github.com/beenuar/AiSOC/issues/159) — proposed cross-tenant isolation tests + nightly CI for RBAC regression. Directly informed the tenant-isolation hardening work that landed in [PR #221](https://github.com/beenuar/AiSOC/pull/221). |
+| [**@jay-cyble**](https://github.com/jay-cyble) (Jay Vasant) | Reported [#130](https://github.com/beenuar/AiSOC/issues/130) — a structured review of 13 security & UI issues found via code review + live-site inspection. Multiple findings were used to drive follow-up hardening tickets. |
+
+If you want to report a vulnerability, please use [GitHub's private vulnerability reporting](https://github.com/beenuar/AiSOC/security/advisories/new) and read [SECURITY.md](SECURITY.md) first.
+
+---
+
+## Code contributors
+
+People outside the core maintainer team who have shipped code into AiSOC. Ordered by first merged contribution.
+
+| Contributor | Highlights |
+| --- | --- |
+| [**@jay-cyble**](https://github.com/jay-cyble) | [PR #135](https://github.com/beenuar/AiSOC/pull/135) — UEBA service environment-variable alignment, closing [#134](https://github.com/beenuar/AiSOC/issues/134). First community contribution to the project. |
+| [**@prince30121**](https://github.com/prince30121) | Multiple infrastructure & CI commits (including CI restoration work). 9 commits and counting. |
+| [**@ARDA7787**](https://github.com/ARDA7787) | [PR #218](https://github.com/beenuar/AiSOC/pull/218) — Redis-backed scheduler singleton guard + dependency-CVE security-audit CI tooling (`security-audit.yml`, `scripts/security_audit.py`). |
+| [**@TanmayZade**](https://github.com/TanmayZade) | [PR #219](https://github.com/beenuar/AiSOC/pull/219) — prompt sanitiser + untrusted-content wrapping across the five classification agents (fix for [#220](https://github.com/beenuar/AiSOC/issues/220)). |
+
+The full, always-up-to-date list of code contributors lives on the [GitHub contributors page](https://github.com/beenuar/AiSOC/graphs/contributors).
+
+---
+
+## Bug reporters & community feedback
+
+Folks who took the time to file high-signal issues that drove visible improvements in the project:
+
+- [**@cyberdometanza**](https://github.com/cyberdometanza) — Docker / packaging bug reports (e.g. [#82](https://github.com/beenuar/AiSOC/issues/82))
+- [**@AMoneronIQBusiness**](https://github.com/AMoneronIQBusiness) — Docker demo / quickstart feedback ([#81](https://github.com/beenuar/AiSOC/issues/81))
+- [**@ThiagoDataEngineer**](https://github.com/ThiagoDataEngineer) — Early platform feedback ([#48](https://github.com/beenuar/AiSOC/issues/48))
+- [**@alvarofraguas**](https://github.com/alvarofraguas) — Connector / setup feedback ([#44](https://github.com/beenuar/AiSOC/issues/44))
+- [**@sonalig-cyble**](https://github.com/sonalig-cyble) — Product feedback ([#131](https://github.com/beenuar/AiSOC/issues/131))
+
+---
+
+## Automation
+
+- [**@dependabot[bot]**](https://github.com/apps/dependabot) — Keeps the dependency tree healthy across every service in the monorepo.
+
+---
+
+## Maintainers
+
+AiSOC is currently maintained by [**@beenuar**](https://github.com/beenuar) (project lead) with help from everyone listed above.
+
+If you'd like to take on ongoing responsibility for an area of the codebase (a connector family, the web console, the agents pipeline, infra, docs), open an issue tagged `maintainership` and let's talk.
+
+---
+
+## How to be added here
+
+You're added automatically if:
+
+- You authored a merged PR
+- You reported a security issue that was acknowledged and triaged (via [private advisory](https://github.com/beenuar/AiSOC/security/advisories/new) or a confirmed public issue)
+- You filed a high-signal issue that drove a real change in the codebase
+
+If something landed because of you and you're not on this list, that's a bug — please open a PR against `CREDITS.md` and we'll merge it.
+
+Thank you for making AiSOC better.

--- a/README.md
+++ b/README.md
@@ -1045,6 +1045,29 @@ Good first issues:
 
 ---
 
+## Credits
+
+AiSOC is built and improved by a growing community of contributors, security researchers, and operators.
+
+**Security researchers** who have made AiSOC measurably safer for everyone running it:
+
+- [**@TanmayZade**](https://github.com/TanmayZade) — Reported & fixed the prompt-injection auto-close bypass ([#220](https://github.com/beenuar/AiSOC/issues/220) / [PR #219](https://github.com/beenuar/AiSOC/pull/219))
+- [**@mangod12**](https://github.com/mangod12) — Proposed cross-tenant isolation tests + nightly RBAC regression CI ([#159](https://github.com/beenuar/AiSOC/issues/159)); informed [PR #221](https://github.com/beenuar/AiSOC/pull/221)
+- [**@jay-cyble**](https://github.com/jay-cyble) — Structured review of 13 security & UI findings ([#130](https://github.com/beenuar/AiSOC/issues/130))
+
+**Code contributors** outside the core maintainer team:
+
+- [**@jay-cyble**](https://github.com/jay-cyble) — First community contribution: UEBA service env-var alignment ([PR #135](https://github.com/beenuar/AiSOC/pull/135))
+- [**@prince30121**](https://github.com/prince30121) — Infrastructure & CI fixes
+- [**@ARDA7787**](https://github.com/ARDA7787) — Redis-backed scheduler singleton guard + dependency-CVE audit CI ([PR #218](https://github.com/beenuar/AiSOC/pull/218))
+- [**@TanmayZade**](https://github.com/TanmayZade) — Prompt sanitiser + untrusted-content wrapping across the classification agents ([PR #219](https://github.com/beenuar/AiSOC/pull/219))
+
+The full list — including bug reporters, community feedback, and how to get yourself added — lives in [**CREDITS.md**](CREDITS.md). The always-up-to-date code-contribution graph is on the [GitHub contributors page](https://github.com/beenuar/AiSOC/graphs/contributors).
+
+Thank you to everyone who has filed an issue, shipped a PR, or quietly improved this project.
+
+---
+
 ## Security
 
 For security issues, please do not open a public issue. Use [GitHub's private vulnerability reporting](https://github.com/beenuar/AiSOC/security/advisories/new). Full policy in [SECURITY.md](SECURITY.md). AiSOC follows coordinated disclosure.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -64,3 +64,13 @@ AiSOC is an open-source project and does not currently operate a paid bounty pro
 ## Hall of fame
 
 We publicly thank researchers who report valid issues. Once a fix has shipped, we credit reporters (with their consent) in the corresponding [GitHub Security Advisory](https://github.com/beenuar/AiSOC/security/advisories) and the relevant `CHANGELOG.md` entry.
+
+The full list of credited researchers lives in [CREDITS.md](CREDITS.md#security-researchers). Highlights:
+
+| Reporter | Issue / PR | Summary |
+| --- | --- | --- |
+| [@TanmayZade](https://github.com/TanmayZade) | [#220](https://github.com/beenuar/AiSOC/issues/220) → [PR #219](https://github.com/beenuar/AiSOC/pull/219) | Prompt injection in classification agents leading to alert auto-close bypass. Reporter also authored the fix (prompt sanitiser + untrusted-content wrapping). |
+| [@mangod12](https://github.com/mangod12) | [#159](https://github.com/beenuar/AiSOC/issues/159) → [PR #221](https://github.com/beenuar/AiSOC/pull/221) | Proposed cross-tenant isolation tests + nightly CI for RBAC regression; informed the tenant-isolation hardening on the detection-loop endpoint. |
+| [@jay-cyble](https://github.com/jay-cyble) | [#130](https://github.com/beenuar/AiSOC/issues/130) | Structured review of 13 security & UI issues found via code review + live-site inspection. |
+
+If you've reported a valid issue and aren't listed here, please open a PR against [CREDITS.md](CREDITS.md) — we'd rather over-credit than miss anyone.


### PR DESCRIPTION
## Summary

Adds a dedicated **CREDITS.md** and surfaces credits in **README.md** and **SECURITY.md** so contributors and security researchers are visibly thanked in the repo, not just in private advisories or commit history.

### What changed

- **`CREDITS.md`** (new) — full list covering:
  - Security researchers (with the issue/PR they reported or fixed)
  - Code contributors outside the core team (with first merged contribution)
  - Bug reporters & community feedback
  - Automation (Dependabot)
  - Maintainers
  - "How to be added here" guide
- **`README.md`** — short Credits block placed just before the Security section, linking to `CREDITS.md` and to the GitHub contributors graph.
- **`SECURITY.md`** — the previously-empty Hall of Fame is now populated with the researchers who reported and/or fixed real issues (#220, #159, #130) and links to `CREDITS.md` for the full list.

### Who's credited (initial list)

**Security researchers**
- @TanmayZade — reported & fixed prompt-injection auto-close bypass (#220 → #219)
- @mangod12 — proposed cross-tenant isolation tests + nightly RBAC regression CI (#159), informed #221
- @jay-cyble — structured review of 13 security & UI findings (#130)

**Code contributors (community)**
- @jay-cyble — first community PR (#135 — UEBA env-var alignment)
- @prince30121 — infra & CI fixes
- @ARDA7787 — Redis scheduler singleton + dependency-CVE audit CI (#218)
- @TanmayZade — prompt sanitiser + untrusted-content wrapping across classification agents (#219)

**Community feedback** — @cyberdometanza, @AMoneronIQBusiness, @ThiagoDataEngineer, @alvarofraguas, @sonalig-cyble (with linked issues).

### Why

- Security researchers who report responsibly deserve visible credit.
- Community contributors should be able to point to a public list of their contributions.
- Reduces the risk of quietly missing someone — there is now a documented PR-against-CREDITS.md path to be added.

## Test plan

No code changes — docs only.

- [x] CREDITS.md renders correctly on GitHub
- [x] All @username mentions link to existing GitHub profiles
- [x] All #NNN issue / PR references link to real issues / PRs in this repo
- [x] README.md Credits section links to CREDITS.md and the contributors graph
- [x] SECURITY.md Hall of Fame links to CREDITS.md#security-researchers

If anyone listed here would prefer not to be credited (or wants their entry edited), please reply on this PR or open a follow-up PR against CREDITS.md and we'll adjust before merging.

Made with [Cursor](https://cursor.com)