### PR TITLE
fix(web): point marketing-page docs links at the Docusaurus site

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -162,3 +162,7 @@ AZURE_WORKSPACE_NAME=
 NEXT_PUBLIC_API_URL=http://localhost:8000
 NEXT_PUBLIC_REALTIME_URL=http://localhost:8086
 NEXT_PUBLIC_WS_URL=ws://localhost:8086
+
+# Override the docs site base URL (default: https://beenuar.github.io/AiSOC/docs).
+# Set this when serving docs from a custom domain like https://docs.tryaisoc.com/docs.
+# NEXT_PUBLIC_DOCS_URL=https://docs.tryaisoc.com/docs

--- a/apps/web/src/app/(marketing)/sovereign/page.tsx
+++ b/apps/web/src/app/(marketing)/sovereign/page.tsx
@@ -395,7 +395,7 @@ export default function SovereignPage() {
             <RepoArtefact
               label="Investigation ledger"
               path="services/agents/app/ledger/"
-              href="https://github.com/beenuar/AiSOC#investigation-ledger"
+              href="https://github.com/beenuar/AiSOC/tree/main/services/agents/app/ledger"
               body="Every prompt, tool call, evidence row, and decision the agent makes — durable and replayable. The auditor reads the events directly, not a vendor summary."
             />
             <RepoArtefact

--- a/apps/web/src/app/benchmark/page.tsx
+++ b/apps/web/src/app/benchmark/page.tsx
@@ -9,6 +9,7 @@ import {
 import { ComparisonTable } from '@/components/benchmark/ComparisonTable';
 import { KpiBar } from '@/components/benchmark/KpiBar';
 import { CommunitySubmissions } from '@/components/benchmark/CommunitySubmissions';
+import { docs } from '@/lib/docs';
 
 export const metadata: Metadata = {
   title: 'Public benchmark scoreboard',
@@ -169,7 +170,7 @@ export default async function BenchmarkPage() {
             append-only weekly history (substrate and wet-eval rows side-by-side
             with a MITRE-accuracy trend chart), see the{' '}
             <a
-              href="https://github.com/beenuar/AiSOC#readme"
+              href={docs('benchmark')}
               target="_blank"
               rel="noreferrer"
               className="underline decoration-dotted hover:text-gray-300"
@@ -414,7 +415,7 @@ export default async function BenchmarkPage() {
           </p>
           <div className="mt-6 flex flex-wrap justify-center gap-3">
             <a
-              href="https://github.com/beenuar/AiSOC/blob/main/CONTRIBUTING.md"
+              href={docs('contributing/guidelines')}
               target="_blank"
               rel="noreferrer"
               className="inline-flex items-center gap-2 rounded-md bg-brand-500 px-4 py-2 text-sm font-semibold text-white transition hover:bg-brand-400"

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -5,6 +5,7 @@ import './globals.css';
 import { PwaBootstrap } from '@/components/pwa/PwaBootstrap';
 import { ThemeProvider } from '@/components/theme/ThemeProvider';
 import { themeBootstrapScript } from '@/components/theme/themeScript';
+import { docs } from '@/lib/docs';
 import { DISCOVERY_KEYWORDS, getPublicSiteUrl } from '@/lib/site';
 
 const inter = Inter({
@@ -125,7 +126,7 @@ const jsonLd = {
       },
       url: siteUrl,
       downloadUrl: 'https://github.com/beenuar/AiSOC',
-      installUrl: 'https://github.com/beenuar/AiSOC#quick-start',
+      installUrl: docs('quickstart'),
       releaseNotes: 'https://github.com/beenuar/AiSOC/releases',
       featureList: [
         'Click-and-connect 26 security sources (EDR, SIEM, cloud, IAM, SaaS) with encrypted credential vault',

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next';
 import dynamic from 'next/dynamic';
+import { docs } from '@/lib/docs';
 import { getPublicSiteUrl } from '@/lib/site';
 import { velvetFontVariables } from '@/lib/marketing-fonts';
 import { StickyNav } from '@/components/landing/sections/StickyNav';
@@ -116,7 +117,7 @@ const productJsonLd = {
   license: 'https://opensource.org/licenses/MIT',
   url: siteUrl,
   downloadUrl: 'https://github.com/beenuar/AiSOC',
-  installUrl: 'https://github.com/beenuar/AiSOC#quick-start',
+  installUrl: docs('quickstart'),
   releaseNotes: 'https://github.com/beenuar/AiSOC/releases',
   description:
     'AiSOC is an MIT-licensed agentic Security Operations Center: four specialised agents (Detect, Triage, Hunt, Respond), 69 first-party connectors, a public 200-incident benchmark, and air-gap deploy on a single environment flag.',

--- a/apps/web/src/app/why-open-source/page.tsx
+++ b/apps/web/src/app/why-open-source/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next';
 import Link from 'next/link';
 import { LandingNav } from '@/components/landing/LandingNav';
 import { Footer } from '@/components/landing/Footer';
+import { docs } from '@/lib/docs';
 
 export const metadata: Metadata = {
   // Use `absolute` so the root layout's `template: '%s | AiSOC'` doesn't
@@ -22,7 +23,7 @@ export const metadata: Metadata = {
 const PILLARS = [
   {
     label: 'Investigation Ledger',
-    href: 'https://github.com/beenuar/AiSOC#investigation-ledger',
+    href: docs('architecture/itsm-as-source-of-truth'),
     body: 'Every prompt, tool call, evidence citation, and decision the agent emits is written to a durable, queryable, replayable ledger. The ledger stores the literal LLM input and output, not a summary.',
   },
   {

--- a/apps/web/src/components/demo/DemoBanner.tsx
+++ b/apps/web/src/components/demo/DemoBanner.tsx
@@ -13,6 +13,7 @@
  */
 
 import { isDemoMode, demoBannerMessage } from '@/lib/demoMode';
+import { docs } from '@/lib/docs';
 
 export function DemoBanner() {
   if (!isDemoMode()) return null;
@@ -36,7 +37,7 @@ export function DemoBanner() {
         |
       </span>
       <a
-        href="https://github.com/beenuar/AiSOC#quickstart"
+        href={docs('quickstart')}
         target="_blank"
         rel="noopener noreferrer"
         className="underline underline-offset-2 hover:text-amber-100 transition-colors"

--- a/apps/web/src/components/landing/Footer.tsx
+++ b/apps/web/src/components/landing/Footer.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link';
 import packageJson from '../../../package.json';
+import { docs } from '@/lib/docs';
 import { Logo } from './Logo';
 
 const APP_VERSION = packageJson.version;
@@ -22,7 +23,7 @@ const COLUMNS = [
     links: [
       { label: 'Why open source', href: '/why-open-source' },
       { label: 'GitHub', href: 'https://github.com/beenuar/AiSOC' },
-      { label: 'Quickstart', href: 'https://github.com/beenuar/AiSOC#quickstart' },
+      { label: 'Quickstart', href: docs('quickstart') },
       { label: 'Roadmap', href: 'https://github.com/beenuar/AiSOC/blob/main/ROADMAP.md' },
       { label: 'Changelog', href: 'https://github.com/beenuar/AiSOC/blob/main/CHANGELOG.md' },
     ],
@@ -32,7 +33,7 @@ const COLUMNS = [
     links: [
       { label: 'Issues', href: 'https://github.com/beenuar/AiSOC/issues' },
       { label: 'Discussions', href: 'https://github.com/beenuar/AiSOC/discussions' },
-      { label: 'Contributing', href: 'https://github.com/beenuar/AiSOC/blob/main/CONTRIBUTING.md' },
+      { label: 'Contributing', href: docs('contributing/guidelines') },
       { label: 'Code of conduct', href: 'https://github.com/beenuar/AiSOC/blob/main/CODE_OF_CONDUCT.md' },
     ],
   },

--- a/apps/web/src/components/landing/OpenSource.tsx
+++ b/apps/web/src/components/landing/OpenSource.tsx
@@ -2,6 +2,7 @@
 
 import Link from 'next/link';
 import { motion } from 'framer-motion';
+import { docs } from '@/lib/docs';
 
 const PILLARS = [
   {
@@ -63,7 +64,7 @@ export function OpenSource() {
                   github.com/beenuar/AiSOC
                 </a>
                 <a
-                  href="https://github.com/beenuar/AiSOC#quickstart"
+                  href={docs('quickstart')}
                   target="_blank"
                   rel="noreferrer"
                   className="inline-flex items-center gap-2 rounded-lg border border-velvet-content-primary/15 bg-white/[0.04] px-5 py-3 text-sm font-semibold text-gray-200 transition hover:border-velvet-content-primary/30 hover:bg-white/[0.08]"

--- a/apps/web/src/components/landing/sections/BenchmarkBand.tsx
+++ b/apps/web/src/components/landing/sections/BenchmarkBand.tsx
@@ -20,6 +20,7 @@ import Link from 'next/link';
 import { motion, useReducedMotion } from 'framer-motion';
 import { ArrowRight, ExternalLink, GitCompare } from 'lucide-react';
 import { NumberTicker } from '@/components/magicui/NumberTicker';
+import { docs } from '@/lib/docs';
 
 interface Metric {
   /**
@@ -135,7 +136,7 @@ export function BenchmarkBand() {
             />
           </Link>
           <Link
-            href="https://github.com/beenuar/AiSOC#readme"
+            href={docs('benchmark')}
             className="inline-flex items-center gap-1 text-sm font-medium text-velvet-content-tertiary transition-colors duration-200 hover:text-velvet-content-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-velvet-emerald-mint focus-visible:ring-offset-2 focus-visible:ring-offset-velvet-surface-base"
           >
             Open the public scoreboard

--- a/apps/web/src/components/landing/sections/ConnectorsMarquee.tsx
+++ b/apps/web/src/components/landing/sections/ConnectorsMarquee.tsx
@@ -19,6 +19,7 @@
 import Link from 'next/link';
 import { ArrowRight } from 'lucide-react';
 import { Marquee } from '@/components/magicui/Marquee';
+import { docs } from '@/lib/docs';
 import { cn } from '@/lib/utils';
 
 interface ConnectorPill {
@@ -203,7 +204,7 @@ export function ConnectorsMarquee() {
                 TypeScript, and Go.
               </p>
               <Link
-                href="https://github.com/beenuar/AiSOC#readme"
+                href={docs('contributing/guidelines')}
                 className="group mt-5 inline-flex items-center gap-1 text-sm font-semibold text-velvet-emerald-mint transition-colors duration-200 hover:text-velvet-emerald-mint focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-velvet-emerald-mint focus-visible:ring-offset-2 focus-visible:ring-offset-velvet-surface-base"
               >
                 Read the connector SDK

--- a/apps/web/src/components/landing/sections/DemoEmbed.tsx
+++ b/apps/web/src/components/landing/sections/DemoEmbed.tsx
@@ -25,6 +25,7 @@ import Link from 'next/link';
 import { motion, useReducedMotion } from 'framer-motion';
 import { ArrowRight, Clock, Cpu, Database } from 'lucide-react';
 import { BorderBeam } from '@/components/magicui/BorderBeam';
+import { docs } from '@/lib/docs';
 import { cn } from '@/lib/utils';
 
 interface LedgerStep {
@@ -278,7 +279,7 @@ export function DemoEmbed() {
 
         <div className="mx-auto mt-10 flex max-w-3xl flex-col items-center justify-center gap-3 text-center sm:flex-row sm:gap-5">
           <Link
-            href="https://github.com/beenuar/AiSOC#5-minute-demo"
+            href={docs('quickstart')}
             className="group inline-flex h-11 items-center gap-2 rounded-md bg-velvet-emerald-cta px-6 text-sm font-semibold text-velvet-content-primary shadow-[0_1px_0_rgba(255,255,255,0.18)_inset] transition-shadow duration-200 ease-landing-out-quart motion-safe:hover:shadow-glow-emerald-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-velvet-emerald-mint focus-visible:ring-offset-2 focus-visible:ring-offset-velvet-surface-base"
           >
             Run this yourself in 5 minutes
@@ -288,7 +289,7 @@ export function DemoEmbed() {
             />
           </Link>
           <Link
-            href="https://github.com/beenuar/AiSOC#readme"
+            href={docs('architecture')}
             className="inline-flex items-center gap-1 text-sm font-medium text-velvet-content-tertiary transition-colors duration-200 hover:text-velvet-content-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-velvet-emerald-mint focus-visible:ring-offset-2 focus-visible:ring-offset-velvet-surface-base"
           >
             Read the architecture

--- a/apps/web/src/components/landing/sections/Footer.tsx
+++ b/apps/web/src/components/landing/sections/Footer.tsx
@@ -15,6 +15,7 @@
 import type { ReactElement, SVGProps } from 'react';
 import Link from 'next/link';
 import { GithubMark } from './icons';
+import { docs } from '@/lib/docs';
 
 interface LinkSpec {
   label: string;
@@ -41,8 +42,8 @@ const COLUMNS: ReadonlyArray<LinkColumn> = [
   {
     heading: 'Resources',
     links: [
-      { label: 'Docs', href: 'https://github.com/beenuar/AiSOC#readme' },
-      { label: 'Architecture', href: 'https://github.com/beenuar/AiSOC#readme' },
+      { label: 'Docs', href: docs('intro') },
+      { label: 'Architecture', href: docs('architecture') },
       { label: 'Benchmark', href: '/benchmark' },
       { label: 'Blog', href: '/blog' },
       { label: 'Changelog', href: '/changelog' },

--- a/apps/web/src/components/landing/sections/OpenSourceMoment.tsx
+++ b/apps/web/src/components/landing/sections/OpenSourceMoment.tsx
@@ -20,10 +20,11 @@ import Link from 'next/link';
 import { motion, useReducedMotion } from 'framer-motion';
 import { ArrowRight, GitBranch, Star, Terminal } from 'lucide-react';
 import { BorderBeam } from '@/components/magicui/BorderBeam';
+import { docs } from '@/lib/docs';
 import { GithubMark } from './icons';
 
 const REPO_URL = 'https://github.com/beenuar/AiSOC';
-const CONTRIBUTING_URL = 'https://github.com/beenuar/AiSOC/blob/main/CONTRIBUTING.md';
+const CONTRIBUTING_URL = docs('contributing/guidelines');
 const SNIPPET = `git clone https://github.com/beenuar/AiSOC.git
 cd AiSOC
 pnpm aisoc:demo`;

--- a/apps/web/src/components/landing/sections/Pillars.tsx
+++ b/apps/web/src/components/landing/sections/Pillars.tsx
@@ -22,6 +22,7 @@ import { motion, useReducedMotion } from 'framer-motion';
 import { ArrowRight, GitGraph, ScrollText, Sparkles, Boxes } from 'lucide-react';
 import type { ComponentType, SVGProps } from 'react';
 import { GlowingEffect } from '@/components/aceternity/GlowingEffect';
+import { docs } from '@/lib/docs';
 import { cn } from '@/lib/utils';
 
 interface Pillar {
@@ -55,7 +56,7 @@ const PILLARS: ReadonlyArray<Pillar> = [
       'The entity graph is written while events are normalised, not when an analyst clicks "show graph." Schema v1.0 is published.',
     stat: '17 + 14',
     statLabel: 'node labels · relationships',
-    href: 'https://github.com/beenuar/AiSOC#readme',
+    href: docs('architecture/graph-schema'),
     linkLabel: 'Read the graph schema',
   },
   {
@@ -66,7 +67,7 @@ const PILLARS: ReadonlyArray<Pillar> = [
       'Four named agents. Every prompt, tool call, and decision is logged, the LLM-input contract fails closed on malformed prompts, and a CI-gated CVE audit blocks every merge.',
     stat: '4 / 100%',
     statLabel: 'agents · audited',
-    href: 'https://github.com/beenuar/AiSOC#readme',
+    href: docs('architecture/agents'),
     linkLabel: 'Read the agent contract',
   },
   {
@@ -77,7 +78,7 @@ const PILLARS: ReadonlyArray<Pillar> = [
       'Render, Fly.io, Kubernetes, AWS, your air-gapped rack — same code path. BYOK LLM credentials in the encrypted vault.',
     stat: '6 + 1',
     statLabel: 'deploy targets · air-gap overlay',
-    href: 'https://github.com/beenuar/AiSOC#readme',
+    href: docs('deployment/docker'),
     linkLabel: 'Read the deployment guide',
   },
 ];

--- a/apps/web/src/components/landing/sections/StickyNav.tsx
+++ b/apps/web/src/components/landing/sections/StickyNav.tsx
@@ -19,6 +19,7 @@ import Link from 'next/link';
 import { useEffect, useState } from 'react';
 import { ArrowRight, Menu, X } from 'lucide-react';
 import { GithubMark } from './icons';
+import { docs } from '@/lib/docs';
 import { cn } from '@/lib/utils';
 
 const NAV_LINKS: ReadonlyArray<{ label: string; href: string }> = [
@@ -27,7 +28,7 @@ const NAV_LINKS: ReadonlyArray<{ label: string; href: string }> = [
   { label: 'Connectors', href: '#connectors' },
   { label: 'Benchmark', href: '#benchmark' },
   { label: 'Pricing', href: '#pricing' },
-  { label: 'Docs', href: 'https://github.com/beenuar/AiSOC#readme' },
+  { label: 'Docs', href: docs('intro') },
 ];
 
 export function StickyNav() {

--- a/apps/web/src/lib/docs.ts
+++ b/apps/web/src/lib/docs.ts
@@ -1,0 +1,5 @@
+export const DOCS_BASE =
+  process.env.NEXT_PUBLIC_DOCS_URL ?? "https://beenuar.github.io/AiSOC/docs";
+
+export const docs = (path: string) =>
+  `${DOCS_BASE}/${path.replace(/^\//, "")}`;


### PR DESCRIPTION
The marketing pages (landing, benchmark, why-open-source, sovereign, demo banner) routed every "Docs" / "Quickstart" / "Read the architecture" CTA at github.com/beenuar/AiSOC#readme anchors, hiding the deployed docs site at beenuar.github.io/AiSOC/docs from every public-facing surface. In-app surfaces (OnboardingView, SettingsView) already linked there correctly.

Centralise the docs base via a new `docs()` helper backed by NEXT_PUBLIC_DOCS_URL so the maintainer can flip everything to a custom domain by setting one env var. Map each link to the most specific Docusaurus page that exists: intro, quickstart, architecture, architecture/graph-schema, architecture/agents, deployment/docker, benchmark, contributing/guidelines, and
architecture/itsm-as-source-of-truth.

Also fixes:
  - JSON-LD installUrl in page.tsx / layout.tsx (was pointing at the README's #quick-start anchor)
  - sovereign's "Investigation ledger" RepoArtefact card (was pointing at #investigation-ledger; now points at the actual services/agents/app/ledger directory like its sibling cards)
  - "Contributing" link in the landing footer Community column and the "Read CONTRIBUTING.md" CTA in OpenSourceMoment (were pointing at raw GitHub markdown; now point at the rendered docs version)
  - "Contributing guide" CTA on the benchmark page

In-app CONTRIBUTING.md links (SettingsView, MarketplaceView) are intentionally left for a follow-up PR to keep this change scoped to visitor-facing surfaces.

Artefact links (LICENSE, git clone URLs, view-on-GitHub buttons, sovereign's raw config-file links to docker-compose.airgap.yml, helm Chart.yaml, terraform dirs) deliberately stay on GitHub because GitHub is their canonical home.
Fix #244 