### PR TITLE
chore(deps): bump zod from 3.25.76 to 4.4.3

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -248,10 +248,10 @@ importers:
     dependencies:
       '@modelcontextprotocol/sdk':
         specifier: ^1.0.4
-        version: 1.29.0(zod@3.25.76)
+        version: 1.29.0(zod@4.4.3)
       zod:
-        specifier: ^3.23.8
-        version: 3.25.76
+        specifier: ^4.4.3
+        version: 4.4.3
     devDependencies:
       '@types/node':
         specifier: ^20.11.5
@@ -4465,7 +4465,7 @@ packages:
       react: 19.2.6
     dev: false
 
-  /@modelcontextprotocol/sdk@1.29.0(zod@3.25.76):
+  /@modelcontextprotocol/sdk@1.29.0(zod@4.4.3):
     resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
     engines: {node: '>=18'}
     peerDependencies:
@@ -4490,8 +4490,8 @@ packages:
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
       raw-body: 3.0.2
-      zod: 3.25.76
-      zod-to-json-schema: 3.25.2(zod@3.25.76)
+      zod: 4.4.3
+      zod-to-json-schema: 3.25.2(zod@4.4.3)
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -9251,8 +9251,8 @@ packages:
       '@babel/parser': 7.29.3
       eslint: 9.39.4
       hermes-parser: 0.25.1
-      zod: 3.25.76
-      zod-validation-error: 4.0.2(zod@3.25.76)
+      zod: 4.4.3
+      zod-validation-error: 4.0.2(zod@4.4.3)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -16592,25 +16592,25 @@ packages:
     engines: {node: '>=12.20'}
     dev: false
 
-  /zod-to-json-schema@3.25.2(zod@3.25.76):
+  /zod-to-json-schema@3.25.2(zod@4.4.3):
     resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
     peerDependencies:
       zod: ^3.25.28 || ^4
     dependencies:
-      zod: 3.25.76
+      zod: 4.4.3
     dev: false
 
