### PR TITLE
fix(compose): make full stack boot — quote reserved "window" column + ship pydantic[email]

### DIFF
--- a/services/api/Dockerfile
+++ b/services/api/Dockerfile
@@ -36,7 +36,7 @@ RUN set -eux; \
         pip install --no-cache-dir \
             "fastapi>=0.111,<0.112" \
             "uvicorn[standard]>=0.29,<0.30" \
-            "pydantic>=2.7,<2.11" \
+            "pydantic[email]>=2.7,<2.14" \
             "pydantic-settings>=2.2,<3" \
             "sqlalchemy[asyncio]>=2.0.30,<3" \
             "asyncpg>=0.29,<0.32" \

--- a/services/api/app/api/v1/endpoints/attack_chain.py
+++ b/services/api/app/api/v1/endpoints/attack_chain.py
@@ -140,7 +140,7 @@ async def get_attack_chain(
             text(
                 """
                 INSERT INTO aisoc_attack_chains (
-                    tenant_id, seed_alert_id, case_id, window,
+                    tenant_id, seed_alert_id, case_id, "window",
                     chain, entity_graph, chain_signature, confidence,
                     updated_at
                 ) VALUES (
@@ -148,7 +148,7 @@ async def get_attack_chain(
                     CAST(:chain AS JSONB), CAST(:entity_graph AS JSONB),
                     :signature, :confidence, NOW()
                 )
-                ON CONFLICT (tenant_id, seed_alert_id, window, chain_signature)
+                ON CONFLICT (tenant_id, seed_alert_id, "window", chain_signature)
                 DO UPDATE SET
                     case_id      = EXCLUDED.case_id,
                     chain        = EXCLUDED.chain,

--- a/services/api/migrations/041_attack_chains.sql
+++ b/services/api/migrations/041_attack_chains.sql
@@ -56,7 +56,10 @@ CREATE TABLE IF NOT EXISTS aisoc_attack_chains (
     tenant_id           UUID NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
     seed_alert_id       UUID NOT NULL,
     case_id             UUID,
-    window              VARCHAR(8) NOT NULL,
+    -- "window" is a reserved keyword in Postgres; it must be quoted
+    -- everywhere it is used as an identifier (column def, constraints,
+    -- and in the application's INSERT/ON CONFLICT statements).
+    "window"            VARCHAR(8) NOT NULL,
     chain               JSONB NOT NULL DEFAULT '[]'::jsonb,
     entity_graph        JSONB NOT NULL DEFAULT '{}'::jsonb,
     chain_signature     VARCHAR(64) NOT NULL,
@@ -64,9 +67,9 @@ CREATE TABLE IF NOT EXISTS aisoc_attack_chains (
     created_at          TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     updated_at          TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     CONSTRAINT aisoc_attack_chains_window_check
-        CHECK (window IN ('1h', '6h', '24h', '72h', '7d', '30d')),
+        CHECK ("window" IN ('1h', '6h', '24h', '72h', '7d', '30d')),
     CONSTRAINT aisoc_attack_chains_unique_signature
-        UNIQUE (tenant_id, seed_alert_id, window, chain_signature)
+        UNIQUE (tenant_id, seed_alert_id, "window", chain_signature)
 );
 
 CREATE INDEX IF NOT EXISTS aisoc_attack_chains_seed_idx

--- a/services/api/pyproject.toml
+++ b/services/api/pyproject.toml
@@ -10,7 +10,10 @@ readme = "README.md"
 python = "^3.11"
 fastapi = ">=0.111,<0.137"
 uvicorn = { version = ">=0.29,<0.49", extras = ["standard"] }
-pydantic = ">=2.7,<2.14"
+# EmailStr (used in auth/passkeys/tenants endpoints) requires the optional
+# email-validator package, which is only pulled in via the "email" extra.
+# Without it the API crashes on import with "email-validator is not installed".
+pydantic = { version = ">=2.7,<2.14", extras = ["email"] }
 pydantic-settings = "^2.2.1"
 sqlalchemy = { version = "^2.0.30", extras = ["asyncio"] }
 asyncpg = ">=0.29.0,<0.32"


### PR DESCRIPTION
## Summary

The `docker compose up — full stack` (Compose Smoke) CI job had been **chronically red**, meaning the product could not actually boot end-to-end. Root-caused and fixed two independent, product-breaking bugs. The full-stack smoke job now **passes** (first green in a long time).

### Bug 1 — Postgres init crash (`aisoc-postgres exited (3)`)
`services/api/migrations/041_attack_chains.sql` used `window` (a **reserved keyword** in Postgres) as an unquoted column name. Postgres refused to run the migration on container init:

```
ERROR: syntax error at or near "window"
```

Because migrations are mounted into `/docker-entrypoint-initdb.d`, this killed the DB container on startup and took the whole stack down.

**Fix:** quote the identifier as `"window"` everywhere it is used:
- column definition, `CHECK` constraint, and `UNIQUE` constraint in the migration
- the raw `INSERT ... ON CONFLICT` in `services/api/app/api/v1/endpoints/attack_chain.py`

### Bug 2 — API container crash on import (`email-validator is not installed`)
`app/api/v1/endpoints/auth.py` uses Pydantic's `EmailStr`, which requires the optional `email-validator` package. `pydantic` was declared **without** the `[email]` extra, so neither the Poetry install nor the Dockerfile pip-fallback shipped it. The `aisoc-api` container crashed on import.

**Fix:**
- `services/api/pyproject.toml`: `pydantic = { version = ">=2.7,<2.14", extras = ["email"] }`
- `services/api/Dockerfile`: pip fallback now installs `pydantic[email]>=2.7,<2.14`

## Test plan
- [x] `docker compose up — full stack` CI job passes (5m34s) — previously failing
- [x] All other CI checks green (Python/Go/TS lint, type-check, tests, builds, CodeQL, OpenAPI verify, compose validate)
- [x] Local: `email_validator` importable after `pyproject.toml` change
- [x] Local: Postgres init runs `041_attack_chains.sql` without syntax error

> Note: the `security-audit` check remains red — this is the pre-existing, accepted failure surfacing transitive-dependency CVEs (langchain/cryptography/starlette/idna + pnpm transitive deps) unrelated to this change. Tracked separately.