### PR TITLE
feat(infra): add Azure Terraform skeleton (mirror of gcp)

### DIFF
--- a/infra/terraform/README.md
+++ b/infra/terraform/README.md
@@ -139,6 +139,21 @@ RDS and OpenSearch take a final snapshot before deletion (set explicitly in
 the modules). The S3 state bucket and DynamoDB lock table are **not** managed
 by this configuration and survive `destroy`.
 
+## Alternate cloud skeletons
+
+This directory is the AWS/EKS reference. Two serverless-container skeletons
+exist for teams that don't want to run Kubernetes:
+
+- `infra/terraform/gcp/` — Cloud Run + Cloud SQL Postgres + Memorystore Redis +
+  Secret Manager + Artifact Registry, fronted by Serverless VPC Access.
+- `infra/terraform/azure/` — Container Apps + PostgreSQL Flexible Server +
+  Azure Cache for Redis + Key Vault + Container Registry, on a private VNet
+  with user-assigned managed identities. Mirrors the GCP layout file-for-file.
+
+Both deploy the `api`, `web`, and `ingest` services directly as managed
+containers (no cluster), and emit the same env-var contract documented in
+`apps/docs/docs/deployment/env-vars.md`.
+
 ## Related docs
 
 - `apps/docs/docs/deployment/kubernetes.md` — production deployment guide.

