### PR TITLE
fix(infra): add missing rds, elasticache, and kafka terraform modules

### DIFF
--- a/infra/terraform/modules/elasticache/main.tf
+++ b/infra/terraform/modules/elasticache/main.tf
@@ -1,0 +1,71 @@
+resource "aws_elasticache_subnet_group" "main" {
+  name       = "${var.name_prefix}-redis"
+  subnet_ids = var.subnet_ids
+
+  tags = {
+    Name = "${var.name_prefix}-redis"
+  }
+}
+
+resource "aws_security_group" "redis" {
+  name        = "${var.name_prefix}-redis"
+  description = "Allow Redis access from approved security groups"
+  vpc_id      = var.vpc_id
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = "${var.name_prefix}-redis"
+  }
+}
+
+resource "aws_security_group_rule" "redis_ingress" {
+  count                    = length(var.allowed_security_groups)
+  type                     = "ingress"
+  from_port                = 6379
+  to_port                  = 6379
+  protocol                 = "tcp"
+  security_group_id        = aws_security_group.redis.id
+  source_security_group_id = var.allowed_security_groups[count.index]
+}
+
+resource "aws_elasticache_replication_group" "main" {
+  replication_group_id = "${var.name_prefix}-redis"
+  description          = "${var.name_prefix} Redis cluster"
+
+  engine         = "redis"
+  engine_version = var.engine_version
+  node_type      = var.node_type
+  port           = 6379
+
+  num_node_groups            = var.num_shards
+  replicas_per_node_group    = var.replicas_per_shard
+  automatic_failover_enabled = true
+  multi_az_enabled           = true
+
+  subnet_group_name  = aws_elasticache_subnet_group.main.name
+  security_group_ids = [aws_security_group.redis.id]
+
+  at_rest_encryption_enabled = true
+  transit_encryption_enabled = true
+
+  tags = {
+    Name = "${var.name_prefix}-redis"
+  }
+}
+
+output "endpoint" {
+  description = "Redis configuration (cluster) endpoint"
+  value       = aws_elasticache_replication_group.main.configuration_endpoint_address
+  sensitive   = true
+}
+
+output "security_group_id" {
+  description = "Security group attached to the cache"
+  value       = aws_security_group.redis.id
+}

--- a/infra/terraform/modules/elasticache/variables.tf
+++ b/infra/terraform/modules/elasticache/variables.tf
@@ -1,0 +1,44 @@
+variable "name_prefix" {
+  description = "Prefix applied to all ElastiCache resource names"
+  type        = string
+}
+
+variable "vpc_id" {
+  description = "VPC the cache is deployed into"
+  type        = string
+}
+
+variable "subnet_ids" {
+  description = "Subnet IDs used for the cache subnet group"
+  type        = list(string)
+}
+
+variable "node_type" {
+  description = "ElastiCache node type"
+  type        = string
+  default     = "cache.r6g.large"
+}
+
+variable "engine_version" {
+  description = "Redis engine version"
+  type        = string
+  default     = "7.1"
+}
+
+variable "num_shards" {
+  description = "Number of node groups (shards) in the cluster"
+  type        = number
+  default     = 2
+}
+
+variable "replicas_per_shard" {
+  description = "Number of read replicas per shard"
+  type        = number
+  default     = 1
+}
+
+variable "allowed_security_groups" {
+  description = "Security group IDs permitted to reach Redis on port 6379"
+  type        = list(string)
+  default     = []
+}

