### PR TITLE
fix(agents): point threat-actor attribution at threatintel:8005 (not :8083)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Threat-actor attribution could never connect.** The investigation
+  agent defaulted `AISOC_THREATINTEL_URL` to `http://threatintel:8083`,
+  but the `threatintel` service binds port **8005** (Dockerfile,
+  `docker-compose.yml`, and the README service table). Every
+  `POST /api/v1/actors/attribute` call from
+  `services/agents/app/agents/investigation_agent.py` therefore targeted a
+  port nothing listens on and failed (soft-handled, so attribution silently
+  degraded). Corrected the default to `http://threatintel:8005`, fixed the
+  matching `docs/threat-actor-attribution.md` references (and a stale
+  `AISOC_ATTRIBUTION_TIMEOUT_SECONDS` default of `10` → `30`), and added a
+  regression test (`services/agents/tests/test_attribution_service_url.py`).
+
 ## [7.4.0] — 2026-05-29
 
 Security-hardening and platform release. Folds in the May 27–29 hardening wave,

--- a/docs/threat-actor-attribution.md
+++ b/docs/threat-actor-attribution.md
@@ -65,7 +65,7 @@ There is **no** synthetic "every observed IOC counts as a match" inflation.
 ## API
 
 Mounted under `/api/v1/actors` on the `threatintel` service (default
-port `8083`).
+port `8005`).
 
 ### `POST /api/v1/actors/attribute`
 
@@ -154,8 +154,8 @@ and `severity`. To enrich attribution, populate those fields on the
 incoming alert.
 
 The HTTP timeout is tunable via `AISOC_ATTRIBUTION_TIMEOUT_SECONDS`
-(default `10`), and the `threatintel` base URL via `AISOC_THREATINTEL_URL`
-(default `http://threatintel:8083`).
+(default `30`), and the `threatintel` base URL via `AISOC_THREATINTEL_URL`
+(default `http://threatintel:8005`).
 
 ## v0 limits and intended next steps
 

--- a/services/agents/app/agents/investigation_agent.py
+++ b/services/agents/app/agents/investigation_agent.py
@@ -20,7 +20,7 @@ logger = structlog.get_logger()
 # Address of the threat intel service that hosts the attribution endpoint.
 # Defaults to the in-cluster Docker Compose hostname; override via env in
 # Kubernetes / Fly / standalone deployments.
-THREAT_INTEL_SERVICE_URL = os.getenv("AISOC_THREATINTEL_URL", "http://threatintel:8083").rstrip("/")
+THREAT_INTEL_SERVICE_URL = os.getenv("AISOC_THREATINTEL_URL", "http://threatintel:8005").rstrip("/")
 ATTRIBUTION_TIMEOUT_SECONDS = float(os.getenv("AISOC_ATTRIBUTION_TIMEOUT_SECONDS", "30.0"))
 
 

