### PR TITLE
fix(infra): keep API/agents machines warm so the 6PN proxy stays reachable (dashboard 500 fix)

### DIFF
--- a/infra/fly/agents/fly.toml
+++ b/infra/fly/agents/fly.toml
@@ -35,7 +35,10 @@ kill_timeout   = "10s"            # agent runs may need to flush ledger writes
 [http_service]
   internal_port       = 8084
   force_https         = true
-  auto_stop_machines  = "stop"
+  # Never auto-stop: the web app proxies AI Copilot / agent calls over 6PN
+  # (aisoc-demo-agents.internal:8084), and 6PN connections do NOT trigger Fly's
+  # auto-start, so a stopped machine 500s the Copilot. Keep it warm 24/7.
+  auto_stop_machines  = "off"
   auto_start_machines = true
   min_machines_running = 1
   processes           = ["app"]

--- a/infra/fly/api/fly.toml
+++ b/infra/fly/api/fly.toml
@@ -80,7 +80,12 @@ kill_timeout   = "5s"
 [http_service]
   internal_port       = 8000
   force_https         = true
-  auto_stop_machines  = "stop"
+  # Never auto-stop: the web app proxies /api/v1/* over 6PN
+  # (aisoc-demo-api.internal:8000), and 6PN connections do NOT trigger Fly's
+  # auto-start. A stopped machine therefore 500s the dashboard's metrics calls
+  # even though the public api.tryaisoc.com edge would auto-start it. Keeping
+  # the single demo machine warm 24/7 makes the internal proxy reliable.
+  auto_stop_machines  = "off"
   auto_start_machines = true
   min_machines_running = 1       # keep one warm for sub-60s TTFI
   processes           = ["app"]


### PR DESCRIPTION
## Summary
Fixes the intermittent **HTTP 500s on the live dashboard** (`/api/v1/metrics/dashboard`, `/api/v1/metrics/funnel`, pipeline health) and the same failure mode for the **AI Copilot**.

**Root cause:** the web app proxies `/api/v1/*` and agent calls over Fly's private **6PN** network (`aisoc-demo-api.internal:8000`, `aisoc-demo-agents.internal:8084`). Both services ran with `auto_stop_machines = "stop"` and a single machine. Fly only auto-starts a stopped machine on **public edge** traffic — **6PN internal connections do NOT trigger auto-start**. So once the single machine auto-stopped, the web app's internal proxy could not reach it and returned 500, even though `api.tryaisoc.com` (public edge) would have woken it.

**Fix:** set `auto_stop_machines = "off"` for both API and agents. With `min_machines_running = 1`, the single demo machine stays warm 24/7, so the internal 6PN proxy is always reachable.
- `realtime` was already `"off"` — no change.
- `web` is reached via the public edge (auto-starts), so it can keep auto-stopping — no change.

## Why the dashboard degraded "gracefully" but still showed errors
The frontend already falls back to baseline mock data and SWR-retries every 4s, so the page stayed usable — but the red "metrics unavailable / API 503" banners persisted because the upstream 6PN call never succeeded while the machine was stopped.

## Deploy notes
- `deploy-api.yml` triggers on `infra/fly/api/**` → **the API fix auto-deploys on merge** and resolves the reported dashboard 500s.
- There is **no `deploy-agents.yml`** workflow, so the agents config change lands as correct config but needs a manual `flyctl deploy --config infra/fly/agents/fly.toml` to take effect.

## Test plan
- [ ] After merge + API deploy, load `https://tryaisoc.com/dashboard` and confirm the metrics banners are gone and live numbers render.
- [ ] `curl -s -o /dev/null -w '%{http_code}' https://tryaisoc.com/api/v1/metrics/dashboard` returns `200`/`401` (auth) rather than `500`.
- [ ] Confirm the API machine reports `started` and does not auto-stop (`fly status -a aisoc-demo-api`).
- [ ] (Follow-up) Manually deploy agents and verify AI Copilot responds without intermittent 500s.

Made with [Cursor](https://cursor.com)