### PR TITLE
feat(web): point landing CTAs at the live dashboard (not /signup)

### DIFF
--- a/apps/web/src/components/landing/sections/Hero.tsx
+++ b/apps/web/src/components/landing/sections/Hero.tsx
@@ -116,10 +116,10 @@ export function Hero() {
             style={{ animationDelay: '540ms' }}
           >
             <Link
-              href="https://tryaisoc.com/signup"
+              href="https://tryaisoc.com/dashboard"
               className="group inline-flex h-11 w-full items-center justify-center gap-2 rounded-md bg-velvet-emerald-cta px-6 text-sm font-semibold text-velvet-content-primary shadow-[0_1px_0_rgba(255,255,255,0.18)_inset] transition-[filter,box-shadow,transform] duration-200 ease-landing-out-quart hover:brightness-110 motion-safe:hover:shadow-glow-emerald-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-velvet-emerald-mint focus-visible:ring-offset-2 focus-visible:ring-offset-velvet-surface-base sm:w-auto"
             >
-              Start free on managed
+              Open the live dashboard
               <ArrowRight
                 className="h-4 w-4 transition-transform duration-200 ease-landing-out-quart group-hover:translate-x-0.5 motion-reduce:transition-none motion-reduce:group-hover:translate-x-0"
                 aria-hidden="true"

--- a/apps/web/src/components/landing/sections/StickyNav.tsx
+++ b/apps/web/src/components/landing/sections/StickyNav.tsx
@@ -109,10 +109,10 @@ export function StickyNav() {
             Self-host
           </Link>
           <Link
-            href="https://tryaisoc.com/signup"
+            href="https://tryaisoc.com/dashboard"
             className="group inline-flex items-center gap-1 rounded-md bg-velvet-emerald-cta px-4 py-1.5 text-sm font-semibold text-velvet-content-primary shadow-[0_1px_0_rgba(255,255,255,0.18)_inset] transition-[filter,box-shadow] duration-200 ease-landing-out-quart hover:brightness-110 motion-safe:hover:shadow-glow-emerald-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-velvet-emerald-mint focus-visible:ring-offset-2 focus-visible:ring-offset-velvet-surface-base"
           >
-            Start free
+            Open dashboard
             <ArrowRight
               className="h-3.5 w-3.5 transition-transform duration-200 ease-landing-out-quart group-hover:translate-x-0.5 motion-reduce:transition-none motion-reduce:group-hover:translate-x-0"
               aria-hidden="true"
@@ -167,11 +167,11 @@ export function StickyNav() {
             Self-host
           </a>
           <Link
-            href="https://tryaisoc.com/signup"
+            href="https://tryaisoc.com/dashboard"
             onClick={() => setOpen(false)}
             className="flex-1 rounded-md bg-velvet-emerald-cta px-3 py-2 text-center text-sm font-semibold text-velvet-content-primary motion-safe:shadow-glow-emerald-sm"
           >
-            Start free
+            Open dashboard
           </Link>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- The hero and sticky-nav **Start free** CTAs linked to `https://tryaisoc.com/signup`, which is **not a real route** — AiSOC is open-source / self-hosted and the managed offering is waitlist-only, so the link dead-ended.
- Repointed all three CTAs (hero, sticky-nav desktop, sticky-nav mobile) to **`https://tryaisoc.com/dashboard`** — the always-on hosted demo — so visitors can click through and immediately play with the product.
- Relabeled the buttons to match intent: **"Open the live dashboard"** (hero) and **"Open dashboard"** (nav).

The `/dashboard` route exists (`apps/web/src/app/(app)/dashboard`). The remaining `/signup` references in the tree are the backend waitlist API endpoint (`/v1/waitlist/signup`) and a sitemap comment — both accurate and intentionally left.

## Test plan
- [ ] Hero primary CTA navigates to `/dashboard`
- [ ] Sticky-nav desktop + mobile CTAs navigate to `/dashboard`
- [ ] No dead `/signup` links remain in the marketing surface

Made with [Cursor](https://cursor.com)