--- a/services/agents/tests/test_attribution_service_url.py
+++ b/services/agents/tests/test_attribution_service_url.py
@@ -1,0 +1,108 @@
+"""Regression tests for the threat-actor attribution client URL.
+
+The investigation agent calls the ``threatintel`` service's
+``POST /api/v1/actors/attribute`` endpoint. The ``threatintel`` service
+binds port **8005** everywhere it is actually run — ``Dockerfile``
+(``EXPOSE 8005`` / ``--port 8005``), ``docker-compose.yml``
+(``127.0.0.1:8005:8005``), and the canonical service/port table in
+``README.md``. An earlier default of ``http://threatintel:8083`` meant the
+agent → attribution call could never connect: it has been pointed at a
+port nothing listens on since the feature shipped.
+
+These tests lock the contract in two places:
+
+* the default base URL resolves to ``:8005`` (the regression guard for the
+  ``8083`` typo), and an operator override via ``AISOC_THREATINTEL_URL`` is
+  honoured with the trailing slash stripped;
+* ``_call_attribution_service`` posts to ``{base}/api/v1/actors/attribute``
+  so neither the port nor the path can silently drift again.
+
+We mock the network with :mod:`respx` so the suite stays offline-safe,
+mirroring ``test_fusion_client.py`` which guards the analogous fusion
+``/process`` path/port mismatch.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
+
+import httpx
+import pytest
+import respx
+
+# Match the path-mutation pattern used by the rest of services/agents/tests/.
+_AGENTS_ROOT = Path(__file__).resolve().parents[1]
+if str(_AGENTS_ROOT) not in sys.path:
+    sys.path.insert(0, str(_AGENTS_ROOT))
+
+
+def _reload_agent(monkeypatch: pytest.MonkeyPatch, url: str | None):
+    """Reload ``investigation_agent`` under a controlled env.
+
+    The module reads ``AISOC_THREATINTEL_URL`` at import time, so the env
+    must be set/cleared before the reload. We use ``importlib.import_module``
+    (rather than ``import app.agents.investigation_agent as ...``) so
+    CodeQL's py/import-and-import-from rule doesn't flag this file.
+    """
+    if url is None:
+        monkeypatch.delenv("AISOC_THREATINTEL_URL", raising=False)
+    else:
+        monkeypatch.setenv("AISOC_THREATINTEL_URL", url)
+    module = importlib.import_module("app.agents.investigation_agent")
+    return importlib.reload(module)
+
+
+def test_default_base_url_uses_canonical_port(monkeypatch: pytest.MonkeyPatch) -> None:
+    """With no override, the agent targets ``threatintel:8005`` — never ``:8083``.
+
+    8005 is where the threatintel service actually listens (Dockerfile,
+    docker-compose, README service table). A regression to ``:8083`` would
+    silently break threat-actor attribution end to end.
+    """
+    module = _reload_agent(monkeypatch, None)
+    assert module.THREAT_INTEL_SERVICE_URL == "http://threatintel:8005"
+    assert ":8083" not in module.THREAT_INTEL_SERVICE_URL
+
+
+def test_env_override_is_honoured_and_trailing_slash_stripped(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``AISOC_THREATINTEL_URL`` wins for non-Compose deployments."""
+    module = _reload_agent(monkeypatch, "http://ti.internal:9000/")
+    assert module.THREAT_INTEL_SERVICE_URL == "http://ti.internal:9000"
+
+
+async def test_call_attribution_service_posts_to_correct_url(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The client must POST to ``{base}/api/v1/actors/attribute``.
+
+    Guards both the port and the path together, so neither can drift back
+    out of sync with where the threatintel router is mounted.
+    """
+    base = "http://threatintel-test:8005"
+    module = _reload_agent(monkeypatch, base)
+
+    attribution = {
+        "actor_id": "APT28",
+        "actor_name": "APT28 (Fancy Bear)",
+        "confidence_score": 0.5,
+        "reasoning": ["Matched 2/3 TTPs"],
+    }
+
+    async with respx.mock(base_url=base, assert_all_called=True) as router:
+        route = router.post("/api/v1/actors/attribute").mock(
+            return_value=httpx.Response(200, json=attribution),
+        )
+
+        result = await module._call_attribution_service(
+            iocs=[{"value": "evil.exe", "type": "filename"}],
+            mitre_techniques=["T1566", "T1059"],
+            case_metadata={"targets": ["government"]},
+        )
+
+    assert result == attribution
+    assert route.called
+    assert str(route.calls.last.request.url) == f"{base}/api/v1/actors/attribute"


### PR DESCRIPTION
## Summary

Threat-actor attribution from the investigation agent has **never been able to connect** since the feature shipped in v7.0. The agent defaults the threatintel base URL to `http://threatintel:8083`, but the `threatintel` service binds **8005** everywhere it actually runs. Because the call is wrapped in a soft `except`, the failure is swallowed and a whole headline feature degrades silently.

## Evidence

| Check | Result |
|---|---|
| Where `threatintel` listens | **8005** — `services/threatintel/Dockerfile` (`EXPOSE 8005` + `--port 8005`), `docker-compose.yml` (`8005:8005`), and the service/port table in `README.md` |
| Agent default | `http://threatintel:8083` (`services/agents/app/agents/investigation_agent.py`) |
| Anything binding `8083`? | **Nothing** — no service / compose / helm / k8s / fly entry binds 8083 |
| Any `AISOC_THREATINTEL_URL` override? | **None** in the repo — the wrong default is always used |
| Reached at runtime? | **Yes** — `run_investigation` → `_perform_threat_actor_attribution` → `_call_attribution_service`, on every investigation with an IOC or MITRE technique |

So the agent POSTs `/api/v1/actors/attribute` to a port with no listener → connection refused → soft-handled as a `"Threat actor attribution failed"` finding. No crash, so it went unnoticed.

## Fix

- `services/agents/app/agents/investigation_agent.py` — default → `http://threatintel:8005`.
- `docs/threat-actor-attribution.md` — corrected the two `8083` references, plus a stale `AISOC_ATTRIBUTION_TIMEOUT_SECONDS` doc default (`10` → `30`) that no longer matched the code.
- `services/agents/tests/test_attribution_service_url.py` — new respx regression test (default port, env override + trailing-slash strip, and the full `{base}/api/v1/actors/attribute` URL), modeled on the existing fusion `/process` port/path guard in `test_fusion_client.py`.
- `CHANGELOG.md` — entry under `[Unreleased] / Fixed`.

## Testing

```
pytest services/agents/tests/test_attribution_service_url.py   # 3 passed
pytest services/agents/tests/test_fusion_client.py \
       services/agents/tests/test_investigation_completeness.py \
       services/agents/tests/test_four_agent_facade.py          # 46 passed
```

## Scope / severity

Functional bug, not a crash or security issue — investigations still complete; only the attribution step was dead. No behavior change beyond making the call reach the service.