--- a/infra/terraform/modules/kafka/main.tf
+++ b/infra/terraform/modules/kafka/main.tf
@@ -1,0 +1,91 @@
+resource "aws_security_group" "kafka" {
+  name        = "${var.name_prefix}-kafka"
+  description = "Allow Kafka access from approved security groups"
+  vpc_id      = var.vpc_id
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = "${var.name_prefix}-kafka"
+  }
+}
+
+resource "aws_security_group_rule" "kafka_ingress" {
+  for_each = {
+    for pair in setproduct(var.allowed_security_groups, [9092, 9094, 9098, 2181]) :
+    "${pair[0]}-${pair[1]}" => {
+      sg   = pair[0]
+      port = pair[1]
+    }
+  }
+
+  type                     = "ingress"
+  from_port                = each.value.port
+  to_port                  = each.value.port
+  protocol                 = "tcp"
+  security_group_id        = aws_security_group.kafka.id
+  source_security_group_id = each.value.sg
+}
+
+resource "aws_cloudwatch_log_group" "kafka" {
+  name              = "/aws/msk/${var.name_prefix}"
+  retention_in_days = 30
+
+  tags = {
+    Name = "${var.name_prefix}-kafka"
+  }
+}
+
+resource "aws_msk_cluster" "main" {
+  cluster_name           = "${var.name_prefix}-kafka"
+  kafka_version          = var.kafka_version
+  number_of_broker_nodes = var.broker_count
+
+  broker_node_group_info {
+    instance_type   = var.instance_type
+    client_subnets  = var.subnet_ids
+    security_groups = [aws_security_group.kafka.id]
+
+    storage_info {
+      ebs_storage_info {
+        volume_size = var.ebs_volume_size
+      }
+    }
+  }
+
+  encryption_info {
+    encryption_in_transit {
+      client_broker = "TLS"
+      in_cluster    = true
+    }
+  }
+
+  logging_info {
+    broker_logs {
+      cloudwatch_logs {
+        enabled   = true
+        log_group = aws_cloudwatch_log_group.kafka.name
+      }
+    }
+  }
+
+  tags = {
+    Name = "${var.name_prefix}-kafka"
+  }
+}
+
+output "bootstrap_brokers" {
+  description = "TLS bootstrap broker connection string"
+  value       = aws_msk_cluster.main.bootstrap_brokers_tls
+  sensitive   = true
+}
+
+output "security_group_id" {
+  description = "Security group attached to the Kafka brokers"
+  value       = aws_security_group.kafka.id
+}

--- a/infra/terraform/modules/kafka/variables.tf
+++ b/infra/terraform/modules/kafka/variables.tf
@@ -1,0 +1,44 @@
+variable "name_prefix" {
+  description = "Prefix applied to all MSK resource names"
+  type        = string
+}
+
+variable "vpc_id" {
+  description = "VPC the Kafka cluster is deployed into"
+  type        = string
+}
+
+variable "subnet_ids" {
+  description = "Subnet IDs the broker nodes are placed in"
+  type        = list(string)
+}
+
+variable "instance_type" {
+  description = "MSK broker instance type"
+  type        = string
+  default     = "kafka.m5.large"
+}
+
+variable "broker_count" {
+  description = "Number of broker nodes (must be a multiple of the number of subnets)"
+  type        = number
+  default     = 3
+}
+
+variable "kafka_version" {
+  description = "Apache Kafka version"
+  type        = string
+  default     = "3.6.0"
+}
+
+variable "ebs_volume_size" {
+  description = "EBS volume size per broker in GiB"
+  type        = number
+  default     = 100
+}
+
+variable "allowed_security_groups" {
+  description = "Security group IDs permitted to reach the brokers"
+  type        = list(string)
+  default     = []
+}

