### PR TITLE
fix(infra/gcp): drop sensitive-var taint from terraform for_each and …

### DIFF
--- a/infra/terraform/gcp/cloud_run.tf
+++ b/infra/terraform/gcp/cloud_run.tf
@@ -152,12 +152,15 @@ resource "google_cloud_run_v2_service" "api" {
       }
 
       dynamic "env" {
-        for_each = var.openai_api_key == "" ? [] : [1]
+        # Iterate over the count-driven secret resource (0 or 1 element) so the
+        # for_each collection is derived from resource state, not the sensitive
+        # var.openai_api_key. Sensitive values are rejected as for_each args.
+        for_each = google_secret_manager_secret.openai_api_key
         content {
           name = "OPENAI_API_KEY"
           value_source {
             secret_key_ref {
-              secret  = google_secret_manager_secret.openai_api_key[0].secret_id
+              secret  = env.value.secret_id
               version = "latest"
             }
           }

--- a/infra/terraform/gcp/iam.tf
+++ b/infra/terraform/gcp/iam.tf
@@ -73,13 +73,15 @@ resource "google_project_iam_member" "runtime_shared" {
 # bundle that talks to the API over HTTP — it doesn't need DB or vault keys.
 
 locals {
-  api_secrets = compact([
-    google_secret_manager_secret.postgres_password.id,
-    google_secret_manager_secret.secret_key.id,
-    google_secret_manager_secret.credential_key.id,
-    google_secret_manager_secret.redis_auth.id,
-    var.openai_api_key == "" ? "" : google_secret_manager_secret.openai_api_key[0].id,
-  ])
+  api_secrets = concat(
+    [
+      google_secret_manager_secret.postgres_password.id,
+      google_secret_manager_secret.secret_key.id,
+      google_secret_manager_secret.credential_key.id,
+      google_secret_manager_secret.redis_auth.id,
+    ],
+    google_secret_manager_secret.openai_api_key[*].id,
+  )
 
   ingest_secrets = [
     google_secret_manager_secret.postgres_password.id,

--- a/infra/terraform/gcp/outputs.tf
+++ b/infra/terraform/gcp/outputs.tf
@@ -109,5 +109,9 @@ output "secret_redis_auth_id" {
 
 output "secret_openai_api_key_id" {
   description = "Secret Manager ID for the OpenAI API key (null when not provisioned)."
-  value       = var.openai_api_key == "" ? null : google_secret_manager_secret.openai_api_key[0].secret_id
+  value = nonsensitive(
+    length(google_secret_manager_secret.openai_api_key) == 0
+    ? null
+    : google_secret_manager_secret.openai_api_key[0].secret_id
+  )
 }


### PR DESCRIPTION
## Summary

`terraform validate` in [`infra/terraform/gcp/`](infra/terraform/gcp/) fails
with two errors caused by Terraform's sensitivity propagation through any
expression that touches `var.openai_api_key` (declared `sensitive = true`):

- `local.api_secrets has a sensitive value` — used as `for_each` key at
  `iam.tf:92`
- `Output refers to sensitive values` — `secret_openai_api_key_id` at
  `outputs.tf:110`

Both stem from existence-check ternaries (`var.openai_api_key == "" ? ...`)
that taint expressions even though the exposed values are just Secret
Manager resource IDs — not the secret material.

## Changes

- **`iam.tf`** — replace `compact([...])` with `concat([...], google_secret_manager_secret.openai_api_key[*].id)`. The splat returns an empty list when `count = 0`, so the optional include is gated on the resource's count (not sensitive) instead of `var.openai_api_key` (sensitive). `compact()` is no longer needed.
- **`outputs.tf`** — wrap the value in `nonsensitive(...)` and gate on `length(google_secret_manager_secret.openai_api_key) == 0`. The output is a Secret Manager resource ID, intentionally not marked sensitive so operators can pipe it into `gcloud secrets versions access`.

## Test plan

- [x] `terraform init -backend=false` in `infra/terraform/gcp/`
- [x] `terraform validate` → `Success! The configuration is valid.`

Fixes #242