-  /zod-validation-error@4.0.2(zod@3.25.76):
+  /zod-validation-error@4.0.2(zod@4.4.3):
     resolution: {integrity: sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
     dependencies:
-      zod: 3.25.76
+      zod: 4.4.3
     dev: true
 
-  /zod@3.25.76:
-    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+  /zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
   /zustand@4.5.7(@types/react@19.2.15)(react@19.2.6):
     resolution: {integrity: sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==}

--- a/services/mcp/package.json
+++ b/services/mcp/package.json
@@ -51,7 +51,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.4",
-    "zod": "^3.23.8"
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@types/node": "^20.11.5",

--- a/services/mcp/src/tools/alerts.ts
+++ b/services/mcp/src/tools/alerts.ts
@@ -164,90 +164,22 @@ function summariseAlert(a: AlertResponse): Record<string, unknown> {
 }
 
 /**
- * Local zod→JSON-Schema converter. We keep this in the tools layer so the
- * server doesn't have to import zod itself; we only need a subset of the
- * spec (object types with strings/numbers/enums/booleans) which is easier
- * to maintain than pulling in `zod-to-json-schema` (~30kB for what we use).
+ * Convert a zod schema to JSON Schema for MCP tool input descriptors.
  *
- * If we hit a corner case the tool layer needs (recursive types, unions of
- * objects, etc.) we'll switch to the dedicated package; for now the strict
- * argument schemas stay simple enough for this to hold.
+ * Zod 4 ships `z.toJSONSchema()` natively (was previously a third-party
+ * package). We use the `input` target since these schemas describe tool
+ * *arguments* — the host validates inputs against this shape, and `input`
+ * leaves `.default()` fields optional rather than required.
  *
- * Exported so other tool files can reuse it (see `cases.ts`, `investigations.ts`).
+ * Exported so other tool files can reuse it (see `cases.ts`,
+ * `investigations.ts`, `detections.ts`, `lake.ts`).
  */
-export function zodToJsonSchema(schema: z.ZodTypeAny): Record<string, unknown> {
-  return zodToJson(schema);
-}
-
-function zodToJson(schema: z.ZodTypeAny): Record<string, unknown> {
-  const def = schema._def as { typeName: string } & Record<string, unknown>;
-  switch (def.typeName) {
-    case "ZodObject": {
-      const shape = (schema as unknown as { shape: Record<string, z.ZodTypeAny> }).shape;
-      const properties: Record<string, unknown> = {};
-      const required: string[] = [];
-      for (const [key, child] of Object.entries(shape)) {
-        properties[key] = zodToJson(child);
-        if (!child.isOptional()) required.push(key);
-      }
-      const out: Record<string, unknown> = {
-        type: "object",
-        properties,
-        additionalProperties: false,
-      };
-      if (required.length > 0) out.required = required;
-      return out;
-    }
-    case "ZodString": {
-      const checks = (def.checks ?? []) as Array<{ kind: string }>;
-      const out: Record<string, unknown> = { type: "string" };
-      if (checks.some((c) => c.kind === "uuid")) out.format = "uuid";
-      const description = (schema as unknown as { description?: string }).description;
-      if (description) out.description = description;
-      return out;
-    }
-    case "ZodNumber": {
-      const out: Record<string, unknown> = { type: "number" };
-      const checks = (def.checks ?? []) as Array<{ kind: string; value?: number; inclusive?: boolean }>;
-      if (checks.some((c) => c.kind === "int")) out.type = "integer";
-      for (const check of checks) {
-        if (check.kind === "min" && typeof check.value === "number") out.minimum = check.value;
-        if (check.kind === "max" && typeof check.value === "number") out.maximum = check.value;
-      }
-      const description = (schema as unknown as { description?: string }).description;
-      if (description) out.description = description;
-      return out;
-    }
-    case "ZodBoolean": {
-      const out: Record<string, unknown> = { type: "boolean" };
-      const description = (schema as unknown as { description?: string }).description;
-      if (description) out.description = description;
-      return out;
-    }
-    case "ZodEnum": {
-      const values = (def.values ?? []) as string[];
-      const out: Record<string, unknown> = { type: "string", enum: values };
-      const description = (schema as unknown as { description?: string }).description;
-      if (description) out.description = description;
-      return out;
-    }
-    case "ZodOptional": {
-      const inner = (def.innerType ?? schema) as z.ZodTypeAny;
-      return zodToJson(inner);
-    }
-    case "ZodDefault": {
-      const inner = (def.innerType ?? schema) as z.ZodTypeAny;
-      const defVal = (def.defaultValue as () => unknown)();
-      return { ...zodToJson(inner), default: defVal };
-    }
-    case "ZodArray": {
-      const inner = (def.type ?? schema) as z.ZodTypeAny;
-      return { type: "array", items: zodToJson(inner) };
-    }
-    default:
-      // Conservative fallback — describe as JSON of any shape. The MCP host
-      // will still call the tool and zod's runtime parse will catch
-      // anything genuinely malformed.
-      return { description: `Unsupported schema type ${def.typeName}` };
-  }
+export function zodToJsonSchema(schema: z.ZodType): Record<string, unknown> {
+  return z.toJSONSchema(schema, {
+    target: "draft-7",
+    io: "input",
+    // MCP hosts expect concrete object schemas with `additionalProperties: false`
+    // (matches the prior hand-rolled behaviour). zod 4 sets this from `.strict()`
+    // on the source schema, which all our top-level argument schemas already use.
+  }) as Record<string, unknown>;
 }


### PR DESCRIPTION
## Summary

Replaces Dependabot PR #207, which carried a stale `pnpm-lock.yaml` and a `TS2352` error against zod 4's internal API. This PR brings the repo to **zod 4.4.3** and fixes the breaking-change surface in the MCP tool layer.

## Changes

- `services/mcp/package.json`: `zod ^3.23.8` → `^4.4.3`
- `services/mcp/src/tools/alerts.ts`: replace the hand-rolled `zodToJsonSchema` helper (which reached into zod 3's `_def` internals) with zod 4's native `z.toJSONSchema()`, targeting `draft-7` with `io: "input"` so MCP hosts see argument-shaped schemas:
  - default fields stay optional (not required)
  - `additionalProperties: false` continues to flow from the `.strict()` source schemas
  - the helper is still exported so `cases.ts`, `investigations.ts`, `detections.ts`, and `lake.ts` keep working unchanged
- `pnpm-lock.yaml`: regenerated via `npx pnpm@8.15.1 install --lockfile-only` so `lockfileVersion` stays at `'6.0'` (the version CI's `pnpm/action-setup@v4` picks up from the `packageManager` field). Diff is scoped to the `zod` graph.

## Why a new PR instead of rebasing #207

PR #207 was authored against an older `main` where:
1. The custom `zodToJsonSchema` poked at `schema._def`, which zod 4 no longer exposes the same way → `TS2352` at compile.
2. The shipped lockfile diff was generated with the wrong pnpm major and failed `pnpm install --frozen-lockfile` in CI.

Rebasing kept producing `pnpm-lock.yaml` conflicts on every retry, so a clean branch off the current `main` is the simpler, lower-risk path.

## Test plan

Verified locally on the merge commit candidate:

- [x] `pnpm --filter @aisoc/mcp typecheck` — clean
- [x] `pnpm --filter @aisoc/mcp test` — **102/102** vitest tests pass
- [x] `pnpm --filter @aisoc/mcp build` — clean (`tsc -p tsconfig.json` then chmod)
- [x] `pnpm -r --filter '!@aisoc/mcp' typecheck` — clean
- [x] `pnpm run type-check` (root, via turbo) — clean
- [x] `pnpm run lint` (root, via turbo) — 0 errors (76 pre-existing warnings, no new ones)

CI to confirm on push.

Closes #207

Made with [Cursor](https://cursor.com)