--- a/infra/terraform/modules/rds/main.tf
+++ b/infra/terraform/modules/rds/main.tf
@@ -1,0 +1,87 @@
+resource "random_password" "master" {
+  length           = 32
+  special          = true
+  override_special = "!#$%&*()-_=+[]{}<>:?"
+}
+
+resource "aws_db_subnet_group" "main" {
+  name       = "${var.name_prefix}-rds"
+  subnet_ids = var.db_subnet_ids
+
+  tags = {
+    Name = "${var.name_prefix}-rds"
+  }
+}
+
+resource "aws_security_group" "rds" {
+  name        = "${var.name_prefix}-rds"
+  description = "Allow PostgreSQL access from approved security groups"
+  vpc_id      = var.vpc_id
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = "${var.name_prefix}-rds"
+  }
+}
+
+resource "aws_security_group_rule" "rds_ingress" {
+  count                    = length(var.allowed_security_groups)
+  type                     = "ingress"
+  from_port                = 5432
+  to_port                  = 5432
+  protocol                 = "tcp"
+  security_group_id        = aws_security_group.rds.id
+  source_security_group_id = var.allowed_security_groups[count.index]
+}
+
+resource "aws_db_instance" "main" {
+  identifier     = "${var.name_prefix}-postgres"
+  engine         = "postgres"
+  engine_version = var.engine_version
+  instance_class = var.instance_class
+
+  db_name  = var.db_name
+  username = var.db_username
+  password = random_password.master.result
+
+  allocated_storage     = var.allocated_storage
+  max_allocated_storage = var.max_allocated_storage
+  storage_type          = "gp3"
+  storage_encrypted     = true
+
+  db_subnet_group_name   = aws_db_subnet_group.main.name
+  vpc_security_group_ids = [aws_security_group.rds.id]
+
+  multi_az                  = var.multi_az
+  backup_retention_period   = var.backup_retention_period
+  deletion_protection       = true
+  skip_final_snapshot       = false
+  final_snapshot_identifier = "${var.name_prefix}-postgres-final"
+
+  tags = {
+    Name = "${var.name_prefix}-postgres"
+  }
+}
+
+output "endpoint" {
+  description = "PostgreSQL connection endpoint"
+  value       = aws_db_instance.main.endpoint
+  sensitive   = true
+}
+
+output "db_password" {
+  description = "Generated master password"
+  value       = random_password.master.result
+  sensitive   = true
+}
+
+output "security_group_id" {
+  description = "Security group attached to the database"
+  value       = aws_security_group.rds.id
+}

--- a/infra/terraform/modules/rds/variables.tf
+++ b/infra/terraform/modules/rds/variables.tf
@@ -1,0 +1,69 @@
+variable "name_prefix" {
+  description = "Prefix applied to all RDS resource names"
+  type        = string
+}
+
+variable "vpc_id" {
+  description = "VPC the database is deployed into"
+  type        = string
+}
+
+variable "db_subnet_ids" {
+  description = "Subnet IDs used for the database subnet group"
+  type        = list(string)
+}
+
+variable "instance_class" {
+  description = "RDS instance class"
+  type        = string
+  default     = "db.r6g.large"
+}
+
+variable "db_name" {
+  description = "Initial database name"
+  type        = string
+  default     = "aisoc"
+}
+
+variable "db_username" {
+  description = "Master username"
+  type        = string
+  default     = "aisoc_admin"
+  sensitive   = true
+}
+
+variable "engine_version" {
+  description = "PostgreSQL engine version"
+  type        = string
+  default     = "16.4"
+}
+
+variable "allocated_storage" {
+  description = "Initial allocated storage in GiB"
+  type        = number
+  default     = 100
+}
+
+variable "max_allocated_storage" {
+  description = "Upper bound for storage autoscaling in GiB"
+  type        = number
+  default     = 1000
+}
+
+variable "backup_retention_period" {
+  description = "Number of days to retain automated backups"
+  type        = number
+  default     = 7
+}
+
+variable "multi_az" {
+  description = "Deploy the database across multiple availability zones"
+  type        = bool
+  default     = true
+}
+
+variable "allowed_security_groups" {
+  description = "Security group IDs permitted to reach the database on port 5432"
+  type        = list(string)
+  default     = []
+}


### PR DESCRIPTION
## Summary

The top-level `infra/terraform/main.tf` referenced `module.rds`, `module.elasticache`, and `module.kafka` at `./modules/*` paths that did not exist, so `terraform init -backend=false` failed on a clean clone (issue #249).

This PR adds the three missing modules, with inputs/outputs matching how the root configuration calls them:

- **rds** — PostgreSQL `aws_db_instance` with subnet group, security group, generated master password (`random_password`), gp3 encrypted storage, multi-AZ, and backups.
- **elasticache** — Redis `aws_elasticache_replication_group` in cluster mode (`num_node_groups`), subnet group, security group, encryption in transit + at rest, and automatic failover.
- **kafka** — `aws_msk_cluster` with TLS in transit, CloudWatch broker logging, EBS storage, and ingress security group rules for broker ports.

## Test plan

- [x] `terraform init -backend=false` succeeds on a clean clone
- [x] `terraform validate` passes
- [x] `terraform fmt -check -recursive` is clean
- [x] Terraform CI workflow (added in #251) exercises the above on every PR

Fixes #249

Made with [Cursor](https://cursor.com)