### PR TITLE
sync(plans/cyble-aisoc): archive notice from upstream AISOC-Cyble

### DIFF
--- a/DEPRECATED.md
+++ b/DEPRECATED.md
@@ -1,0 +1,49 @@
+# This repository is archived
+
+> **As of 2026-06-27, `beenuar/AISOC-Cyble` is archived and read-only.**
+
+All content from this repository has been merged into the canonical, public,
+open-source repository:
+
+## → https://github.com/beenuar/AiSOC
+
+`beenuar/AiSOC` is now the **single source of truth** for the AiSOC project,
+including:
+
+- The deployable monorepo at the repo root (`services/`, `apps/`, `infra/`,
+  `packages/`, `detections/`, `playbooks/`, etc.).
+- The original spec, architecture notes, roadmap, and FastAPI/static
+  prototype from this repository, now preserved under
+  [`plans/cyble-aisoc/`](https://github.com/beenuar/AiSOC/tree/main/plans/cyble-aisoc).
+
+### How the merge was done
+
+`AISOC-Cyble` was incorporated via `git subtree add --prefix=plans/cyble-aisoc`,
+which preserved both founding commits of this repository in the public history:
+
+- `5581d4b Initial import: Cyble AiSOC platform`
+- `e4080973 feat(platform): land 13 feature areas from cyble-aisoc-plan.md`
+
+Both commits remain reachable from `main` of `beenuar/AiSOC` via the merge
+commit
+[`bbaca46e Add 'plans/cyble-aisoc/' from commit 'e4080973…'`](https://github.com/beenuar/AiSOC/commit/bbaca46e)
+landed in [PR #324](https://github.com/beenuar/AiSOC/pull/324).
+
+### What to do
+
+- **Update bookmarks and clones** to point at `https://github.com/beenuar/AiSOC`.
+- **For the spec doc** (`cyble-aisoc-plan.md`): use
+  `https://github.com/beenuar/AiSOC/blob/main/plans/cyble-aisoc/cyble-aisoc-plan.md`.
+- **For the prototype code**: it has been superseded by the production
+  implementation under `services/` in the new repo. Treat
+  `plans/cyble-aisoc/platform/` as historical reference only.
+
+### Why this repo was archived
+
+The project was originally developed here as a private staging area while
+the canonical, open-source deployable monorepo lived at `beenuar/AiSOC`.
+Keeping two repos in sync became unnecessary friction once the public repo
+matured. Consolidation under one MIT-licensed home is simpler for
+contributors and clearer for downstream consumers.
+
+— 2026-06-27


### PR DESCRIPTION
## Summary

Pulls in the `DEPRECATED.md` archive notice that was just landed on the (now-being-archived) `beenuar/AISOC-Cyble` repo, via `git subtree pull --prefix=plans/cyble-aisoc aisoc-cyble main`. This keeps the public mirror under `plans/cyble-aisoc/` faithful to its upstream right up to the moment AISOC-Cyble is archived.

After this lands:
- `beenuar/AISOC-Cyble` will be archived (read-only) and its `DEPRECATED.md` will point everyone to this repo.
- The same `DEPRECATED.md` will be visible at [`plans/cyble-aisoc/DEPRECATED.md`](https://github.com/beenuar/AiSOC/blob/main/plans/cyble-aisoc/DEPRECATED.md) so the archive notice is reachable from anywhere — both the old URL and the new home.

## Diff

Single file added: `plans/cyble-aisoc/DEPRECATED.md` (49 lines, MIT-compatible prose). No code, no workflow changes.

## Subtree history

```
0f4c3f30 Sync archive notice from AISOC-Cyble  ← this PR's merge commit
dc4f08d7 chore: archive notice — superseded by github.com/beenuar/AiSOC  ← upstream commit on AISOC-Cyble
dc2ab762 Merge pull request #324 from beenuar/merge/aisoc-cyble-into-plans  ← previous main
```

The subtree-pull merge commit (`0f4c3f30`) keeps the AISOC-Cyble commit (`dc4f08d7`) reachable from `main` of this repo — completing the provenance chain.

## Test plan

- [x] Diff is single-file additive under `plans/cyble-aisoc/`
- [x] No workflow path-filter matches → CodeQL/Security-Audit/CI all should be unaffected (or trivially green)
- [ ] CI green on this PR
- [ ] After merge, AISOC-Cyble is archived


Made with [Cursor](https://cursor.com)