### PR TITLE
ci: grant contents:write to OpenAPI auto-export job

### DIFF
--- a/.github/workflows/check-openapi.yml
+++ b/.github/workflows/check-openapi.yml
@@ -58,6 +58,11 @@ jobs:
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     needs: openapi-check
+    # The default GITHUB_TOKEN is read-only under the repo's restrictive
+    # token policy, so the commit/push step below 403s. Grant write scope so
+    # the bot can push the regenerated docs/openapi.yaml back to main.
+    permissions:
+      contents: write
 
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Summary
The **Auto-export OpenAPI on merge to main** job has failed on every push to `main` (a recurring red X). The schema regeneration succeeds, but the follow-up `git push` of `docs/openapi.yaml` is denied:

```
remote: Permission to beenuar/AiSOC.git denied to github-actions[bot].
fatal: unable to access 'https://github.com/beenuar/AiSOC/': error: 403
```

Root cause: the job runs under the default **read-only** `GITHUB_TOKEN`, so it can't push back to `main`.

## Fix
Scope `permissions: contents: write` to the `openapi-export` job so the bot can commit the regenerated spec. The gating `openapi-check` job stays read-only.

## Risk
CI-config only; no application code changes. The export job is `push`-to-`main` only, so it's exercised after merge.

Made with [Cursor](https://cursor.com)