### PR TITLE
docs(web): surface security-hardening posture on landing page

### DIFF
--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -179,6 +179,15 @@ const faqJsonLd = {
     },
     {
       '@type': 'Question',
+      name: 'How is AiSOC kept secure and up to date?',
+      acceptedAnswer: {
+        '@type': 'Answer',
+        text:
+          'Every pull request runs a CI-gated security audit (pip-audit + pnpm audit) that blocks the merge on any unresolved CVE, alongside CodeQL static analysis. Dependencies are kept current — the cryptography floor was recently raised to 44.0.1 to clear CVE-2024-12797, and detection-loop lookups are tenant-scoped so cross-tenant reads are impossible. The audit policy lives in scripts/security_audit.py.',
+      },
+    },
+    {
+      '@type': 'Question',
       name: 'How is this benchmarked?',
       acceptedAnswer: {
         '@type': 'Answer',

--- a/apps/web/src/components/landing/sections/Faq.tsx
+++ b/apps/web/src/components/landing/sections/Faq.tsx
@@ -50,6 +50,11 @@ const FAQS: ReadonlyArray<QA> = [
       'Only inside the maturity tier you configure. L0 keeps the agent advisory only; L2 (the production default) lets it run reversible containment actions; L4 allows whitelisted closed-loop actions. Every action class is gated against blast radius.',
   },
   {
+    q: 'How is AiSOC kept secure and up to date?',
+    a:
+      'Every pull request runs a CI-gated security audit (pip-audit + pnpm audit) that blocks the merge on any unresolved CVE, alongside CodeQL static analysis. Dependencies are kept current — the cryptography floor was recently raised to 44.0.1 to clear CVE-2024-12797, and detection-loop lookups are tenant-scoped so cross-tenant reads are impossible. The audit policy lives in scripts/security_audit.py.',
+  },
+  {
     q: 'How is this benchmarked?',
     a:
       'Five pytest suites in services/agents/tests/ run on every PR. Three are substrate self-consistency gates; the fourth is a real measurement against a fixed 1,000-alert noisy stream; the fifth is a coverage gate on the synthetic telemetry corpus. The methodology page documents what each suite measures and what it does not.',

--- a/apps/web/src/components/landing/sections/Pillars.tsx
+++ b/apps/web/src/components/landing/sections/Pillars.tsx
@@ -63,7 +63,7 @@ const PILLARS: ReadonlyArray<Pillar> = [
     icon: Sparkles,
     title: 'Agentic and auditable',
     body:
-      'Four named agents. Every prompt, tool call, and decision is logged. The LLM-input contract fails closed on malformed prompts.',
+      'Four named agents. Every prompt, tool call, and decision is logged, the LLM-input contract fails closed on malformed prompts, and a CI-gated CVE audit blocks every merge.',
     stat: '4 / 100%',
     statLabel: 'agents · audited',
     href: 'https://github.com/beenuar/AiSOC#readme',


### PR DESCRIPTION
## Summary
Syncs the `tryaisoc.com` marketing copy to the **v7.3.1 security & stability wave** that just landed in the README (PR #230), so the site messaging matches the refreshed docs. Content/SEO copy only — no deploy, no infra/token changes.

- **FAQ** — new entry: *"How is AiSOC kept secure and up to date?"* covering the CI-gated security audit (`pip-audit` + `pnpm audit`), CodeQL, the `cryptography` 44.0.1 floor that cleared CVE-2024-12797, and tenant-scoped detection-loop lookups.
- **JSON-LD** — the same Q&A is mirrored in the FAQ structured data in `page.tsx` so crawler copy stays in parity with the visible accordion.
- **Pillars** — the *"Agentic and auditable"* pillar now notes the CI-gated CVE audit gating every merge.

## Test plan
- [x] `ReadLints` clean on all three edited files
- [ ] CI green (build / lint / typecheck)
- [ ] Manual: FAQ accordion renders the new entry; pillar copy reads correctly

Made with [Cursor](https://cursor.com)