--- a/infra/terraform/azure/README.md
+++ b/infra/terraform/azure/README.md
@@ -1,0 +1,188 @@
+# AiSOC on Azure — Terraform skeleton
+
+A serverless-first deployment of the AiSOC stack on Microsoft Azure, mirroring
+the [GCP skeleton](../gcp/README.md):
+
+- **Azure Container Apps** for the API (FastAPI), web console (Next.js), and
+  ingest gateway
+- **Azure Database for PostgreSQL Flexible Server 16** for the application
+  database (VNet-integrated private access, no public endpoint)
+- **Azure Cache for Redis** for queues, rate limits, and websocket fan-out
+  (private endpoint, TLS-only)
+- **Azure Key Vault** for the application secrets (DB password, `SECRET_KEY`,
+  `AISOC_CREDENTIAL_KEY`, Redis auth, optional `OPENAI_API_KEY`)
+- **Azure Container Registry** as the registry CI pushes to
+- **User-assigned managed identities** so each Container App pulls its own
+  image and reads only the secrets it needs — no registry passwords or
+  connection strings on disk
+
+> This is the **skeleton** — a buyer-friendly starting point that runs the
+> three customer-visible services. Long-running workloads (`agents`,
+> `realtime`, `connectors`, `threatintel`, `alert-fusion`, `fusion`) need
+> always-on compute and are deferred to a follow-up plan. See
+> [Limitations](#limitations).
+
+## Layout
+
+```
+infra/terraform/azure/
+├── README.md                ← you are here
+├── versions.tf              ← terraform + provider pinning, provider features
+├── variables.tf             ← input variables (defaults targeting startup credit)
+├── main.tf                  ← resource group, VNet + subnets, Log Analytics,
+│                              Container Apps environment, ACR
+├── database.tf              ← Postgres Flexible Server + DB + private DNS
+├── redis.tf                 ← Azure Cache for Redis + private endpoint
+├── secrets.tf               ← Key Vault + generated/optional secret values
+├── iam.tf                   ← per-service managed identities + role assignments
+├── container_apps.tf        ← api / web / ingest Container Apps
+├── outputs.tf               ← URLs, connection targets, identity + vault IDs
+└── terraform.tfvars.example ← copy → terraform.tfvars and override
+```
+
+Files are split by concern, not by module, to keep the skeleton legible. Lift
+into modules when you start running multiple environments off the same code.
+
+## Prerequisites
+
+1. **An Azure subscription** with credits or billing attached.
+2. **`az` authenticated** (`az login`) as a principal that can create resource
+   groups, Container Apps, Postgres, Key Vault, and **role assignments**.
+   Granting role assignments needs `Owner` or `User Access Administrator` on
+   the subscription (the apply wires AcrPull + Key Vault Secrets User itself).
+3. **Terraform 1.5+** and the `azurerm` 3.116 provider (the lockfile pins the
+   exact versions on first `init`).
+4. (Optional) **A storage account for remote state** — recommended for anything
+   beyond a personal sandbox; see *State backend* below.
+
+## Quick start
+
+```bash
+cd infra/terraform/azure
+cp terraform.tfvars.example terraform.tfvars
+$EDITOR terraform.tfvars            # optional — defaults already work
+
+az login
+az account set --subscription <subscription-id>
+
+terraform init
+terraform plan -out tfplan          # review the proposed plan
+terraform apply tfplan
+```
+
+A full apply against an empty subscription takes ~15 minutes — most of that is
+the Postgres Flexible Server and the Redis private endpoint. After apply, the
+`api_url`, `web_url`, and `ingest_url` outputs are publicly reachable
+immediately (Container Apps ingress issues a managed TLS cert per service).
+
+## State backend
+
+Terraform state is **not configured** by default so you can pick what fits.
+For anything shared across operators, use an Azure Storage backend:
+
+1. Create the state container once (outside Terraform):
+   ```bash
+   az group create -n aisoc-tfstate -l eastus
+   az storage account create -g aisoc-tfstate -n aisoctfstate$RANDOM \
+     --sku Standard_LRS --encryption-services blob
+   az storage container create -n tfstate --account-name <account-name>
+   ```
+2. Add a `backend "azurerm"` block to `versions.tf`:
+   ```hcl
+   backend "azurerm" {
+     resource_group_name  = "aisoc-tfstate"
+     storage_account_name = "<account-name>"
+     container_name       = "tfstate"
+     key                  = "azure.tfstate"
+   }
+   ```
+3. Re-run `terraform init -migrate-state`.
+
+## Container images
+
+The defaults point at the public GHCR demo images
+(`ghcr.io/beenuar/aisoc-{api,web,ingest}:latest`) so the skeleton runs with
+zero CI work. For a real deployment, push your own images to the ACR this stack
+provisions:
+
+```bash
+ACR=$(terraform output -raw container_registry_login_server)
+az acr login --name "${ACR%%.*}"
+
+docker build -t $ACR/api:$(git rev-parse --short HEAD)    services/api
+docker push     $ACR/api:$(git rev-parse --short HEAD)
+# repeat for web + ingest
+
+terraform apply \
+  -var "api_image=$ACR/api:<sha>" \
+  -var "web_image=$ACR/web:<sha>" \
+  -var "ingest_image=$ACR/ingest:<sha>"
+```
+
+The managed identities already hold `AcrPull`, so no registry admin user or
+password is needed.
+
+## Connecting to Postgres from your laptop
+
+The Flexible Server has no public endpoint — it's only resolvable inside the
+VNet via the `privatelink.postgres.database.azure.com` zone. Reach it through a
+jump host in the VNet, a point-to-site VPN, or temporarily enable a public
+firewall rule. The admin password lives in Key Vault:
+
+```bash
+VAULT=$(terraform output -raw key_vault_name)
+az keyvault secret show --vault-name "$VAULT" --name postgres-password \
+  --query value -o tsv
+```
+
+## Costs
+
+Defaults are chosen so a fresh apply fits inside an Azure free-trial / startup
+envelope:
+
+| Resource                  | Default               | ~Monthly cost (East US) |
+| ------------------------- | --------------------- | ----------------------- |
+| Postgres Flexible Server  | `GP_Standard_D2s_v3`  | ~$135                   |
+| Azure Cache for Redis     | `Standard C1` (1 GB)  | ~$55                    |
+| Container Apps (idle)     | 0–10 replicas         | ~$0 (scale-to-zero)     |
+| Container Registry        | `Standard`            | ~$20                    |
+| Key Vault + Log Analytics | low volume            | ~$5                     |
+
+For the cheapest sandbox set `postgres_sku = "B_Standard_B1ms"` and
+`redis_sku = "Basic"` in `terraform.tfvars`.
+
+## Limitations
+
+This is the **skeleton**, not the full migration. Known gaps:
+
+- **No long-running services.** `services/agents`, `services/realtime`,
+  `services/connectors`, `services/alert-fusion`, `services/threatintel`, and
+  `services/fusion` need always-on compute. Run them as dedicated Container
+  Apps with `min_replicas > 0` (KEDA can still scale on queue depth) or move
+  them to AKS sharing this VNet, Postgres, and Redis.
+- **Redis is TLS-only.** The non-SSL port is disabled, so the apps connect on
+  `6380` with `REDIS_SSL=true`. Confirm the AiSOC Redis client honours that
+  before pointing production traffic at it.
+- **No Azure Front Door / WAF.** Container Apps ingress gives every service a
+  managed `*.azurecontainerapps.io` certificate, fine for the skeleton. Put
+  Azure Front Door + WAF in front of the API for a custom domain and edge
+  filtering.
+- **No customer-managed keys.** Key Vault is the secret store; CMEK on
+  Postgres / Redis / ACR is a small addition deferred to keep the trust
+  boundary tight.
+- **Key Vault public access stays on** to keep first-run secret population
+  simple (it mirrors GCP Secret Manager's API-plane reachability). Lock it down
+  with a private endpoint + `network_acls` for a hardened install.
+- **Demo image source.** `ghcr.io/beenuar/aisoc-*` is the zero-config default;
+  don't ship that to production. See *Container images* above.
+
+## Tear-down
+
+```bash
+terraform destroy
+```
+
+Key Vault is created with soft-delete on but **purge-on-destroy enabled**
+(`versions.tf`), so a destroy fully removes it — back up any secrets you want
+to keep first. The Postgres server and Redis cache are deleted with the rest of
+the stack.

--- a/infra/terraform/azure/container_apps.tf
+++ b/infra/terraform/azure/container_apps.tf
@@ -1,0 +1,353 @@
+/**
+ * AiSOC — Azure serverless skeleton
+ *
+ * Container Apps for the three customer-visible workloads:
+ *
+ *   - api    — FastAPI control plane (port 8000)
+ *   - web    — Next.js console (port 3000)
+ *   - ingest — Go fan-in service that accepts /v1/ingest/batch (port 8080)
+ *
+ * Long-running workloads (agents, alert-fusion, realtime, threatintel,
+ * connectors, fusion, ocsf) intentionally aren't here — they belong on a
+ * dedicated always-on Container App (min_replicas > 0) or AKS in a follow-up
+ * plan because scale-to-zero doesn't fit websocket fan-out or scheduler loops.
+ * This skeleton ships the surface customers see first, mirroring the GCP stack.
+ *
+ * Secrets flow: Key Vault entry -> `secret { key_vault_secret_id, identity }`
+ * -> `env { secret_name }`. The managed identity reads Key Vault at revision
+ * activation time, so the apps depend on the "Key Vault Secrets User" role
+ * assignment (iam.tf) existing first.
+ */
+
+locals {
+  # Azure Postgres Flexible Server is reached by FQDN over the private DNS zone;
+  # unlike Cloud SQL there's no unix socket, so the app dials host:5432 w/ TLS.
+  postgres_host = azurerm_postgresql_flexible_server.main.fqdn
+
+  # Azure Cache for Redis with the non-SSL port disabled is TLS-only on 6380.
+  redis_host = azurerm_redis_cache.main.hostname
+  redis_port = azurerm_redis_cache.main.ssl_port
+}
+
+# ─── API ─────────────────────────────────────────────────────────────────────
+
+resource "azurerm_container_app" "api" {
+  name                         = "${var.name_prefix}-api"
+  container_app_environment_id = azurerm_container_app_environment.main.id
+  resource_group_name          = azurerm_resource_group.main.name
+  revision_mode                = "Single"
+  tags                         = var.tags
+
+  identity {
+    type         = "UserAssigned"
+    identity_ids = [azurerm_user_assigned_identity.api.id]
+  }
+
+  registry {
+    server   = azurerm_container_registry.main.login_server
+    identity = azurerm_user_assigned_identity.api.id
+  }
+
+  # ── Key Vault-backed secrets ───────────────────────────────────────────────
+  secret {
+    name                = "postgres-password"
+    identity            = azurerm_user_assigned_identity.api.id
+    key_vault_secret_id = azurerm_key_vault_secret.postgres_password.id
+  }
+  secret {
+    name                = "secret-key"
+    identity            = azurerm_user_assigned_identity.api.id
+    key_vault_secret_id = azurerm_key_vault_secret.secret_key.id
+  }
+  secret {
+    name                = "credential-key"
+    identity            = azurerm_user_assigned_identity.api.id
+    key_vault_secret_id = azurerm_key_vault_secret.credential_key.id
+  }
+  secret {
+    name                = "redis-auth"
+    identity            = azurerm_user_assigned_identity.api.id
+    key_vault_secret_id = azurerm_key_vault_secret.redis_auth.id
+  }
+  dynamic "secret" {
+    for_each = toset(var.openai_api_key == "" ? [] : ["openai"])
+    content {
+      name                = "openai-api-key"
+      identity            = azurerm_user_assigned_identity.api.id
+      key_vault_secret_id = azurerm_key_vault_secret.openai_api_key[0].id
+    }
+  }
+
+  ingress {
+    external_enabled = true
+    target_port      = 8000
+    transport        = "auto" # HTTP/1.1 + HTTP/2 + websockets (for realtime later)
+
+    traffic_weight {
+      latest_revision = true
+      percentage      = 100
+    }
+  }
+
+  template {
+    min_replicas = var.api_min_replicas
+    max_replicas = var.api_max_replicas
+
+    container {
+      name   = "api"
+      image  = var.api_image
+      cpu    = 1.0
+      memory = "2Gi"
+
+      # ── Static config ────────────────────────────────────────────────────────
+      env {
+        name  = "AISOC_DEPLOYMENT"
+        value = "azure-containerapps"
+      }
+      env {
+        name  = "ENVIRONMENT"
+        value = "production"
+      }
+      env {
+        name  = "POSTGRES_DB"
+        value = var.postgres_db_name
+      }
+      env {
+        name  = "POSTGRES_USER"
+        value = var.postgres_user
+      }
+      env {
+        name  = "POSTGRES_HOST"
+        value = local.postgres_host
+      }
+      env {
+        name  = "POSTGRES_PORT"
+        value = "5432"
+      }
+      env {
+        name  = "POSTGRES_SSLMODE"
+        value = "require"
+      }
+      env {
+        name  = "REDIS_HOST"
+        value = local.redis_host
+      }
+      env {
+        name  = "REDIS_PORT"
+        value = tostring(local.redis_port)
+      }
+      env {
+        name  = "REDIS_SSL"
+        value = "true"
+      }
+      env {
+        name  = "CORS_ORIGINS"
+        value = var.cors_origins
+      }
+
+      # ── Secret-backed env ────────────────────────────────────────────────────
+      env {
+        name        = "POSTGRES_PASSWORD"
+        secret_name = "postgres-password"
+      }
+      env {
+        name        = "SECRET_KEY"
+        secret_name = "secret-key"
+      }
+      env {
+        name        = "AISOC_CREDENTIAL_KEY"
+        secret_name = "credential-key"
+      }
+      env {
+        name        = "REDIS_PASSWORD"
+        secret_name = "redis-auth"
+      }
+      dynamic "env" {
+        for_each = toset(var.openai_api_key == "" ? [] : ["openai"])
+        content {
+          name        = "OPENAI_API_KEY"
+          secret_name = "openai-api-key"
+        }
+      }
+    }
+  }
+
+  depends_on = [
+    azurerm_role_assignment.acr_pull,
+    azurerm_role_assignment.kv_secrets_user,
+    azurerm_postgresql_flexible_server_database.aisoc,
+  ]
+}
+
+# ─── Web ─────────────────────────────────────────────────────────────────────
+
+resource "azurerm_container_app" "web" {
+  name                         = "${var.name_prefix}-web"
+  container_app_environment_id = azurerm_container_app_environment.main.id
+  resource_group_name          = azurerm_resource_group.main.name
+  revision_mode                = "Single"
+  tags                         = var.tags
+
+  identity {
+    type         = "UserAssigned"
+    identity_ids = [azurerm_user_assigned_identity.web.id]
+  }
+
+  registry {
+    server   = azurerm_container_registry.main.login_server
+    identity = azurerm_user_assigned_identity.web.id
+  }
+
+  ingress {
+    external_enabled = true
+    target_port      = 3000
+    transport        = "auto"
+
+    traffic_weight {
+      latest_revision = true
+      percentage      = 100
+    }
+  }
+
+  template {
+    min_replicas = 0
+    max_replicas = var.web_max_replicas
+
+    container {
+      name   = "web"
+      image  = var.web_image
+      cpu    = 0.5
+      memory = "1Gi"
+
+      env {
+        name  = "AISOC_DEPLOYMENT"
+        value = "azure-containerapps"
+      }
+      env {
+        name  = "NEXT_PUBLIC_API_URL"
+        value = "https://${azurerm_container_app.api.ingress[0].fqdn}"
+      }
+      env {
+        name  = "NODE_ENV"
+        value = "production"
+      }
+    }
+  }
+
+  depends_on = [azurerm_role_assignment.acr_pull]
+}
+
+# ─── Ingest ──────────────────────────────────────────────────────────────────
+
+resource "azurerm_container_app" "ingest" {
+  name                         = "${var.name_prefix}-ingest"
+  container_app_environment_id = azurerm_container_app_environment.main.id
+  resource_group_name          = azurerm_resource_group.main.name
+  revision_mode                = "Single"
+  tags                         = var.tags
+
+  identity {
+    type         = "UserAssigned"
+    identity_ids = [azurerm_user_assigned_identity.ingest.id]
+  }
+
+  registry {
+    server   = azurerm_container_registry.main.login_server
+    identity = azurerm_user_assigned_identity.ingest.id
+  }
+
+  secret {
+    name                = "postgres-password"
+    identity            = azurerm_user_assigned_identity.ingest.id
+    key_vault_secret_id = azurerm_key_vault_secret.postgres_password.id
+  }
+  secret {
+    name                = "secret-key"
+    identity            = azurerm_user_assigned_identity.ingest.id
+    key_vault_secret_id = azurerm_key_vault_secret.secret_key.id
+  }
+  secret {
+    name                = "redis-auth"
+    identity            = azurerm_user_assigned_identity.ingest.id
+    key_vault_secret_id = azurerm_key_vault_secret.redis_auth.id
+  }
+
+  ingress {
+    external_enabled = true
+    target_port      = 8080
+    transport        = "auto"
+
+    traffic_weight {
+      latest_revision = true
+      percentage      = 100
+    }
+  }
+
+  template {
+    min_replicas = 0
+    max_replicas = var.ingest_max_replicas
+
+    container {
+      name   = "ingest"
+      image  = var.ingest_image
+      cpu    = 0.5
+      memory = "1Gi"
+
+      env {
+        name  = "AISOC_DEPLOYMENT"
+        value = "azure-containerapps"
+      }
+      env {
+        name  = "POSTGRES_DB"
+        value = var.postgres_db_name
+      }
+      env {
+        name  = "POSTGRES_USER"
+        value = var.postgres_user
+      }
+      env {
+        name  = "POSTGRES_HOST"
+        value = local.postgres_host
+      }
+      env {
+        name  = "POSTGRES_PORT"
+        value = "5432"
+      }
+      env {
+        name  = "POSTGRES_SSLMODE"
+        value = "require"
+      }
+      env {
+        name  = "REDIS_HOST"
+        value = local.redis_host
+      }
+      env {
+        name  = "REDIS_PORT"
+        value = tostring(local.redis_port)
+      }
+      env {
+        name  = "REDIS_SSL"
+        value = "true"
+      }
+
+      env {
+        name        = "POSTGRES_PASSWORD"
+        secret_name = "postgres-password"
+      }
+      env {
+        name        = "SECRET_KEY"
+        secret_name = "secret-key"
+      }
+      env {
+        name        = "REDIS_PASSWORD"
+        secret_name = "redis-auth"
+      }
+    }
+  }
+
+  depends_on = [
+    azurerm_role_assignment.acr_pull,
+    azurerm_role_assignment.kv_secrets_user,
+    azurerm_postgresql_flexible_server_database.aisoc,
+  ]
+}

--- a/infra/terraform/azure/database.tf
+++ b/infra/terraform/azure/database.tf
@@ -1,0 +1,85 @@
+/**
+ * AiSOC — Azure serverless skeleton
+ *
+ * PostgreSQL Flexible Server with VNet-integrated private access (no public
+ * endpoint). The password is generated here and stored in Key Vault
+ * (secrets.tf); the Container Apps read it back as a secret-backed env var.
+ */
+
+# ─── Generated admin password ────────────────────────────────────────────────
+
+resource "random_password" "postgres" {
+  length  = 32
+  special = true
+  # Flexible Server rejects a handful of characters in the admin password.
+  override_special = "!#$%&*()-_=+[]{}<>:?"
+}
+
+# ─── Private DNS for VNet integration ────────────────────────────────────────
+#
+# Flexible Server with VNet integration requires a private DNS zone named
+# *.postgres.database.azure.com linked to the VNet so the apps resolve the
+# server's private IP.
+
+resource "azurerm_private_dns_zone" "postgres" {
+  name                = "${var.name_prefix}.private.postgres.database.azure.com"
+  resource_group_name = azurerm_resource_group.main.name
+  tags                = var.tags
+}
+
+resource "azurerm_private_dns_zone_virtual_network_link" "postgres" {
+  name                  = "${var.name_prefix}-pg-dns-link"
+  resource_group_name   = azurerm_resource_group.main.name
+  private_dns_zone_name = azurerm_private_dns_zone.postgres.name
+  virtual_network_id    = azurerm_virtual_network.main.id
+  registration_enabled  = false
+  tags                  = var.tags
+}
+
+# ─── Flexible Server ─────────────────────────────────────────────────────────
+
+resource "azurerm_postgresql_flexible_server" "main" {
+  name                = "${var.name_prefix}-pg"
+  resource_group_name = azurerm_resource_group.main.name
+  location            = azurerm_resource_group.main.location
+
+  version  = var.postgres_version
+  sku_name = var.postgres_sku
+  zone     = var.postgres_zone
+
+  storage_mb            = var.postgres_storage_mb
+  auto_grow_enabled     = true
+  backup_retention_days = 7
+
+  administrator_login    = var.postgres_user
+  administrator_password = random_password.postgres.result
+
+  # VNet integration → private only. public_network_access is implicitly
+  # disabled when delegated_subnet_id is set.
+  delegated_subnet_id = azurerm_subnet.postgres.id
+  private_dns_zone_id = azurerm_private_dns_zone.postgres.id
+
+  tags = var.tags
+
+  depends_on = [azurerm_private_dns_zone_virtual_network_link.postgres]
+
+  lifecycle {
+    # Zone changes after creation force a replacement; ignore drift on these
+    # so an apply doesn't try to rebuild the server under load.
+    ignore_changes = [zone, high_availability[0].standby_availability_zone]
+  }
+}
+
+resource "azurerm_postgresql_flexible_server_database" "aisoc" {
+  name      = var.postgres_db_name
+  server_id = azurerm_postgresql_flexible_server.main.id
+  charset   = "UTF8"
+  collation = "en_US.utf8"
+}
+
+# Require TLS for all connections (matches the app's sslmode=require default).
+resource "azurerm_postgresql_flexible_server_configuration" "require_ssl" {
+  name      = "require_secure_transport"
+  server_id = azurerm_postgresql_flexible_server.main.id
+  value     = "ON"
+}

--- a/infra/terraform/azure/iam.tf
+++ b/infra/terraform/azure/iam.tf
@@ -1,0 +1,72 @@
+/**
+ * AiSOC — Azure serverless skeleton
+ *
+ * Per-service runtime identities. Each Container App runs as a dedicated
+ * user-assigned managed identity so role assignments stay scoped to one
+ * workload at a time (the GCP stack uses one service account per service for
+ * the same reason).
+ *
+ * Bindings:
+ *   - every identity gets AcrPull on the registry (pull its own image)
+ *   - api + ingest get "Key Vault Secrets User" (read DB / vault / redis creds)
+ *   - web is a Next.js bundle that only talks to the API over HTTP, so it gets
+ *     no Key Vault access
+ */
+
+# ─── User-assigned managed identities ────────────────────────────────────────
+
+resource "azurerm_user_assigned_identity" "api" {
+  name                = "${var.name_prefix}-api-id"
+  resource_group_name = azurerm_resource_group.main.name
+  location            = azurerm_resource_group.main.location
+  tags                = var.tags
+}
+
+resource "azurerm_user_assigned_identity" "web" {
+  name                = "${var.name_prefix}-web-id"
+  resource_group_name = azurerm_resource_group.main.name
+  location            = azurerm_resource_group.main.location
+  tags                = var.tags
+}
+
+resource "azurerm_user_assigned_identity" "ingest" {
+  name                = "${var.name_prefix}-ingest-id"
+  resource_group_name = azurerm_resource_group.main.name
+  location            = azurerm_resource_group.main.location
+  tags                = var.tags
+}
+
+# ─── ACR pull (all three) ────────────────────────────────────────────────────
+
+locals {
+  acr_pull_identities = {
+    api    = azurerm_user_assigned_identity.api.principal_id
+    web    = azurerm_user_assigned_identity.web.principal_id
+    ingest = azurerm_user_assigned_identity.ingest.principal_id
+  }
+}
+
+resource "azurerm_role_assignment" "acr_pull" {
+  for_each = local.acr_pull_identities
+
+  scope                = azurerm_container_registry.main.id
+  role_definition_name = "AcrPull"
+  principal_id         = each.value
+}
+
+# ─── Key Vault Secrets User (api + ingest) ───────────────────────────────────
+
+locals {
+  kv_reader_identities = {
+    api    = azurerm_user_assigned_identity.api.principal_id
+    ingest = azurerm_user_assigned_identity.ingest.principal_id
+  }
+}
+
+resource "azurerm_role_assignment" "kv_secrets_user" {
+  for_each = local.kv_reader_identities
+
+  scope                = azurerm_key_vault.main.id
+  role_definition_name = "Key Vault Secrets User"
+  principal_id         = each.value
+}

--- a/infra/terraform/azure/main.tf
+++ b/infra/terraform/azure/main.tf
@@ -1,0 +1,139 @@
+/**
+ * AiSOC — Azure serverless skeleton
+ *
+ * Bootstraps shared resources required by every other file in this stack:
+ *   - a resource group that owns everything
+ *   - a VNet with three subnets (Container Apps, Postgres delegation,
+ *     private endpoints)
+ *   - a Log Analytics workspace + Container Apps managed environment
+ *   - a regional Azure Container Registry for AiSOC container images
+ *
+ * Service-specific resources live in:
+ *   database.tf        — PostgreSQL Flexible Server
+ *   redis.tf           — Azure Cache for Redis
+ *   secrets.tf         — Key Vault entries
+ *   iam.tf             — user-assigned managed identities + role assignments
+ *   container_apps.tf  — api / web / ingest container apps
+ */
+
+data "azurerm_client_config" "current" {}
+
+locals {
+  # When subscription_id is blank, azurerm falls back to ARM_SUBSCRIPTION_ID /
+  # az-cli context; we only thread it into the provider via the root module if
+  # the operator set it explicitly (kept out of the provider block to avoid a
+  # required value during `validate`).
+  subscription_id = var.subscription_id != "" ? var.subscription_id : data.azurerm_client_config.current.subscription_id
+}
+
+# ─── Resource group ──────────────────────────────────────────────────────────
+
+resource "azurerm_resource_group" "main" {
+  name     = "${var.name_prefix}-rg"
+  location = var.location
+  tags     = var.tags
+}
+
+# ─── Network ─────────────────────────────────────────────────────────────────
+#
+# One VNet, three subnets:
+#   - aca           : the Container Apps environment lives here (needs >= /23)
+#   - postgres      : delegated to Microsoft.DBforPostgreSQL/flexibleServers
+#                     for VNet-integrated private access (no public endpoint)
+#   - privatelink   : holds private endpoints (Redis today, more later)
+
+resource "azurerm_virtual_network" "main" {
+  name                = "${var.name_prefix}-vnet"
+  location            = azurerm_resource_group.main.location
+  resource_group_name = azurerm_resource_group.main.name
+  address_space       = [var.vnet_cidr]
+  tags                = var.tags
+}
+
+resource "azurerm_subnet" "aca" {
+  name                 = "${var.name_prefix}-aca-subnet"
+  resource_group_name  = azurerm_resource_group.main.name
+  virtual_network_name = azurerm_virtual_network.main.name
+  address_prefixes     = [var.aca_subnet_cidr]
+}
+
+resource "azurerm_subnet" "postgres" {
+  name                 = "${var.name_prefix}-pg-subnet"
+  resource_group_name  = azurerm_resource_group.main.name
+  virtual_network_name = azurerm_virtual_network.main.name
+  address_prefixes     = [var.postgres_subnet_cidr]
+
+  delegation {
+    name = "fs"
+    service_delegation {
+      name = "Microsoft.DBforPostgreSQL/flexibleServers"
+      actions = [
+        "Microsoft.Network/virtualNetworks/subnets/join/action",
+      ]
+    }
+  }
+}
+
+resource "azurerm_subnet" "privatelink" {
+  name                 = "${var.name_prefix}-pl-subnet"
+  resource_group_name  = azurerm_resource_group.main.name
+  virtual_network_name = azurerm_virtual_network.main.name
+  address_prefixes     = [var.privatelink_subnet_cidr]
+}
+
+# ─── Observability ───────────────────────────────────────────────────────────
+#
+# Container Apps stream stdout/stderr + system logs into Log Analytics. 30-day
+# retention keeps the demo cheap; bump for production audit needs.
+
+resource "azurerm_log_analytics_workspace" "main" {
+  name                = "${var.name_prefix}-logs"
+  location            = azurerm_resource_group.main.location
+  resource_group_name = azurerm_resource_group.main.name
+  sku                 = "PerGB2018"
+  retention_in_days   = 30
+  tags                = var.tags
+}
+
+# ─── Container Apps environment ──────────────────────────────────────────────
+#
+# VNet-injected so the apps can reach Postgres (delegated subnet) and the Redis
+# private endpoint over private IPs. internal_load_balancer_enabled = false
+# keeps the ingress public (the api/web surfaces customers hit first).
+
+resource "azurerm_container_app_environment" "main" {
+  name                       = "${var.name_prefix}-aca-env"
+  location                   = azurerm_resource_group.main.location
+  resource_group_name        = azurerm_resource_group.main.name
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.main.id
+
+  infrastructure_subnet_id       = azurerm_subnet.aca.id
+  internal_load_balancer_enabled = false
+
+  tags = var.tags
+}
+
+# ─── Azure Container Registry ────────────────────────────────────────────────
+#
+# Optional but recommended. CI can push images here instead of GHCR; the
+# Container Apps pull them with the runtime identity's AcrPull role binding
+# (set in iam.tf). Basic SKU is plenty for a single-region demo.
+
+resource "azurerm_container_registry" "main" {
+  name                = "${var.name_prefix}acr${random_string.acr_suffix.result}"
+  resource_group_name = azurerm_resource_group.main.name
+  location            = azurerm_resource_group.main.location
+  sku                 = "Basic"
+  admin_enabled       = false
+  tags                = var.tags
+}
+
+# ACR names are globally unique and alphanumeric-only; a short random suffix
+# avoids collisions across re-applies / forks without forcing the operator to
+# pick a unique name_prefix.
+resource "random_string" "acr_suffix" {
+  length  = 6
+  special = false
+  upper   = false
+  numeric = true
+}

--- a/infra/terraform/azure/outputs.tf
+++ b/infra/terraform/azure/outputs.tf
@@ -1,0 +1,90 @@
+/**
+ * AiSOC — Azure serverless skeleton
+ *
+ * Outputs scoped to what an operator needs right after `terraform apply`: the
+ * public Container App URLs, the connection targets the API dials, and the IDs
+ * the matching CI workflow needs to push container images. Mirrors the GCP
+ * stack's outputs.tf.
+ */
+
+# ─── Container App URLs ──────────────────────────────────────────────────────
+
+output "api_url" {
+  description = "Public Container App URL for the AiSOC API."
+  value       = "https://${azurerm_container_app.api.ingress[0].fqdn}"
+}
+
+output "web_url" {
+  description = "Public Container App URL for the AiSOC web console."
+  value       = "https://${azurerm_container_app.web.ingress[0].fqdn}"
+}
+
+output "ingest_url" {
+  description = "Public Container App URL for the AiSOC ingest endpoint."
+  value       = "https://${azurerm_container_app.ingest.ingress[0].fqdn}"
+}
+
+# ─── PostgreSQL Flexible Server ──────────────────────────────────────────────
+
+output "postgres_fqdn" {
+  description = "Private FQDN of the PostgreSQL Flexible Server (resolves inside the VNet)."
+  value       = azurerm_postgresql_flexible_server.main.fqdn
+}
+
+output "postgres_database" {
+  description = "Application database name inside the Flexible Server."
+  value       = azurerm_postgresql_flexible_server_database.aisoc.name
+}
+
+output "postgres_admin_user" {
+  description = "Administrator login for the Flexible Server."
+  value       = var.postgres_user
+}
+
+# ─── Azure Cache for Redis ───────────────────────────────────────────────────
+
+output "redis_hostname" {
+  description = "Private hostname of the Azure Cache for Redis instance."
+  value       = azurerm_redis_cache.main.hostname
+}
+
+output "redis_ssl_port" {
+  description = "TLS port of the Azure Cache for Redis instance (non-SSL port is disabled)."
+  value       = azurerm_redis_cache.main.ssl_port
+}
+
+# ─── Container Registry ──────────────────────────────────────────────────────
+
+output "container_registry_login_server" {
+  description = "ACR login server (push target for CI image builds)."
+  value       = azurerm_container_registry.main.login_server
+}
+
+# ─── Managed identities ──────────────────────────────────────────────────────
+
+output "identity_api_client_id" {
+  description = "Client ID of the API runtime managed identity."
+  value       = azurerm_user_assigned_identity.api.client_id
+}
+
+output "identity_web_client_id" {
+  description = "Client ID of the web runtime managed identity."
+  value       = azurerm_user_assigned_identity.web.client_id
+}
+
+output "identity_ingest_client_id" {
+  description = "Client ID of the ingest runtime managed identity."
+  value       = azurerm_user_assigned_identity.ingest.client_id
+}
+
+# ─── Key Vault ───────────────────────────────────────────────────────────────
+
+output "key_vault_name" {
+  description = "Name of the Key Vault holding the runtime secrets."
+  value       = azurerm_key_vault.main.name
+}
+
+output "key_vault_uri" {
+  description = "Vault URI for ad-hoc `az keyvault secret show` after apply."
+  value       = azurerm_key_vault.main.vault_uri
+}

--- a/infra/terraform/azure/redis.tf
+++ b/infra/terraform/azure/redis.tf
@@ -1,0 +1,64 @@
+/**
+ * AiSOC — Azure serverless skeleton
+ *
+ * Azure Cache for Redis reached over a private endpoint. Public network access
+ * is disabled; the Container Apps resolve the cache's private IP via the
+ * privatelink.redis.cache.windows.net DNS zone linked to the VNet.
+ *
+ * The primary access key is read back into Key Vault (secrets.tf) so the apps
+ * inject it as REDIS_PASSWORD the same way every other secret flows.
+ */
+
+resource "azurerm_redis_cache" "main" {
+  name                = "${var.name_prefix}-redis"
+  resource_group_name = azurerm_resource_group.main.name
+  location            = azurerm_resource_group.main.location
+
+  sku_name = var.redis_sku
+  family   = var.redis_family
+  capacity = var.redis_capacity
+
+  # Lock down to TLS 1.2 over the private endpoint only.
+  non_ssl_port_enabled          = false
+  minimum_tls_version           = "1.2"
+  public_network_access_enabled = false
+
+  tags = var.tags
+}
+
+# ─── Private endpoint + DNS ──────────────────────────────────────────────────
+
+resource "azurerm_private_dns_zone" "redis" {
+  name                = "privatelink.redis.cache.windows.net"
+  resource_group_name = azurerm_resource_group.main.name
+  tags                = var.tags
+}
+
+resource "azurerm_private_dns_zone_virtual_network_link" "redis" {
+  name                  = "${var.name_prefix}-redis-dns-link"
+  resource_group_name   = azurerm_resource_group.main.name
+  private_dns_zone_name = azurerm_private_dns_zone.redis.name
+  virtual_network_id    = azurerm_virtual_network.main.id
+  registration_enabled  = false
+  tags                  = var.tags
+}
+
+resource "azurerm_private_endpoint" "redis" {
+  name                = "${var.name_prefix}-redis-pe"
+  resource_group_name = azurerm_resource_group.main.name
+  location            = azurerm_resource_group.main.location
+  subnet_id           = azurerm_subnet.privatelink.id
+  tags                = var.tags
+
+  private_service_connection {
+    name                           = "${var.name_prefix}-redis-psc"
+    private_connection_resource_id = azurerm_redis_cache.main.id
+    subresource_names              = ["redisCache"]
+    is_manual_connection           = false
+  }
+
+  private_dns_zone_group {
+    name                 = "redis"
+    private_dns_zone_ids = [azurerm_private_dns_zone.redis.id]
+  }
+}

--- a/infra/terraform/azure/secrets.tf
+++ b/infra/terraform/azure/secrets.tf
@@ -1,0 +1,126 @@
+/**
+ * AiSOC — Azure serverless skeleton
+ *
+ * Key Vault entries that the Container Apps read back as secret-backed env
+ * vars (container_apps.tf). The runtime managed identities are granted
+ * "Key Vault Secrets User" in iam.tf so we don't inline that here.
+ *
+ * Generated values (SECRET_KEY, CredentialVault key) are produced by random_*
+ * resources and only their Key Vault references cross the trust boundary — the
+ * plaintext never lands in tfvars.
+ */
+
+# ─── Generated secrets ───────────────────────────────────────────────────────
+
+resource "random_password" "secret_key" {
+  length  = 64
+  special = false
+}
+
+resource "random_password" "credential_key" {
+  # CredentialVault uses Fernet which expects a 32-byte url-safe base64 key.
+  # 32 random bytes -> base64 is a valid Fernet key; generating it here means a
+  # `terraform destroy` + `apply` rotates the vault key cleanly. Operators who
+  # need rotation-without-rewrap should set AISOC_CREDENTIAL_KEY_ROTATION_FROM
+  # in app config.
+  length      = 32
+  special     = false
+  min_lower   = 1
+  min_upper   = 1
+  min_numeric = 1
+}
+
+# ─── Key Vault ───────────────────────────────────────────────────────────────
+#
+# RBAC-authorization mode (no access policies). The deploying principal gets
+# "Key Vault Secrets Officer" so this apply can write the secret values; the
+# Container App identities get read-only "Key Vault Secrets User" in iam.tf.
+#
+# Public network access stays enabled to keep first-run secret population simple
+# (mirrors GCP's Secret Manager, which is reachable over the Google API plane).
+# Lock it down with a private endpoint + network_acls for a hardened install.
+
+resource "azurerm_key_vault" "main" {
+  name                = "${var.name_prefix}-kv-${random_string.kv_suffix.result}"
+  resource_group_name = azurerm_resource_group.main.name
+  location            = azurerm_resource_group.main.location
+  tenant_id           = data.azurerm_client_config.current.tenant_id
+
+  sku_name                      = "standard"
+  enable_rbac_authorization     = true
+  purge_protection_enabled      = false
+  soft_delete_retention_days    = 7
+  public_network_access_enabled = true
+
+  tags = var.tags
+}
+
+# Key Vault names are globally unique (3-24 chars). A short random suffix keeps
+# re-applies and forks from colliding without forcing a unique name_prefix.
+resource "random_string" "kv_suffix" {
+  length  = 6
+  special = false
+  upper   = false
+  numeric = true
+}
+
+# Let this apply's identity write secret values. Without this, the
+# azurerm_key_vault_secret resources below 403 on a fresh RBAC vault.
+resource "azurerm_role_assignment" "deployer_secrets_officer" {
+  scope                = azurerm_key_vault.main.id
+  role_definition_name = "Key Vault Secrets Officer"
+  principal_id         = data.azurerm_client_config.current.object_id
+}
+
+# ─── Secret values ───────────────────────────────────────────────────────────
+
+resource "azurerm_key_vault_secret" "postgres_password" {
+  name         = "postgres-password"
+  value        = random_password.postgres.result
+  key_vault_id = azurerm_key_vault.main.id
+  tags         = var.tags
+
+  depends_on = [azurerm_role_assignment.deployer_secrets_officer]
+}
+
+resource "azurerm_key_vault_secret" "secret_key" {
+  name         = "secret-key"
+  value        = random_password.secret_key.result
+  key_vault_id = azurerm_key_vault.main.id
+  tags         = var.tags
+
+  depends_on = [azurerm_role_assignment.deployer_secrets_officer]
+}
+
+resource "azurerm_key_vault_secret" "credential_key" {
+  name         = "credential-key"
+  value        = base64encode(random_password.credential_key.result)
+  key_vault_id = azurerm_key_vault.main.id
+  tags         = var.tags
+
+  depends_on = [azurerm_role_assignment.deployer_secrets_officer]
+}
+
+resource "azurerm_key_vault_secret" "redis_auth" {
+  name         = "redis-auth"
+  value        = azurerm_redis_cache.main.primary_access_key
+  key_vault_id = azurerm_key_vault.main.id
+  tags         = var.tags
+
+  depends_on = [azurerm_role_assignment.deployer_secrets_officer]
+}
+
+# ─── Optional: OpenAI key ────────────────────────────────────────────────────
+# Only created when var.openai_api_key is non-empty so an air-gapped install
+# (Ollama / LiteLLM overlay) doesn't have to invent a placeholder secret.
+
+resource "azurerm_key_vault_secret" "openai_api_key" {
+  count = var.openai_api_key == "" ? 0 : 1
+
+  name         = "openai-api-key"
+  value        = var.openai_api_key
+  key_vault_id = azurerm_key_vault.main.id
+  tags         = var.tags
+
+  depends_on = [azurerm_role_assignment.deployer_secrets_officer]
+}

--- a/infra/terraform/azure/terraform.tfvars.example
+++ b/infra/terraform/azure/terraform.tfvars.example
@@ -1,0 +1,69 @@
+# AiSOC — Azure serverless skeleton
+#
+# Copy this file to `terraform.tfvars` and override what you need. Every
+# variable has a sensible default for a startup-credit-friendly demo, so an
+# empty `terraform.tfvars` already produces a working stack. Authentication is
+# picked up from `az login` (or ARM_* env vars), not from this file.
+
+# ─── Subscription / location ─────────────────────────────────────────────────
+
+# subscription_id = "00000000-0000-0000-0000-000000000000"  # or use ARM_SUBSCRIPTION_ID
+# location        = "eastus"
+# name_prefix     = "aisoc"   # 3-12 lowercase chars; keeps ACR + Key Vault names valid
+
+# tags = {
+#   project    = "aisoc"
+#   managed_by = "terraform"
+#   env        = "demo"
+# }
+
+# ─── Networking ──────────────────────────────────────────────────────────────
+
+# vnet_cidr               = "10.20.0.0/16"
+# aca_subnet_cidr         = "10.20.0.0/23"   # Container Apps needs at least /23
+# postgres_subnet_cidr    = "10.20.2.0/27"   # delegated to Postgres Flexible Server
+# privatelink_subnet_cidr = "10.20.3.0/27"   # Redis (+ future) private endpoints
+
+# ─── PostgreSQL Flexible Server ──────────────────────────────────────────────
+
+# postgres_sku        = "GP_Standard_D2s_v3"  # B_Standard_B1ms for a cheap sandbox
+# postgres_version    = "16"
+# postgres_storage_mb = 32768
+# postgres_db_name    = "aisoc"
+# postgres_user       = "aisoc"
+# postgres_zone       = "1"
+
+# ─── Azure Cache for Redis ───────────────────────────────────────────────────
+
+# redis_sku      = "Standard"   # Basic = no SLA/HA, Premium = VNet injection
+# redis_family   = "C"
+# redis_capacity = 1            # 0=250MB, 1=1GB, 2=2.5GB (C family)
+
+# ─── Container Apps images ───────────────────────────────────────────────────
+#
+# Defaults point at the public GHCR demo images so the skeleton runs with zero
+# CI work. Override with images you've pushed to the ACR this stack provisions.
+
+# api_image    = "ghcr.io/beenuar/aisoc-api:latest"
+# web_image    = "ghcr.io/beenuar/aisoc-web:latest"
+# ingest_image = "ghcr.io/beenuar/aisoc-ingest:latest"
+
+# ─── Container Apps scaling ──────────────────────────────────────────────────
+
+# api_min_replicas    = 0   # >0 to avoid cold starts
+# api_max_replicas    = 10
+# web_max_replicas    = 5
+# ingest_max_replicas = 5
+
+# ─── Access ──────────────────────────────────────────────────────────────────
+
+# cors_origins = "https://app.example.com,https://demo.example.com"
+
+# ─── Optional: agents / OpenAI ───────────────────────────────────────────────
+#
+# When set, an openai-api-key secret is provisioned in Key Vault and mounted
+# into the API container. Leave blank for the air-gapped (Ollama / LiteLLM)
+# configuration. Pass on the CLI to keep it off disk:
+#   terraform apply -var "openai_api_key=$OPENAI_API_KEY"
+
+# openai_api_key = ""

--- a/infra/terraform/azure/variables.tf
+++ b/infra/terraform/azure/variables.tf
@@ -1,0 +1,184 @@
+/**
+ * AiSOC — Azure serverless skeleton
+ *
+ * Input variables. Defaults aim for "smallest viable AiSOC" so a `terraform
+ * apply` against a fresh subscription produces a working stack inside an
+ * Azure free-trial / startup-credit envelope, not a five-figure surprise.
+ */
+
+# ─── Subscription / location ─────────────────────────────────────────────────
+
+variable "subscription_id" {
+  description = "Azure subscription ID that will own every resource. Leave blank to use the ARM_SUBSCRIPTION_ID / az-cli default."
+  type        = string
+  default     = ""
+}
+
+variable "location" {
+  description = "Primary Azure region for the resource group, Container Apps, Postgres, and Redis."
+  type        = string
+  default     = "eastus"
+}
+
+variable "name_prefix" {
+  description = "Prefix used for resource names (Container Apps, Postgres server, etc.). Must be lowercase; 3-12 chars keeps globally-unique names (ACR, Key Vault) under their length caps."
+  type        = string
+  default     = "aisoc"
+
+  validation {
+    condition     = can(regex("^[a-z][a-z0-9]{2,11}$", var.name_prefix))
+    error_message = "name_prefix must be 3-12 chars, lowercase letters/digits, starting with a letter (keeps ACR + Key Vault names valid)."
+  }
+}
+
+variable "tags" {
+  description = "Common tags applied to every resource."
+  type        = map(string)
+  default = {
+    project    = "aisoc"
+    managed_by = "terraform"
+  }
+}
+
+# ─── Networking ──────────────────────────────────────────────────────────────
+
+variable "vnet_cidr" {
+  description = "CIDR for the VNet that hosts the Container Apps environment and the data-tier private endpoints."
+  type        = string
+  default     = "10.20.0.0/16"
+}
+
+variable "aca_subnet_cidr" {
+  description = "Subnet for the Container Apps environment. Must be at least /23 for a Consumption-only environment."
+  type        = string
+  default     = "10.20.0.0/23"
+}
+
+variable "postgres_subnet_cidr" {
+  description = "Delegated subnet for the Postgres Flexible Server VNet integration."
+  type        = string
+  default     = "10.20.2.0/27"
+}
+
+variable "privatelink_subnet_cidr" {
+  description = "Subnet that holds the Redis (and any future) private endpoints."
+  type        = string
+  default     = "10.20.3.0/27"
+}
+
+# ─── PostgreSQL Flexible Server ──────────────────────────────────────────────
+
+variable "postgres_sku" {
+  description = "Flexible Server SKU. B_Standard_B1ms is the cheapest burstable dev tier; GP_Standard_D2s_v3 is the smallest sensible production tier."
+  type        = string
+  default     = "GP_Standard_D2s_v3"
+}
+
+variable "postgres_version" {
+  description = "PostgreSQL major version."
+  type        = string
+  default     = "16"
+}
+
+variable "postgres_storage_mb" {
+  description = "Initial storage in MB (must be a supported Flexible Server size, e.g. 32768, 65536)."
+  type        = number
+  default     = 32768
+}
+
+variable "postgres_db_name" {
+  description = "Logical database name created inside the server."
+  type        = string
+  default     = "aisoc"
+}
+
+variable "postgres_user" {
+  description = "Administrator login for the Flexible Server."
+  type        = string
+  default     = "aisoc"
+}
+
+variable "postgres_zone" {
+  description = "Availability zone for the primary Flexible Server node."
+  type        = string
+  default     = "1"
+}
+
+# ─── Azure Cache for Redis ───────────────────────────────────────────────────
+
+variable "redis_sku" {
+  description = "Redis SKU — Basic for dev (no SLA, no HA), Standard for prod, Premium for VNet injection / clustering."
+  type        = string
+  default     = "Standard"
+}
+
+variable "redis_family" {
+  description = "Redis SKU family — C for Basic/Standard, P for Premium."
+  type        = string
+  default     = "C"
+}
+
+variable "redis_capacity" {
+  description = "Redis size unit (0=250MB, 1=1GB, 2=2.5GB for the C family)."
+  type        = number
+  default     = 1
+}
+
+# ─── Container Apps ──────────────────────────────────────────────────────────
+
+variable "api_image" {
+  description = "Container image for the API service (FastAPI). Defaults to the GHCR demo image."
+  type        = string
+  default     = "ghcr.io/beenuar/aisoc-api:latest"
+}
+
+variable "web_image" {
+  description = "Container image for the web service (Next.js)."
+  type        = string
+  default     = "ghcr.io/beenuar/aisoc-web:latest"
+}
+
+variable "ingest_image" {
+  description = "Container image for the ingest service (Go)."
+  type        = string
+  default     = "ghcr.io/beenuar/aisoc-ingest:latest"
+}
+
+variable "api_min_replicas" {
+  description = "Minimum Container App replicas for the API. Set >0 to avoid cold starts."
+  type        = number
+  default     = 0
+}
+
+variable "api_max_replicas" {
+  description = "Maximum Container App replicas for the API."
+  type        = number
+  default     = 10
+}
+
+variable "web_max_replicas" {
+  description = "Maximum Container App replicas for the web app."
+  type        = number
+  default     = 5
+}
+
+variable "ingest_max_replicas" {
+  description = "Maximum Container App replicas for the ingest service."
+  type        = number
+  default     = 5
+}
+
+variable "cors_origins" {
+  description = "Comma-separated CORS allow-list passed to the API service."
+  type        = string
+  default     = ""
+}
+
+# ─── OpenAI / agents ─────────────────────────────────────────────────────────
+
+variable "openai_api_key" {
+  description = "Optional OpenAI API key persisted to Key Vault. Leave blank to skip (air-gapped Ollama / LiteLLM config)."
+  type        = string
+  default     = ""
+  sensitive   = true
+}

--- a/infra/terraform/azure/versions.tf
+++ b/infra/terraform/azure/versions.tf
@@ -1,0 +1,52 @@
+/**
+ * AiSOC — Azure serverless skeleton
+ *
+ * Provider pinning. Tested against Terraform 1.5+ and the azurerm 3.116
+ * provider. The Container Apps, PostgreSQL Flexible Server, and Azure Cache
+ * for Redis resources used here are all GA in the 3.x line; bump in lockstep
+ * when you move to azurerm 4.x (a few attribute names changed there — see the
+ * README upgrade note).
+ */
+
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 3.116"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.6"
+    }
+  }
+
+  # State backend left intentionally unconfigured. Pick one of:
+  #
+  #   backend "azurerm" {
+  #     resource_group_name  = "aisoc-tfstate-rg"
+  #     storage_account_name = "aisoctfstate<suffix>"
+  #     container_name       = "tfstate"
+  #     key                  = "azure.tfstate"
+  #   }
+  #   backend "local" {}
+  #
+  # …and bootstrap the storage account once per subscription before
+  # `terraform init`. See the README for the bootstrap commands.
+}
+
+provider "azurerm" {
+  features {
+    key_vault {
+      # Let `terraform destroy` purge soft-deleted vaults so a re-apply with
+      # the same name_prefix doesn't collide with a tombstoned vault.
+      purge_soft_delete_on_destroy = true
+    }
+    resource_group {
+      # Refuse to delete a resource group that still has resources Terraform
+      # doesn't know about — protects against half-managed subscriptions.
+      prevent_deletion_if_contains_resources = true
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds `infra/terraform/azure/` — a serverless-container deployment skeleton for AiSOC on Azure, mirroring the existing `infra/terraform/gcp/` Cloud Run stack file-for-file. Closes #237.

The stack provisions the `api`, `web`, and `ingest` services on **Azure Container Apps** (no Kubernetes), backed by managed Azure data + secret services on a private VNet:

| Concern | Azure resource | GCP analog |
|---|---|---|
| Compute | Container Apps (`api`/`web`/`ingest`) | Cloud Run |
| Database | PostgreSQL Flexible Server (private) | Cloud SQL Postgres |
| Cache | Azure Cache for Redis (private endpoint) | Memorystore Redis |
| Secrets | Key Vault (RBAC) | Secret Manager |
| Registry | Azure Container Registry | Artifact Registry |
| Identity | user-assigned managed identities | service accounts |
| Networking | VNet + delegated subnets + private endpoints | Serverless VPC Access |
| Logs | Log Analytics Workspace | Cloud Logging |

### Files
- `main.tf` — resource group, VNet (ACA + Postgres-delegated + PE subnets), Log Analytics, Container Apps environment, ACR
- `database.tf` — PostgreSQL Flexible Server, private DNS zone, logical database
- `redis.tf` — Azure Cache for Redis behind a private endpoint
- `secrets.tf` — Key Vault (RBAC) + generated `SECRET_KEY` / `AISOC_CREDENTIAL_KEY`
- `iam.tf` — user-assigned managed identities + `AcrPull` / `Key Vault Secrets User` roles
- `container_apps.tf` — the three apps, Key-Vault-backed secret injection via managed identity
- `variables.tf` / `outputs.tf` / `versions.tf` / `terraform.tfvars.example`
- `README.md` — architecture, quickstart, state backend, container image, cost notes, known limits

### Security notes
- Sensitive values (`SECRET_KEY`, credential key, Postgres password, Redis key, optional `OPENAI_API_KEY`) are **generated by Terraform and stored in Key Vault**; apps read them at runtime via managed identity. No secrets land in `tfvars` or env blocks.
- Postgres and Redis are private-only (private endpoints + private DNS); no public ingress on data services.
- Emits the same env-var contract as the AWS/GCP stacks (`apps/docs/docs/deployment/env-vars.md`).

Also adds an **Alternate cloud skeletons** section to `infra/terraform/README.md` pointing at the GCP and Azure options.

## Test plan
- [x] `terraform fmt` clean
- [x] `terraform validate` -> `Success! The configuration is valid.`
- [ ] `terraform plan` against a real subscription (requires `az login` + `subscription_id`)
- [ ] End-to-end apply in a scratch resource group
- [ ] Confirm `api`/`web`/`ingest` boot and resolve Key Vault secrets via managed identity


Made with [Cursor](https://cursor.com)