### PR TITLE
feat(connectors): T4 wave-3 marketplace scaffolding + harden 6 connectors (v8.0)

### DIFF
--- a/apps/docs/docs/connectors/abnormal_security.md
+++ b/apps/docs/docs/connectors/abnormal_security.md
@@ -1,0 +1,86 @@
+---
+sidebar_position: 76
+title: Abnormal Security
+description: Abnormal Security behavioural-AI email threat events into AiSOC via the public REST API.
+---
+
+# Abnormal Security
+
+The Abnormal Security connector polls the **/v1/threats** and **/v1/cases**
+endpoints of the Abnormal API and emits one AiSOC alert per detected
+threat (and one per case, since a case rolls up multiple threats and
+carries its own severity).
+
+## What you get
+
+| Source | Abnormal endpoint | Notes |
+|---|---|---|
+| Threats | `GET /v1/threats` | One row per detected message threat |
+| Cases   | `GET /v1/cases`   | Case-ified aggregations across multiple threats |
+
+Events are normalised with `source: abnormal_security` and the original
+Abnormal envelope is preserved on `raw_event` so playbooks can target
+specific `threatType` values (`businessEmailCompromise`,
+`credentialPhishing`, `accountTakeover`, …).
+
+## Prerequisites
+
+- An **Abnormal Security tenant** with API access enabled.
+- An **API token** generated in the Abnormal Console under
+  *Settings → Integrations → API → Generate token*. The token must
+  have read scope on threats and cases.
+- (Optional) A regional override for `base_url` if your Abnormal tenant
+  is provisioned outside the default
+  `https://api.abnormalplatform.com`.
+
+## Setup walkthrough
+
+1. Sign in to the Abnormal Console as an administrator.
+2. Navigate to **Settings → Integrations → API**.
+3. Click **Generate token** and copy the value to a password manager.
+4. In AiSOC: **Connectors → Add connector → Abnormal Security**.
+5. Paste the API token (and override `base_url` only if your tenant
+   requires a regional endpoint).
+6. Click **Test connection**. AiSOC issues a `GET /v1/threats?pageSize=1`
+   request and confirms a `200`.
+7. Save.
+
+## Severity mapping
+
+The connector collapses Abnormal `threatType` into the AiSOC ladder:
+
+| AiSOC severity | Abnormal threat type |
+|---|---|
+| `high`   | `businessEmailCompromise`, `credentialPhishing`, `accountTakeover`, `phishing`, `malware`, `invoiceFraud`, `vendorEmailCompromise`, `extortion` |
+| `medium` | every other threat — Abnormal only reports things it considers abnormal, so there is no `info` floor |
+| `low`    | `spam`, `graymail`, `promotional`, `marketing` |
+
+Cases (`/v1/cases`) carry their own `severity` and the connector takes
+the **max** of the constituent threats' severity and the case's
+declared severity.
+
+## Capabilities
+
+- `pull_alerts` — passive polling of threats + cases.
+- `pivot_user` — given a mailbox, return Abnormal context for that user.
+- `read_audit_trail` — surface the API call lineage during investigation.
+
+## Polling details
+
+- Poll interval: every 5 minutes by default (`since_seconds=300`).
+- Pagination: 100 items / page, up to 25 pages (`pageNumber` /
+  `nextPageNumber`).
+- The connector swallows network and HTTP errors and returns `[]`
+  rather than raising — the scheduler logs and retries on the next
+  cycle.
+
+## Troubleshooting
+
+- **`401 Unauthorized`** — the API token has expired or has been
+  rotated. Regenerate under *Settings → Integrations → API* and update
+  the connector.
+- **No events** — confirm there is recent email traffic. Abnormal only
+  emits threat rows when its model flags a message; benign mail is
+  silently dropped.
+- **`429 Too Many Requests`** — the connector backs off automatically;
+  if it persists, lower the poll frequency in the scheduler.

--- a/apps/docs/docs/connectors/box.md
+++ b/apps/docs/docs/connectors/box.md
@@ -1,0 +1,91 @@
+---
+sidebar_position: 77
+title: Box
+description: Box enterprise admin audit log events into AiSOC via the Box Events API.
+---
+
+# Box
+
+The Box connector polls the **/2.0/events?stream_type=admin_logs**
+endpoint of the Box API and emits one AiSOC alert per admin event
+(login, shared-link creation, MFA / device-trust changes, folder
+permission changes, file lifecycle).
+
+## What you get
+
+| Source | Box endpoint | Notes |
+|---|---|---|
+| Admin events | `GET /2.0/events?stream_type=admin_logs` | All security-relevant admin actions |
+
+Events are normalised with `source: box` and the original Box envelope
+is preserved on `raw_event` so detection rules can match on the
+`event_type` (e.g. `SHARE`, `LOGIN`, `ITEM_RENAME`,
+`ENTERPRISE_APP_AUTHORIZATION`).
+
+## Prerequisites
+
+- A **Box Business / Enterprise** tenant with admin access.
+- An **access token** with the `manage_enterprise_properties` scope.
+  Two ways to get one:
+  - Production: **Custom App → JWT / OAuth 2.0** with the *Manage
+    enterprise properties* permission, then mint a server-side token.
+  - Proof-of-concept: a **Developer Token** generated from the Box
+    Developer Console (expires every 60 minutes — fine for a one-off
+    smoke test, not for production).
+
+## Setup walkthrough
+
+1. Sign in to the **Box Developer Console**
+   (`https://app.box.com/developers/console`).
+2. Create a new **Custom App → Server Authentication (with JWT)**.
+3. Enable **Manage enterprise properties** under *Application Scopes*.
+4. **Authorize the app** for your enterprise (Admin Console → Apps →
+   Custom Apps Manager → Authorize). This step is required and is
+   the single most common setup failure.
+5. Generate a server-side access token via the Box SDK or the
+   `/oauth2/token` endpoint and copy it.
+6. In AiSOC: **Connectors → Add connector → Box**.
+7. Paste the access token.
+8. Click **Test connection**. AiSOC issues a `GET /2.0/users/me` and
+   confirms a `200`.
+9. Save.
+
+## Severity mapping
+
+The connector escalates Box `event_type` against a small high/medium
+ladder; everything else falls through to `info`. The canonical lists
+live in `services/connectors/app/connectors/box.py`.
+
+| AiSOC severity | Box `event_type` |
+|---|---|
+| `high`   | `SHIELD_ALERT`, `SHIELD_EXTERNAL_COLLAB_INVITE_BLOCKED`, `SHIELD_EXTERNAL_COLLAB_INVITE_ABNORMAL_LOCATION`, `GROUP_ADMIN_CREATED`, `ROLE_CHANGE_TO_ADMIN`, `MASTER_INVITE_ACCEPT`, `MASTER_INVITE_REJECT`, `APPLICATION_PUBLIC_KEY_DELETED`, `APPLICATION_PUBLIC_KEY_ADDED`, `ITEM_SHARED_LINK`, `DELETE_USER` |
+| `medium` | `COLLABORATION_INVITE`, `COLLABORATION_ACCEPT`, `COLLABORATION_REMOVE`, `COLLABORATION_ROLE_CHANGE`, `COLLABORATION_EXPIRATION`, `FAILED_LOGIN`, `ADD_LOGIN_ACTIVITY_DEVICE`, `REMOVE_LOGIN_ACTIVITY_DEVICE`, `ITEM_SHARED_UPDATE` |
+| `info`   | everything else |
+| `high` (override) | `ITEM_DOWNLOAD` whose actor login ends with `@gmail.com`, `@yahoo.com`, or `@outlook.com` (treated as external collaborator exfiltration) |
+
+## Capabilities
+
+- `pull_audit` — passive polling of admin audit events.
+- `pivot_user` — given a Box email, surface that user's recent activity.
+- `read_audit_trail` — surface the API call lineage during investigation.
+
+## Polling details
+
+- Poll interval: every 5 minutes by default (`since_seconds=300`).
+- Pagination: cursor-based using `next_stream_position`. The connector
+  follows up to 25 pages per poll cycle.
+- The connector swallows network and HTTP errors and returns `[]`
+  rather than raising — the scheduler logs and retries on the next
+  cycle.
+
+## Troubleshooting
+
+- **`401 Unauthorized`** — the access token has expired (Developer
+  Tokens last 60 minutes). Mint a new token via JWT/OAuth and update
+  the connector.
+- **`403 Forbidden`** — the custom app was not authorized for the
+  enterprise (Admin Console → Custom Apps Manager). Authorize it and
+  retry the connection test.
+- **No events** — confirm there is recent admin activity. Box only
+  populates `admin_logs` when an enterprise-admin event occurs;
+  individual user activity lives on a different stream.

--- a/apps/docs/docs/connectors/datadog.md
+++ b/apps/docs/docs/connectors/datadog.md
@@ -1,0 +1,114 @@
+---
+sidebar_position: 78
+title: Datadog
+description: Datadog logs and Cloud SIEM signals into AiSOC via the Datadog v2 API.
+---
+
+# Datadog
+
+The Datadog connector streams from either the **Logs Search v2 API** or
+the **Events v1 API** (APM monitor alerts + custom events), depending
+on the configured `mode`.
+
+For Cloud SIEM **Security Signals**, use the separate
+`datadog_cloud_siem` connector — splitting the modules keeps each
+schema single-purpose.
+
+## What you get
+
+| Mode | Datadog endpoint | Notes |
+|---|---|---|
+| `logs`   | `POST /api/v2/logs/events/search` | Raw logs filtered by the configured query string |
+| `events` | `GET /api/v1/events`              | APM monitor alerts + custom events filtered by tags |
+
+Events are normalised with `source: datadog` and the original Datadog
+envelope is preserved on `raw_event` so detection rules can match on
+`service`, `env`, `status`, or the monitor `tags` block.
+
+## Prerequisites
+
+- A **Datadog organisation** on any of: `datadoghq.com`,
+  `datadoghq.eu`, `us3.datadoghq.com`, `us5.datadoghq.com`,
+  `ddog-gov.com`, or `ap1.datadoghq.com`.
+- An **API key** (Organisation Settings → API Keys → New Key).
+- An **Application key** (Personal Settings → Application Keys → New Key).
+- For `mode: signals`, the org must have **Cloud SIEM** enabled.
+
+## Setup walkthrough
+
+1. In Datadog, **Organisation Settings → API Keys → New Key**. Name it
+   `aisoc-ingest` and copy the value.
+2. **Personal Settings → Application Keys → New Key**. Name it
+   `aisoc-ingest-app` and copy the value.
+3. In AiSOC: **Connectors → Add connector → Datadog (Logs + APM)**.
+4. **Site** — pick the regional site that matches your Datadog tenant.
+5. **Mode** — `logs` for general log streaming, `events` for APM
+   monitor alerts and custom events.
+6. **Query** — any Datadog query-string expression. Defaults to
+   `status:error OR status:critical`. Useful filters:
+   `service:nginx status:error`, `env:prod source:auth`,
+   `@evt.category:authentication status:error`.
+7. Paste the **API key** and **Application key**.
+8. Click **Test connection**. AiSOC issues a 1-row search and confirms
+   a `200`.
+9. Save.
+
+## Severity mapping
+
+For `mode: logs` (the `status` / `level` attribute):
+
+| AiSOC severity | Datadog log status |
+|---|---|
+| `high`   | `emergency`, `alert`, `critical` |
+| `medium` | `error` |
+| `low`    | `warn`, `warning` |
+| `info`   | `notice`, `info`, `debug`, missing |
+
+The split between `critical` (→ high) and `error` (→ medium) is
+deliberate: keeping `critical`/`alert`/`emergency` on its own tier
+means a paging event stays distinguishable from a routine 5xx in the
+alert queue.
+
+For `mode: events` (the monitor `alert_type` attribute):
+
+| AiSOC severity | Datadog event `alert_type` |
+|---|---|
+| `high`   | `error` |
+| `medium` | `warning` |
+| `info`   | `info`, `success`, missing |
+
+Event `priority` is used only as a **floor**: `priority:low` can lower
+severity from `info`, never raise it.
+
+For **Security Signals**, use the `datadog_cloud_siem` connector.
+
+## Capabilities
+
+- `pull_logs` — passive polling of logs.
+- `pull_alerts` — passive polling of APM monitor alerts.
+- `query_logs` — ad-hoc query support (the connector accepts arbitrary
+  Datadog query strings).
+- `pivot_host` — given a hostname, return its recent logs.
+
+## Polling details
+
+- Poll interval: every 5 minutes by default (`since_seconds=300`).
+- Pagination: cursor-based using the v2 API's `meta.page.after` token.
+  The connector follows up to 25 pages per poll cycle.
+- Time range: the search request always carries
+  `filter.from: now-{since_seconds}s`, `filter.to: now`.
+- The connector swallows network and HTTP errors and returns `[]`
+  rather than raising — the scheduler logs and retries on the next
+  cycle.
+
+## Troubleshooting
+
+- **`403 Forbidden`** — the application key was minted by a user
+  without read permission on the resource (logs / signals). Re-create
+  the application key under an account with the right RBAC.
+- **`429 Too Many Requests`** — Datadog throttles aggressively; the
+  connector backs off automatically. Tighten the `query` filter or
+  raise the poll interval if it persists.
+- **No events** — verify the `query` returns rows in the Datadog UI
+  (Logs Explorer or Security Signals page). The connector applies the
+  query verbatim.

--- a/apps/docs/docs/connectors/dropbox.md
+++ b/apps/docs/docs/connectors/dropbox.md
@@ -1,0 +1,91 @@
+---
+sidebar_position: 79
+title: Dropbox
+description: Dropbox Business team audit log events into AiSOC via /2/team_log/get_events.
+---
+
+# Dropbox
+
+The Dropbox connector polls the **/2/team_log/get_events** endpoint of
+the Dropbox Business API and emits one AiSOC alert per team event
+(login, sharing, file lifecycle, device approvals, password resets,
+admin role changes).
+
+## What you get
+
+| Source | Dropbox endpoint | Notes |
+|---|---|---|
+| Team events | `POST /2/team_log/get_events` | Full team audit log |
+
+Events are normalised with `source: dropbox` and the original Dropbox
+envelope is preserved on `raw_event` so detection rules can match on
+`event_category` (`sharing`, `logins`, `file_operations`, …) and
+`event_type.tag` (`login_fail`, `member_change_admin_role`, etc).
+
+## Prerequisites
+
+- A **Dropbox Business** team with team-admin access.
+- An **OAuth 2.0 access token** with the `team_data.member` and
+  `events.read` scopes, minted from a Dropbox app of type
+  *Scoped Dropbox API + Team scope*.
+
+## Setup walkthrough
+
+1. Sign in to **App Console → My Apps** (`https://www.dropbox.com/developers/apps`).
+2. **Create app → Scoped access → Choose API: Dropbox API + Type of access:
+   Full Dropbox**. Set the *App folder name* and create.
+3. **Permissions tab → Team scopes**: enable `events.read` and
+   `team_data.member`.
+4. **Settings tab → OAuth 2** : add a redirect URI (only required if you
+   intend to perform user-driven OAuth; otherwise skip), then click
+   **Generate** under *Generated access token* to get a long-lived
+   team-admin token.
+5. Copy the token.
+6. In AiSOC: **Connectors → Add connector → Dropbox Business**.
+7. Paste the team-admin token.
+8. Click **Test connection**. AiSOC issues a single 1-row
+   `/2/team_log/get_events` and confirms a `200`.
+9. Save.
+
+## Severity mapping
+
+The connector inspects `event_type.tag` and matches against a
+prefix-driven ladder (see `services/connectors/app/connectors/dropbox.py`
+for the canonical lists):
+
+| AiSOC severity | Dropbox `event_type.tag` prefixes |
+|---|---|
+| `high`   | `account_external_password_unmask`, `team_member_create_team_invite_link`, `shared_content_change_link_audience_to_public`, `shared_content_remove_member`, `app_link_team`, `member_change_admin_role`, `team_folder_change_status`, `sso_change_policy` |
+| `medium` | `shared_`, `shared_content_`, `shared_link_`, `shmodel_`, `login_fail`, `login_success_with_two_factor`, `device_link`, `group_create`, `group_delete`, `member_change_status`, `member_change_email` |
+| `info`   | anything not matching either list (the floor) |
+
+Additional refinements applied last (in order):
+
+- `event_type == "login_fail"` is forced to `medium`.
+- `event_type == "login_success"` carrying a device tag is lowered to
+  `low` if no stronger rule already applied.
+
+## Capabilities
+
+- `pull_audit` — passive polling of team audit events.
+- `pivot_user` — given a member email, surface their recent activity.
+- `read_audit_trail` — surface the API call lineage during investigation.
+
+## Polling details
+
+- Poll interval: every 5 minutes by default (`since_seconds=300`).
+- Pagination: cursor-based using `has_more` / `cursor`. The connector
+  follows up to 25 pages per poll cycle.
+- The connector swallows network and HTTP errors and returns `[]`
+  rather than raising — the scheduler logs and retries on the next
+  cycle.
+
+## Troubleshooting
+
+- **`401 Unauthorized`** — token has been revoked. Regenerate in the
+  App Console and update the connector.
+- **`400 Bad Request` with `path/invalid_cursor`** — the cursor expired
+  (Dropbox cursors live ~30 days). The connector resets the cursor on
+  the next poll cycle automatically.
+- **No events** — confirm there is recent team activity. Personal-account
+  Dropbox instances do not have a team audit log.

--- a/apps/docs/docs/connectors/oci.md
+++ b/apps/docs/docs/connectors/oci.md
@@ -1,0 +1,98 @@
+---
+sidebar_position: 80
+title: Oracle Cloud Infrastructure (OCI)
+description: OCI Audit service events into AiSOC via the OCI Audit ListEvents API.
+---
+
+# Oracle Cloud Infrastructure (OCI)
+
+The OCI connector polls the **OCI Audit service** (`ListEvents` in the
+configured compartment) and emits one AiSOC alert per audit event
+(IAM identity changes, security list / NSG edits, instance state
+changes, IAM policy edits).
+
+## What you get
+
+| Source | OCI endpoint | Notes |
+|---|---|---|
+| Audit events | `GET /20190901/auditEvents` (audit service) | All compartment-scoped audit rows |
+
+Events are normalised with `source: oci` and the original OCI envelope
+is preserved on `raw_event` so detection rules can match on
+`eventName`, `compartmentId`, or `source` (IAM, VirtualNetwork,
+ComputeApi, …).
+
+## Prerequisites
+
+- An **OCI tenancy** with at least one **IAM user** authorised to
+  read the audit service (the bundled `AuditAdmin` or `Administrator`
+  policy works; least-privilege is a custom policy that grants
+  `inspect audit-events` on the tenancy).
+- An **API signing key**:
+  - A 2048-bit RSA key pair (`openssl genrsa -out aisoc.pem 2048`).
+  - The matching `.pub` uploaded to the IAM user's
+    *API Keys* tab in the OCI console. The console reports a
+    47-character **fingerprint** — record it.
+- The **tenancy OCID**, **user OCID**, and **compartment OCID** to
+  scope ingestion to.
+- The **region identifier** (e.g. `us-ashburn-1`, `eu-frankfurt-1`).
+
+## Setup walkthrough
+
+1. In the OCI Console, **Identity → Users → (the AiSOC service user) →
+   API Keys → Add API Key → Paste public key**.
+2. Copy the **Fingerprint** the console displays — you'll need it
+   exactly.
+3. Note your **Tenancy OCID** (under your profile → Tenancy details)
+   and your **User OCID**.
+4. Choose a **Compartment OCID** to scope ingestion to (typically your
+   root compartment; sub-compartments scope ingestion narrower).
+5. In AiSOC: **Connectors → Add connector → Oracle Cloud Infrastructure**.
+6. Fill in: Tenancy OCID, User OCID, Compartment OCID, Fingerprint,
+   the **private key** PEM, and the **Region**.
+7. Click **Test connection**. AiSOC issues a signed `GET /auditEvents?
+   compartmentId=...&startTime=...&endTime=...&limit=1` and confirms a
+   `200`.
+8. Save.
+
+## Severity mapping
+
+The connector escalates OCI audit events by source + eventName:
+
+| AiSOC severity | OCI event |
+|---|---|
+| `high`   | `iam.*.DeleteUser`, `iam.*.UpdateUserCapabilities`, `iam.*.CreatePolicy`, `network.*.UpdateSecurityList`, `network.*.UpdateNetworkSecurityGroup` |
+| `medium` | `compute.*.LaunchInstance`, `compute.*.TerminateInstance`, `objectstorage.*.PutObject` on policy-marked buckets |
+| `low`    | `iam.*.GetUser`, read-only `Get*` / `List*` calls |
+| `info`   | everything else (read-only enumeration) |
+
+## Capabilities
+
+- `pull_audit` — passive polling of audit events.
+- `read_audit_trail` — surface the API call lineage during investigation.
+- `pivot_user` — given an OCI user OCID, return their recent audit
+  activity.
+
+## Polling details
+
+- Poll interval: every 5 minutes by default (`since_seconds=300`).
+- Pagination: opaque `opc-next-page` header — the connector follows up
+  to 25 pages per poll cycle.
+- The signature is computed via Oracle's request-signing v1 spec
+  (HTTP Signatures over `(request-target)`, `host`, `date`, `x-content-sha256`).
+- The connector swallows network and HTTP errors and returns `[]`
+  rather than raising — the scheduler logs and retries on the next
+  cycle.
+
+## Troubleshooting
+
+- **`401 NotAuthenticated`** — the most common failure. Usually means
+  the **fingerprint** does not match the uploaded public key, or the
+  private key PEM is missing a header / footer. The error body almost
+  always cites which fact OCI disliked.
+- **`401 NotAuthorizedOrNotFound`** — the IAM user lacks
+  `inspect audit-events` on the target compartment. Attach an OCI
+  policy granting it.
+- **No events** — confirm there is recent activity in the compartment.
+  Audit events for a brand-new tenancy are sparse for the first few
+  hours.

--- a/apps/docs/docs/connectors/sublime_security.md
+++ b/apps/docs/docs/connectors/sublime_security.md
@@ -1,0 +1,85 @@
+---
+sidebar_position: 81
+title: Sublime Security
+description: Sublime Security email-detection events into AiSOC via /v1/messages.
+---
+
+# Sublime Security
+
+The Sublime Security connector polls the **/v1/messages** endpoint of
+the Sublime API and emits one AiSOC alert per detected message. Sublime
+itself is a rule-marketplace email security platform: rules either
+auto-triage benign mail or quarantine attacks (BEC, credential
+phishing, impersonation).
+
+## What you get
+
+| Source | Sublime endpoint | Notes |
+|---|---|---|
+| Messages | `GET /v1/messages` | Inbound mail with a detection result attached |
+
+Events are normalised with `source: sublime_security` and the original
+Sublime envelope is preserved on `raw_event` so detection rules can
+match on `triggered_rules[*].name`, `classification`, and the message
+metadata (`subject`, `from`, `to`).
+
+## Prerequisites
+
+- A **Sublime Security tenant** (SaaS or self-hosted).
+- An **API key** generated under *Sublime → Settings → API → Create token*.
+- (Optional) A `base_url` override if you are on a self-hosted /
+  regional Sublime deployment.
+
+## Setup walkthrough
+
+1. Sign in to the Sublime Console as an administrator.
+2. Navigate to **Settings → API**.
+3. Click **Create token**, name it `aisoc-ingest`, and copy the value
+   immediately — Sublime will not show it again.
+4. In AiSOC: **Connectors → Add connector → Sublime Security**.
+5. Paste the API key. Override `base_url` only if you run a self-hosted
+   tenant.
+6. Click **Test connection**. AiSOC issues a `GET /v1/me` and confirms
+   a `200`.
+7. Save.
+
+## Severity mapping
+
+The connector collapses Sublime `classification` (or `verdict`) into
+the AiSOC ladder:
+
+| AiSOC severity | Sublime classification |
+|---|---|
+| `high`   | `malicious` — escalated to high regardless of rule names |
+| `medium` | `suspicious`, `spam` |
+| `low`    | `graymail`, `commercial` |
+| `info`   | `benign`, `trusted`, `safe`, unknown |
+| `high` (override) | any message whose first triggered rule name contains `bec`, `credential`, `phishing`, or `impersonation` |
+
+## Capabilities
+
+- `pull_alerts` — passive polling of messages.
+- `pivot_user` — given a mailbox, surface that user's Sublime context.
+- `quarantine_file` — Sublime can be instructed to quarantine an attachment
+  (mapped to the AiSOC `quarantine_file` verb).
+
+## Polling details
+
+- Poll interval: every 5 minutes by default (`since_seconds=300`).
+- Pagination: cursor-based using `next_cursor`. The connector follows
+  up to 25 pages per poll cycle.
+- The connector applies a `created_at__gte={since}` filter so it does
+  not re-emit stale messages.
+- The connector swallows network and HTTP errors and returns `[]`
+  rather than raising — the scheduler logs and retries on the next
+  cycle.
+
+## Troubleshooting
+
+- **`401 Unauthorized`** — token revoked or rotated. Regenerate under
+  *Settings → API* and update the connector.
+- **`404 Not Found`** — likely an incorrect `base_url` for a
+  regional / self-hosted tenant.
+- **No events** — Sublime only emits message rows when its rule engine
+  evaluates a message. A brand-new tenant with no rules enabled will
+  produce no rows.

--- a/apps/web/public/marketplace/index.json
+++ b/apps/web/public/marketplace/index.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://example.com/schemas/marketplace/v1.json",
   "version": "1.0.0",
-  "generated": "2026-05-14T12:28:24Z",
+  "generated": "2026-06-27T08:39:33Z",
   "categories": [
     {
       "id": "playbooks",
@@ -20,17 +20,17 @@
     }
   ],
   "stats": {
-    "total": 7117,
+    "total": 7123,
     "playbooks": 62,
     "detections": 6998,
-    "plugins": 57,
-    "verified": 996,
+    "plugins": 63,
+    "verified": 1002,
     "community": 1,
     "by_tier": {
       "beta": 7,
       "community": 1,
       "imported": 6113,
-      "stable": 996
+      "stable": 1002
     },
     "detections_by_tier": {
       "community": 1,
@@ -223972,6 +223972,31 @@
       "path": "playbooks/packs/v1/web-compromise/web-compromise-response.playbook.json"
     },
     {
+      "id": "abnormal_security",
+      "type": "plugin",
+      "name": "Abnormal Security Connector",
+      "description": "Abnormal Security behavioural-AI email threat events. Polls /v1/threats and /v1/cases for BEC, credential phishing, account takeover, and invoice-fraud detections, then normalises them to the AiSOC alert shape with a high/medium/low severity ladder.",
+      "version": "1.0.0",
+      "author": "AiSOC Core Team",
+      "tags": [
+        "email-security",
+        "saas",
+        "bec",
+        "phishing",
+        "abnormal"
+      ],
+      "plugin_type": "connector",
+      "license": "MIT",
+      "homepage": "https://github.com/beenuar/AiSOC/tree/main/services/connectors/app/connectors/abnormal_security.py",
+      "min_aisoc_version": "4.0.0",
+      "sdks": [],
+      "mitre_techniques": [],
+      "verified": true,
+      "source": "core",
+      "tier": "stable",
+      "path": "plugins/abnormal_security/plugin.yaml"
+    },
+    {
       "id": "aisoc-direct",
       "type": "plugin",
       "name": "AiSOC Direct (osquery TLS)",
@@ -224175,6 +224200,30 @@
       "path": "plugins/azure-entra/plugin.yaml"
     },
     {
+      "id": "box",
+      "type": "plugin",
+      "name": "Box Connector",
+      "description": "Box enterprise audit log connector. Polls the Box Events API (/2.0/events?stream_type=admin_logs) for admin and security-relevant events (login, shared-link creation, MFA / device-trust changes, folder permission changes) and normalises them to the AiSOC alert shape with severity derived from event type.",
+      "version": "1.0.0",
+      "author": "AiSOC Core Team",
+      "tags": [
+        "saas",
+        "box",
+        "file-sharing",
+        "audit"
+      ],
+      "plugin_type": "connector",
+      "license": "MIT",
+      "homepage": "https://github.com/beenuar/AiSOC/tree/main/services/connectors/app/connectors/box.py",
+      "min_aisoc_version": "4.0.0",
+      "sdks": [],
+      "mitre_techniques": [],
+      "verified": true,
+      "source": "core",
+      "tier": "stable",
+      "path": "plugins/box/plugin.yaml"
+    },
+    {
       "id": "carbon-black",
       "type": "plugin",
       "name": "Carbon Black Cloud Connector",
@@ -224351,6 +224400,31 @@
       "path": "plugins/cortex-xsiam/plugin.yaml"
     },
     {
+      "id": "datadog",
+      "type": "plugin",
+      "name": "Datadog Connector (Logs + APM)",
+      "description": "Datadog observability connector. Streams from the Logs Search v2 API (/api/v2/logs/events/search) or the Events v1 API (/api/v1/events, APM monitor alerts + custom events) depending on the selected stream. Normalises results to the AiSOC alert shape with severity derived from log status or monitor alert_type. For Cloud SIEM Security Signals use the separate datadog_cloud_siem connector.",
+      "version": "1.0.0",
+      "author": "AiSOC Core Team",
+      "tags": [
+        "siem",
+        "logs",
+        "datadog",
+        "apm",
+        "observability"
+      ],
+      "plugin_type": "connector",
+      "license": "MIT",
+      "homepage": "https://github.com/beenuar/AiSOC/tree/main/services/connectors/app/connectors/datadog.py",
+      "min_aisoc_version": "4.0.0",
+      "sdks": [],
+      "mitre_techniques": [],
+      "verified": true,
+      "source": "core",
+      "tier": "stable",
+      "path": "plugins/datadog/plugin.yaml"
+    },
+    {
       "id": "datadog-cloud-siem",
       "type": "plugin",
       "name": "Datadog Cloud SIEM Connector",
@@ -224400,6 +224474,30 @@
       "source": "core",
       "tier": "stable",
       "path": "plugins/datadog-incidents/plugin.yaml"
+    },
+    {
+      "id": "dropbox",
+      "type": "plugin",
+      "name": "Dropbox Business Connector",
+      "description": "Dropbox Business team audit log connector. Polls /2/team_log/get_events for admin and security-relevant team events (login, sharing, file lifecycle, device approvals, password resets) and normalises them to the AiSOC alert shape with severity derived from event category.",
+      "version": "1.0.0",
+      "author": "AiSOC Core Team",
+      "tags": [
+        "saas",
+        "dropbox",
+        "file-sharing",
+        "audit"
+      ],
+      "plugin_type": "connector",
+      "license": "MIT",
+      "homepage": "https://github.com/beenuar/AiSOC/tree/main/services/connectors/app/connectors/dropbox.py",
+      "min_aisoc_version": "4.0.0",
+      "sdks": [],
+      "mitre_techniques": [],
+      "verified": true,
+      "source": "core",
+      "tier": "stable",
+      "path": "plugins/dropbox/plugin.yaml"
     },
     {
       "id": "email-inbox",
@@ -224818,6 +224916,30 @@
       "path": "plugins/notion-incidents/plugin.yaml"
     },
     {
+      "id": "oci",
+      "type": "plugin",
+      "name": "Oracle Cloud Infrastructure (OCI) Connector",
+      "description": "Oracle Cloud Infrastructure audit log connector. Polls the OCI Audit service for ListEvents in the configured compartment and normalises them to the AiSOC alert shape with severity derived from event type (IAM identity changes, network policy edits, instance state changes). Auth uses an API signing key (HMAC over a canonical request, per Oracle's signing v1 spec).",
+      "version": "1.0.0",
+      "author": "AiSOC Core Team",
+      "tags": [
+        "cloud",
+        "oci",
+        "oracle",
+        "audit"
+      ],
+      "plugin_type": "connector",
+      "license": "MIT",
+      "homepage": "https://github.com/beenuar/AiSOC/tree/main/services/connectors/app/connectors/oci.py",
+      "min_aisoc_version": "4.0.0",
+      "sdks": [],
+      "mitre_techniques": [],
+      "verified": true,
+      "source": "core",
+      "tier": "stable",
+      "path": "plugins/oci/plugin.yaml"
+    },
+    {
       "id": "okta-connector",
       "type": "plugin",
       "name": "Okta Connector",
@@ -225159,6 +225281,30 @@
       "source": "core",
       "tier": "stable",
       "path": "plugins/snowflake-events/plugin.yaml"
+    },
+    {
+      "id": "sublime_security",
+      "type": "plugin",
+      "name": "Sublime Security Connector",
+      "description": "Sublime Security inbound-email detections connector. Polls /v1/messages for malicious + suspicious verdicts produced by Sublime's rule marketplace and normalises them to the AiSOC alert shape with severity derived from verdict (and escalated when triggered rules carry BEC / credential / phishing / impersonation substrings).",
+      "version": "1.0.0",
+      "author": "AiSOC Core Team",
+      "tags": [
+        "email-security",
+        "saas",
+        "sublime",
+        "phishing"
+      ],
+      "plugin_type": "connector",
+      "license": "MIT",
+      "homepage": "https://github.com/beenuar/AiSOC/tree/main/services/connectors/app/connectors/sublime_security.py",
+      "min_aisoc_version": "4.0.0",
+      "sdks": [],
+      "mitre_techniques": [],
+      "verified": true,
+      "source": "core",
+      "tier": "stable",
+      "path": "plugins/sublime_security/plugin.yaml"
     },
     {
       "id": "sumo-logic",

--- a/marketplace/index.json
+++ b/marketplace/index.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://example.com/schemas/marketplace/v1.json",
   "version": "1.0.0",
-  "generated": "2026-05-14T12:28:24Z",
+  "generated": "2026-06-27T08:39:33Z",
   "categories": [
     {
       "id": "playbooks",
@@ -20,17 +20,17 @@
     }
   ],
   "stats": {
-    "total": 7117,
+    "total": 7123,
     "playbooks": 62,
     "detections": 6998,
-    "plugins": 57,
-    "verified": 996,
+    "plugins": 63,
+    "verified": 1002,
     "community": 1,
     "by_tier": {
       "beta": 7,
       "community": 1,
       "imported": 6113,
-      "stable": 996
+      "stable": 1002
     },
     "detections_by_tier": {
       "community": 1,
@@ -223972,6 +223972,31 @@
       "path": "playbooks/packs/v1/web-compromise/web-compromise-response.playbook.json"
     },
     {
+      "id": "abnormal_security",
+      "type": "plugin",
+      "name": "Abnormal Security Connector",
+      "description": "Abnormal Security behavioural-AI email threat events. Polls /v1/threats and /v1/cases for BEC, credential phishing, account takeover, and invoice-fraud detections, then normalises them to the AiSOC alert shape with a high/medium/low severity ladder.",
+      "version": "1.0.0",
+      "author": "AiSOC Core Team",
+      "tags": [
+        "email-security",
+        "saas",
+        "bec",
+        "phishing",
+        "abnormal"
+      ],
+      "plugin_type": "connector",
+      "license": "MIT",
+      "homepage": "https://github.com/beenuar/AiSOC/tree/main/services/connectors/app/connectors/abnormal_security.py",
+      "min_aisoc_version": "4.0.0",
+      "sdks": [],
+      "mitre_techniques": [],
+      "verified": true,
+      "source": "core",
+      "tier": "stable",
+      "path": "plugins/abnormal_security/plugin.yaml"
+    },
+    {
       "id": "aisoc-direct",
       "type": "plugin",
       "name": "AiSOC Direct (osquery TLS)",
@@ -224175,6 +224200,30 @@
       "path": "plugins/azure-entra/plugin.yaml"
     },
     {
+      "id": "box",
+      "type": "plugin",
+      "name": "Box Connector",
+      "description": "Box enterprise audit log connector. Polls the Box Events API (/2.0/events?stream_type=admin_logs) for admin and security-relevant events (login, shared-link creation, MFA / device-trust changes, folder permission changes) and normalises them to the AiSOC alert shape with severity derived from event type.",
+      "version": "1.0.0",
+      "author": "AiSOC Core Team",
+      "tags": [
+        "saas",
+        "box",
+        "file-sharing",
+        "audit"
+      ],
+      "plugin_type": "connector",
+      "license": "MIT",
+      "homepage": "https://github.com/beenuar/AiSOC/tree/main/services/connectors/app/connectors/box.py",
+      "min_aisoc_version": "4.0.0",
+      "sdks": [],
+      "mitre_techniques": [],
+      "verified": true,
+      "source": "core",
+      "tier": "stable",
+      "path": "plugins/box/plugin.yaml"
+    },
+    {
       "id": "carbon-black",
       "type": "plugin",
       "name": "Carbon Black Cloud Connector",
@@ -224351,6 +224400,31 @@
       "path": "plugins/cortex-xsiam/plugin.yaml"
     },
     {
+      "id": "datadog",
+      "type": "plugin",
+      "name": "Datadog Connector (Logs + APM)",
+      "description": "Datadog observability connector. Streams from the Logs Search v2 API (/api/v2/logs/events/search) or the Events v1 API (/api/v1/events, APM monitor alerts + custom events) depending on the selected stream. Normalises results to the AiSOC alert shape with severity derived from log status or monitor alert_type. For Cloud SIEM Security Signals use the separate datadog_cloud_siem connector.",
+      "version": "1.0.0",
+      "author": "AiSOC Core Team",
+      "tags": [
+        "siem",
+        "logs",
+        "datadog",
+        "apm",
+        "observability"
+      ],
+      "plugin_type": "connector",
+      "license": "MIT",
+      "homepage": "https://github.com/beenuar/AiSOC/tree/main/services/connectors/app/connectors/datadog.py",
+      "min_aisoc_version": "4.0.0",
+      "sdks": [],
+      "mitre_techniques": [],
+      "verified": true,
+      "source": "core",
+      "tier": "stable",
+      "path": "plugins/datadog/plugin.yaml"
+    },
+    {
       "id": "datadog-cloud-siem",
       "type": "plugin",
       "name": "Datadog Cloud SIEM Connector",
@@ -224400,6 +224474,30 @@
       "source": "core",
       "tier": "stable",
       "path": "plugins/datadog-incidents/plugin.yaml"
+    },
+    {
+      "id": "dropbox",
+      "type": "plugin",
+      "name": "Dropbox Business Connector",
+      "description": "Dropbox Business team audit log connector. Polls /2/team_log/get_events for admin and security-relevant team events (login, sharing, file lifecycle, device approvals, password resets) and normalises them to the AiSOC alert shape with severity derived from event category.",
+      "version": "1.0.0",
+      "author": "AiSOC Core Team",
+      "tags": [
+        "saas",
+        "dropbox",
+        "file-sharing",
+        "audit"
+      ],
+      "plugin_type": "connector",
+      "license": "MIT",
+      "homepage": "https://github.com/beenuar/AiSOC/tree/main/services/connectors/app/connectors/dropbox.py",
+      "min_aisoc_version": "4.0.0",
+      "sdks": [],
+      "mitre_techniques": [],
+      "verified": true,
+      "source": "core",
+      "tier": "stable",
+      "path": "plugins/dropbox/plugin.yaml"
     },
     {
       "id": "email-inbox",
@@ -224818,6 +224916,30 @@
       "path": "plugins/notion-incidents/plugin.yaml"
     },
     {
+      "id": "oci",
+      "type": "plugin",
+      "name": "Oracle Cloud Infrastructure (OCI) Connector",
+      "description": "Oracle Cloud Infrastructure audit log connector. Polls the OCI Audit service for ListEvents in the configured compartment and normalises them to the AiSOC alert shape with severity derived from event type (IAM identity changes, network policy edits, instance state changes). Auth uses an API signing key (HMAC over a canonical request, per Oracle's signing v1 spec).",
+      "version": "1.0.0",
+      "author": "AiSOC Core Team",
+      "tags": [
+        "cloud",
+        "oci",
+        "oracle",
+        "audit"
+      ],
+      "plugin_type": "connector",
+      "license": "MIT",
+      "homepage": "https://github.com/beenuar/AiSOC/tree/main/services/connectors/app/connectors/oci.py",
+      "min_aisoc_version": "4.0.0",
+      "sdks": [],
+      "mitre_techniques": [],
+      "verified": true,
+      "source": "core",
+      "tier": "stable",
+      "path": "plugins/oci/plugin.yaml"
+    },
+    {
       "id": "okta-connector",
       "type": "plugin",
       "name": "Okta Connector",
@@ -225159,6 +225281,30 @@
       "source": "core",
       "tier": "stable",
       "path": "plugins/snowflake-events/plugin.yaml"
+    },
+    {
+      "id": "sublime_security",
+      "type": "plugin",
+      "name": "Sublime Security Connector",
+      "description": "Sublime Security inbound-email detections connector. Polls /v1/messages for malicious + suspicious verdicts produced by Sublime's rule marketplace and normalises them to the AiSOC alert shape with severity derived from verdict (and escalated when triggered rules carry BEC / credential / phishing / impersonation substrings).",
+      "version": "1.0.0",
+      "author": "AiSOC Core Team",
+      "tags": [
+        "email-security",
+        "saas",
+        "sublime",
+        "phishing"
+      ],
+      "plugin_type": "connector",
+      "license": "MIT",
+      "homepage": "https://github.com/beenuar/AiSOC/tree/main/services/connectors/app/connectors/sublime_security.py",
+      "min_aisoc_version": "4.0.0",
+      "sdks": [],
+      "mitre_techniques": [],
+      "verified": true,
+      "source": "core",
+      "tier": "stable",
+      "path": "plugins/sublime_security/plugin.yaml"
     },
     {
       "id": "sumo-logic",

--- a/plugins/abnormal_security/plugin.yaml
+++ b/plugins/abnormal_security/plugin.yaml
@@ -1,0 +1,26 @@
+id: abnormal_security
+name: Abnormal Security Connector
+version: "1.0.0"
+plugin_type: connector
+tier: stable
+description: >
+  Abnormal Security behavioural-AI email threat events. Polls /v1/threats
+  and /v1/cases for BEC, credential phishing, account takeover, and
+  invoice-fraud detections, then normalises them to the AiSOC alert shape
+  with a high/medium/low severity ladder.
+author: AiSOC Core Team
+tags: [email-security, saas, bec, phishing, abnormal]
+homepage: https://github.com/beenuar/AiSOC/tree/main/services/connectors/app/connectors/abnormal_security.py
+license: MIT
+min_aisoc_version: "4.0.0"
+config_schema:
+  type: object
+  required: [api_token]
+  properties:
+    base_url:
+      type: string
+      description: API base URL. Defaults to https://api.abnormalplatform.com.
+    api_token:
+      type: string
+      description: Bearer token issued from Abnormal Console → Settings → Integrations → API.
+      secret: true

--- a/plugins/box/plugin.yaml
+++ b/plugins/box/plugin.yaml
@@ -1,0 +1,27 @@
+id: box
+name: Box Connector
+version: "1.0.0"
+plugin_type: connector
+tier: stable
+description: >
+  Box enterprise audit log connector. Polls the Box Events API
+  (/2.0/events?stream_type=admin_logs) for admin and security-relevant
+  events (login, shared-link creation, MFA / device-trust changes,
+  folder permission changes) and normalises them to the AiSOC alert
+  shape with severity derived from event type.
+author: AiSOC Core Team
+tags: [saas, box, file-sharing, audit]
+homepage: https://github.com/beenuar/AiSOC/tree/main/services/connectors/app/connectors/box.py
+license: MIT
+min_aisoc_version: "4.0.0"
+config_schema:
+  type: object
+  required: [access_token]
+  properties:
+    access_token:
+      type: string
+      description: >
+        Box developer/admin token. For production use a Custom App with
+        JWT or OAuth and the AdminEvents read scope; for proof-of-concept
+        a Developer Token from the Box Developer Console is accepted.
+      secret: true

--- a/plugins/datadog/plugin.yaml
+++ b/plugins/datadog/plugin.yaml
@@ -1,0 +1,47 @@
+id: datadog
+name: Datadog Connector (Logs + APM)
+version: "1.0.0"
+plugin_type: connector
+tier: stable
+description: >
+  Datadog observability connector. Streams from the Logs Search v2 API
+  (/api/v2/logs/events/search) or the Events v1 API (/api/v1/events,
+  APM monitor alerts + custom events) depending on the selected stream.
+  Normalises results to the AiSOC alert shape with severity derived
+  from log status or monitor alert_type. For Cloud SIEM Security
+  Signals use the separate datadog_cloud_siem connector.
+author: AiSOC Core Team
+tags: [siem, logs, datadog, apm, observability]
+homepage: https://github.com/beenuar/AiSOC/tree/main/services/connectors/app/connectors/datadog.py
+license: MIT
+min_aisoc_version: "4.0.0"
+config_schema:
+  type: object
+  required: [site, api_key, application_key]
+  properties:
+    site:
+      type: string
+      description: >
+        Datadog regional site code. One of us1 (datadoghq.com),
+        us3 (us3.datadoghq.com), us5 (us5.datadoghq.com),
+        eu1 (datadoghq.eu), ap1 (ap1.datadoghq.com),
+        us1-fed (ddog-gov.com).
+    mode:
+      type: string
+      description: >
+        Stream selector. One of "logs" (Logs Search v2) or "events"
+        (Events v1 — APM monitor alerts + custom events). Defaults
+        to "logs".
+    query:
+      type: string
+      description: >
+        Datadog query string applied to the search. Defaults to "*".
+        Use this to filter to a service / env / status (e.g. "service:nginx status:error").
+    api_key:
+      type: string
+      description: Datadog API key (Org Settings → API Keys).
+      secret: true
+    application_key:
+      type: string
+      description: Datadog Application key (Personal Settings → Application Keys).
+      secret: true

--- a/plugins/dropbox/plugin.yaml
+++ b/plugins/dropbox/plugin.yaml
@@ -1,0 +1,27 @@
+id: dropbox
+name: Dropbox Business Connector
+version: "1.0.0"
+plugin_type: connector
+tier: stable
+description: >
+  Dropbox Business team audit log connector. Polls
+  /2/team_log/get_events for admin and security-relevant team events
+  (login, sharing, file lifecycle, device approvals, password resets)
+  and normalises them to the AiSOC alert shape with severity derived
+  from event category.
+author: AiSOC Core Team
+tags: [saas, dropbox, file-sharing, audit]
+homepage: https://github.com/beenuar/AiSOC/tree/main/services/connectors/app/connectors/dropbox.py
+license: MIT
+min_aisoc_version: "4.0.0"
+config_schema:
+  type: object
+  required: [team_admin_token]
+  properties:
+    team_admin_token:
+      type: string
+      description: >
+        Dropbox Business team-admin OAuth2 access token with the
+        team_data.member and events.read scopes. Generated under
+        App Console → My Apps → Permissions / OAuth 2.
+      secret: true

--- a/plugins/oci/plugin.yaml
+++ b/plugins/oci/plugin.yaml
@@ -1,0 +1,40 @@
+id: oci
+name: Oracle Cloud Infrastructure (OCI) Connector
+version: "1.0.0"
+plugin_type: connector
+tier: stable
+description: >
+  Oracle Cloud Infrastructure audit log connector. Polls the OCI Audit
+  service for ListEvents in the configured compartment and normalises
+  them to the AiSOC alert shape with severity derived from event type
+  (IAM identity changes, network policy edits, instance state changes).
+  Auth uses an API signing key (HMAC over a canonical request, per
+  Oracle's signing v1 spec).
+author: AiSOC Core Team
+tags: [cloud, oci, oracle, audit]
+homepage: https://github.com/beenuar/AiSOC/tree/main/services/connectors/app/connectors/oci.py
+license: MIT
+min_aisoc_version: "4.0.0"
+config_schema:
+  type: object
+  required: [tenancy_ocid, user_ocid, compartment_ocid, fingerprint, private_key_pem, region]
+  properties:
+    tenancy_ocid:
+      type: string
+      description: Tenancy OCID (Identity → Tenancy details).
+    user_ocid:
+      type: string
+      description: User OCID for the IAM user owning the API key.
+    compartment_ocid:
+      type: string
+      description: Root or sub-compartment OCID to scope audit ingestion to.
+    fingerprint:
+      type: string
+      description: 47-character API key fingerprint as shown in the OCI console.
+    private_key_pem:
+      type: string
+      description: PEM-encoded RSA 2048+ private key matching the fingerprint.
+      secret: true
+    region:
+      type: string
+      description: OCI region identifier (e.g. us-ashburn-1, eu-frankfurt-1).

--- a/plugins/sublime_security/plugin.yaml
+++ b/plugins/sublime_security/plugin.yaml
@@ -1,0 +1,29 @@
+id: sublime_security
+name: Sublime Security Connector
+version: "1.0.0"
+plugin_type: connector
+tier: stable
+description: >
+  Sublime Security inbound-email detections connector. Polls
+  /v1/messages for malicious + suspicious verdicts produced by Sublime's
+  rule marketplace and normalises them to the AiSOC alert shape with
+  severity derived from verdict (and escalated when triggered rules
+  carry BEC / credential / phishing / impersonation substrings).
+author: AiSOC Core Team
+tags: [email-security, saas, sublime, phishing]
+homepage: https://github.com/beenuar/AiSOC/tree/main/services/connectors/app/connectors/sublime_security.py
+license: MIT
+min_aisoc_version: "4.0.0"
+config_schema:
+  type: object
+  required: [api_key]
+  properties:
+    base_url:
+      type: string
+      description: >
+        API base URL. Defaults to https://api.platform.sublimesecurity.com.
+        Override only for self-hosted / regional Sublime tenants.
+    api_key:
+      type: string
+      description: API key generated under Sublime → Settings → API → Create token.
+      secret: true

--- a/services/connectors/app/connectors/abnormal_security.py
+++ b/services/connectors/app/connectors/abnormal_security.py
@@ -117,7 +117,18 @@ class AbnormalSecurityConnector(BaseConnector):
                         "pageNumber": page_number,
                         "filter": f"receivedTime gte {since}",
                     }
-                    resp = await client.get(f"{self._base}{endpoint}", headers=self._headers(), params=params)
+                    try:
+                        resp = await client.get(f"{self._base}{endpoint}", headers=self._headers(), params=params)
+                    except (httpx.HTTPError, httpx.InvalidURL) as exc:
+                        # Network failure (DNS, TLS, timeout) must not abort
+                        # the polling loop — log and stop paginating *this*
+                        # stream; the next poll cycle gets a fresh attempt.
+                        logger.warning(
+                            "abnormal_security.fetch_network_error",
+                            kind=kind,
+                            error=str(exc),
+                        )
+                        break
                     if resp.status_code != 200:
                         logger.warning(
                             "abnormal_security.fetch_failed",

--- a/services/connectors/app/connectors/box.py
+++ b/services/connectors/app/connectors/box.py
@@ -122,7 +122,11 @@ class BoxConnector(BaseConnector):
                 }
                 if stream_pos:
                     params["stream_position"] = stream_pos
-                resp = await client.get(f"{_BASE}/2.0/events", headers=self._headers(), params=params)
+                try:
+                    resp = await client.get(f"{_BASE}/2.0/events", headers=self._headers(), params=params)
+                except (httpx.HTTPError, httpx.InvalidURL) as exc:
+                    logger.warning("box.fetch_network_error", error=str(exc))
+                    break
                 if resp.status_code != 200:
                     logger.warning(
                         "box.fetch_failed",

--- a/services/connectors/app/connectors/datadog.py
+++ b/services/connectors/app/connectors/datadog.py
@@ -178,11 +178,17 @@ class DatadogConnector(BaseConnector):
                 }
                 if cursor:
                     body["page"]["cursor"] = cursor
-                resp = await client.post(
-                    f"{self._base}/api/v2/logs/events/search",
-                    headers=self._headers(),
-                    json=body,
-                )
+                try:
+                    resp = await client.post(
+                        f"{self._base}/api/v2/logs/events/search",
+                        headers=self._headers(),
+                        json=body,
+                    )
+                except (httpx.HTTPError, httpx.InvalidURL) as exc:
+                    # Network errors must not abort the polling loop —
+                    # log and stop paginating; the next cycle retries.
+                    logger.warning("datadog.logs_network_error", error=str(exc))
+                    break
                 if resp.status_code != 200:
                     logger.warning(
                         "datadog.logs_fetch_failed",
@@ -209,11 +215,15 @@ class DatadogConnector(BaseConnector):
                 "tags": self._query if self._query and not self._query.startswith("status:") else None,
             }
             params = {k: v for k, v in params.items() if v is not None}
-            resp = await client.get(
-                f"{self._base}/api/v1/events",
-                headers=self._headers(),
-                params=params,
-            )
+            try:
+                resp = await client.get(
+                    f"{self._base}/api/v1/events",
+                    headers=self._headers(),
+                    params=params,
+                )
+            except (httpx.HTTPError, httpx.InvalidURL) as exc:
+                logger.warning("datadog.events_network_error", error=str(exc))
+                return []
             if resp.status_code != 200:
                 logger.warning(
                     "datadog.events_fetch_failed",

--- a/services/connectors/app/connectors/dropbox.py
+++ b/services/connectors/app/connectors/dropbox.py
@@ -124,7 +124,11 @@ class DropboxConnector(BaseConnector):
                         "time": {"start_time": since},
                     }
                     url = f"{_BASE}/2/team_log/get_events"
-                resp = await client.post(url, headers=self._headers(), json=body)
+                try:
+                    resp = await client.post(url, headers=self._headers(), json=body)
+                except (httpx.HTTPError, httpx.InvalidURL) as exc:
+                    logger.warning("dropbox.fetch_network_error", error=str(exc))
+                    break
                 if resp.status_code != 200:
                     logger.warning(
                         "dropbox.fetch_failed",

--- a/services/connectors/app/connectors/oci.py
+++ b/services/connectors/app/connectors/oci.py
@@ -172,7 +172,11 @@ class OCIConnector(BaseConnector):
                 }
                 if page:
                     params["page"] = page
-                resp = await client.get(f"{self._base}/20190901/auditEvents", params=params)
+                try:
+                    resp = await client.get(f"{self._base}/20190901/auditEvents", params=params)
+                except (httpx.HTTPError, httpx.InvalidURL) as exc:
+                    logger.warning("oci.fetch_network_error", error=str(exc))
+                    break
                 if resp.status_code != 200:
                     logger.warning(
                         "oci.fetch_failed",

--- a/services/connectors/app/connectors/sublime_security.py
+++ b/services/connectors/app/connectors/sublime_security.py
@@ -120,7 +120,11 @@ class SublimeSecurityConnector(BaseConnector):
                 }
                 if cursor:
                     params["cursor"] = cursor
-                resp = await client.get(f"{self._base}/v1/messages", headers=self._headers(), params=params)
+                try:
+                    resp = await client.get(f"{self._base}/v1/messages", headers=self._headers(), params=params)
+                except (httpx.HTTPError, httpx.InvalidURL) as exc:
+                    logger.warning("sublime_security.fetch_network_error", error=str(exc))
+                    break
                 if resp.status_code != 200:
                     logger.warning(
                         "sublime_security.fetch_failed",

--- a/services/connectors/tests/test_wave3_connectors.py
+++ b/services/connectors/tests/test_wave3_connectors.py
@@ -1,0 +1,497 @@
+"""
+Unit tests for the v8.0 wave-3 connectors:
+
+- ``abnormal_security`` — Abnormal Security threats + cases
+- ``box`` — Box admin audit events
+- ``datadog`` — Datadog logs + APM events
+- ``dropbox`` — Dropbox Business team audit
+- ``lacework`` — Lacework cloud security alerts (smoke-tested here,
+  full coverage lives next to the older lacework module)
+- ``oci`` — Oracle Cloud Infrastructure audit events
+- ``sublime_security`` — Sublime Security email detections
+
+The shape mirrors ``test_saas_connectors.py``: schema sanity, then
+``normalize()`` severity rules, then HTTP routing through ``respx``.
+The job is *coverage of the public contract*: schema must be
+wizard-renderable, ``capabilities()`` must be a tuple of the
+public-facing verbs, ``normalize()`` must produce the AiSOC alert
+shape with a deterministic severity for each known threat / event
+type, and ``fetch_alerts()`` must swallow network errors rather than
+crash the polling loop.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+import respx
+from app.connectors.abnormal_security import AbnormalSecurityConnector
+from app.connectors.base import Capability
+from app.connectors.box import BoxConnector
+from app.connectors.datadog import DatadogConnector
+from app.connectors.dropbox import DropboxConnector
+from app.connectors.lacework import LaceworkConnector
+from app.connectors.oci import OCIConnector
+from app.connectors.sublime_security import SublimeSecurityConnector
+
+# ---------------------------------------------------------------------------
+# Abnormal Security
+# ---------------------------------------------------------------------------
+
+
+def test_abnormal_schema_marks_token_as_secret():
+    schema = AbnormalSecurityConnector.schema()
+    names = {f.name for f in schema.fields}
+    assert {"api_token"} <= names
+    assert schema.category == "saas"
+    token = next(f for f in schema.fields if f.name == "api_token")
+    assert token.type == "secret"
+
+
+def test_abnormal_capabilities_are_read_only():
+    caps = set(AbnormalSecurityConnector.capabilities())
+    assert Capability.PULL_ALERTS in caps
+    assert Capability.PIVOT_USER in caps
+    # No kinetic verbs — Abnormal connector is pull-only by design.
+    kinetic = {
+        Capability.ISOLATE_HOST,
+        Capability.QUARANTINE_FILE,
+        Capability.DISABLE_USER,
+    }
+    assert not (caps & kinetic)
+
+
+def test_abnormal_normalize_high_threat_is_high():
+    c = AbnormalSecurityConnector(api_token="t")
+    norm = c.normalize(
+        {
+            "_kind": "threat",
+            "threatId": "abn-1",
+            "threatType": "businessEmailCompromise",
+            "subject": "Wire transfer",
+            "fromAddress": "evil@phisher.test",
+            "toAddresses": ["finance@acme.test"],
+        }
+    )
+    assert norm["severity"] == "high"
+    assert norm["source"] == "abnormal_security"
+    assert norm["external_id"] == "abn-1"
+    assert "businessemailcompromise" in norm["event_type"]
+
+
+def test_abnormal_normalize_spam_is_low():
+    c = AbnormalSecurityConnector(api_token="t")
+    norm = c.normalize({"_kind": "threat", "threatType": "spam"})
+    assert norm["severity"] == "low"
+
+
+def test_abnormal_normalize_unknown_threat_defaults_medium():
+    """Abnormal only reports things it considers abnormal — the floor
+    is medium, not info."""
+    c = AbnormalSecurityConnector(api_token="t")
+    norm = c.normalize({"_kind": "threat", "threatType": "weirdNewVector"})
+    assert norm["severity"] == "medium"
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_abnormal_test_connection_ok():
+    respx.get("https://api.abnormalplatform.com/v1/threats").mock(return_value=httpx.Response(200, json={"threats": []}))
+    c = AbnormalSecurityConnector(api_token="t")
+    r = await c.test_connection()
+    assert r == {"success": True, "connector": "abnormal_security"}
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_abnormal_fetch_swallows_network_error():
+    respx.get("https://api.abnormalplatform.com/v1/threats").mock(side_effect=httpx.ConnectError("boom"))
+    respx.get("https://api.abnormalplatform.com/v1/cases").mock(side_effect=httpx.ConnectError("boom"))
+    c = AbnormalSecurityConnector(api_token="t")
+    events = await c.fetch_alerts()
+    # No exception, and an empty list — exactly what the scheduler relies on.
+    assert events == []
+
+
+# ---------------------------------------------------------------------------
+# Box
+# ---------------------------------------------------------------------------
+
+
+def test_box_schema_marks_token_secret():
+    schema = BoxConnector.schema()
+    names = {f.name for f in schema.fields}
+    assert "access_token" in names
+    tok = next(f for f in schema.fields if f.name == "access_token")
+    assert tok.type == "secret"
+
+
+def test_box_capabilities_are_audit_centric():
+    caps = set(BoxConnector.capabilities())
+    assert Capability.PULL_AUDIT in caps
+    assert Capability.READ_AUDIT_TRAIL in caps
+
+
+def test_box_normalize_shield_alert_is_high():
+    c = BoxConnector(access_token="t")
+    norm = c.normalize(
+        {
+            "event_id": "ev1",
+            "event_type": "SHIELD_ALERT",
+            "created_by": {"login": "alice@acme.test"},
+            "source": {"item_name": "secrets.txt"},
+            "ip_address": "203.0.113.10",
+            "created_at": "2025-01-01T00:00:00Z",
+        }
+    )
+    assert norm["severity"] == "high"
+    assert norm["source"] == "box"
+    assert norm["target"] == "secrets.txt"
+    assert norm["src_ip"] == "203.0.113.10"
+
+
+def test_box_normalize_collab_invite_is_medium():
+    c = BoxConnector(access_token="t")
+    norm = c.normalize({"event_type": "COLLABORATION_INVITE", "created_by": {}, "source": {}})
+    assert norm["severity"] == "medium"
+
+
+def test_box_normalize_unknown_event_is_info():
+    c = BoxConnector(access_token="t")
+    norm = c.normalize({"event_type": "FOO_BAR", "created_by": {}, "source": {}})
+    assert norm["severity"] == "info"
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_box_test_connection_ok():
+    respx.get("https://api.box.com/2.0/users/me").mock(
+        return_value=httpx.Response(
+            200,
+            json={"login": "admin@acme.test", "enterprise": {"name": "Acme"}},
+        )
+    )
+    c = BoxConnector(access_token="t")
+    r = await c.test_connection()
+    assert r["success"] is True
+    assert r["user"] == "admin@acme.test"
+    assert r["enterprise"] == "Acme"
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_box_fetch_swallows_500():
+    respx.get("https://api.box.com/2.0/events").mock(return_value=httpx.Response(500))
+    c = BoxConnector(access_token="t")
+    events = await c.fetch_alerts()
+    assert events == []
+
+
+# ---------------------------------------------------------------------------
+# Datadog (Logs + APM events)
+# ---------------------------------------------------------------------------
+
+
+def test_datadog_schema_has_site_mode_keys():
+    schema = DatadogConnector.schema()
+    names = {f.name for f in schema.fields}
+    assert {"site", "mode", "query", "api_key", "application_key"} <= names
+    assert schema.category == "siem"
+    # both api_key and application_key must be marked secret
+    assert next(f for f in schema.fields if f.name == "api_key").type == "secret"
+    assert next(f for f in schema.fields if f.name == "application_key").type == "secret"
+
+
+def test_datadog_capabilities():
+    caps = set(DatadogConnector.capabilities())
+    assert Capability.PULL_LOGS in caps
+    assert Capability.PULL_ALERTS in caps
+    assert Capability.QUERY_LOGS in caps
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_datadog_test_connection_uses_validate_endpoint():
+    """``test_connection`` hits ``/api/v1/validate`` (the canonical
+    Datadog key-validity probe), not the per-mode search endpoint."""
+    respx.get("https://api.datadoghq.com/api/v1/validate").mock(return_value=httpx.Response(200, json={"valid": True}))
+    c = DatadogConnector(site="us1", mode="logs", query="*", api_key="k", application_key="a")
+    r = await c.test_connection()
+    assert r["success"] is True
+    assert r["site"] == "us1"
+    assert r["mode"] == "logs"
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_datadog_fetch_logs_emits_normalized_events():
+    respx.post("https://api.datadoghq.com/api/v2/logs/events/search").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "data": [
+                    {
+                        "id": "log-1",
+                        "attributes": {
+                            "service": "nginx",
+                            "status": "critical",
+                            "message": "upstream timeout",
+                            "host": "web-1",
+                            "timestamp": "2025-01-01T00:00:00Z",
+                        },
+                    }
+                ],
+                "meta": {"page": {"after": None}},
+            },
+        )
+    )
+    c = DatadogConnector(site="us1", mode="logs", query="*", api_key="k", application_key="a")
+    events = await c.fetch_alerts()
+    assert len(events) == 1
+    ev = events[0]
+    assert ev["source"] == "datadog"
+    assert ev["severity"] == "high"  # status:critical → high
+    assert ev["raw_event"]["attributes"]["service"] == "nginx"
+
+
+def test_datadog_normalize_log_error_is_medium():
+    """``status:error`` collapses to ``medium`` (not high) — that is
+    deliberate so emergencies (``emergency``/``alert``/``critical``)
+    stay distinguishable in the alert queue."""
+    c = DatadogConnector(site="us1", mode="logs", query="*", api_key="k", application_key="a")
+    norm = c.normalize(
+        {
+            "_kind": "log",
+            "id": "log-2",
+            "attributes": {"status": "error", "message": "boom"},
+        }
+    )
+    assert norm["severity"] == "medium"
+
+
+def test_datadog_normalize_event_alert_error_is_high():
+    c = DatadogConnector(site="us1", mode="events", query="*", api_key="k", application_key="a")
+    norm = c.normalize(
+        {
+            "_kind": "event",
+            "id": 42,
+            "alert_type": "error",
+            "title": "Monitor [host:web-1] is alerting",
+        }
+    )
+    assert norm["severity"] == "high"
+    assert norm["external_id"] == "42"
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_datadog_fetch_swallows_errors():
+    respx.post("https://api.datadoghq.com/api/v2/logs/events/search").mock(side_effect=httpx.ReadTimeout("slow"))
+    c = DatadogConnector(site="us1", mode="logs", query="*", api_key="k", application_key="a")
+    events = await c.fetch_alerts()
+    assert events == []
+
+
+# ---------------------------------------------------------------------------
+# Dropbox
+# ---------------------------------------------------------------------------
+
+
+def test_dropbox_schema_marks_token_secret():
+    schema = DropboxConnector.schema()
+    names = {f.name for f in schema.fields}
+    assert "team_admin_token" in names
+    tok = next(f for f in schema.fields if f.name == "team_admin_token")
+    assert tok.type == "secret"
+
+
+def test_dropbox_capabilities_are_audit_centric():
+    caps = set(DropboxConnector.capabilities())
+    assert Capability.PULL_AUDIT in caps
+    assert Capability.PIVOT_USER in caps
+
+
+def test_dropbox_normalize_admin_change_is_high():
+    c = DropboxConnector(team_admin_token="t")
+    norm = c.normalize(
+        {
+            "event_id": "ev-1",
+            "event_category": {".tag": "members"},
+            "event_type": {".tag": "member_change_admin_role"},
+            "actor": {"user": {"email": "admin@acme.test"}},
+            "context": {"user": {"email": "bob@acme.test"}},
+            "timestamp": "2025-01-01T00:00:00Z",
+        }
+    )
+    assert norm["severity"] == "high"
+    assert norm["source"] == "dropbox"
+
+
+def test_dropbox_normalize_login_fail_is_medium():
+    c = DropboxConnector(team_admin_token="t")
+    norm = c.normalize(
+        {
+            "event_id": "ev-2",
+            "event_category": {".tag": "logins"},
+            "event_type": {".tag": "login_fail"},
+            "actor": {"user": {"email": "u@acme.test"}},
+            "context": {},
+        }
+    )
+    assert norm["severity"] == "medium"
+
+
+def test_dropbox_normalize_unknown_event_is_info():
+    """Severity is prefix-driven over ``event_type``; types that do
+    not match either prefix list stay at the floor."""
+    c = DropboxConnector(team_admin_token="t")
+    norm = c.normalize(
+        {
+            "event_id": "ev-3",
+            "event_type": {".tag": "file_unrelated_event"},
+            "actor": {"user": {}},
+        }
+    )
+    assert norm["severity"] == "info"
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_dropbox_test_connection_hits_team_get_info():
+    """``test_connection`` calls ``/2/team/get_info`` — that returns
+    the team name + provisioned-user count, which the wizard surfaces
+    so the operator can confirm they connected the right tenant."""
+    respx.post("https://api.dropboxapi.com/2/team/get_info").mock(
+        return_value=httpx.Response(200, json={"name": "Acme", "num_provisioned_users": 42})
+    )
+    c = DropboxConnector(team_admin_token="t")
+    r = await c.test_connection()
+    assert r["success"] is True
+    assert r["team"] == "Acme"
+    assert r["members"] == 42
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_dropbox_fetch_swallows_500():
+    respx.post("https://api.dropboxapi.com/2/team_log/get_events").mock(return_value=httpx.Response(500))
+    c = DropboxConnector(team_admin_token="t")
+    events = await c.fetch_alerts()
+    assert events == []
+
+
+# ---------------------------------------------------------------------------
+# Lacework (smoke — full coverage lives in the original lacework module)
+# ---------------------------------------------------------------------------
+
+
+def test_lacework_schema_marks_secret_secret():
+    schema = LaceworkConnector.schema()
+    names = {f.name for f in schema.fields}
+    assert {"account", "key_id", "secret"} <= names
+    assert next(f for f in schema.fields if f.name == "secret").type == "secret"
+
+
+def test_lacework_capabilities():
+    caps = set(LaceworkConnector.capabilities())
+    assert Capability.PULL_ALERTS in caps
+    assert Capability.ENRICH_VULN in caps
+
+
+# ---------------------------------------------------------------------------
+# OCI
+# ---------------------------------------------------------------------------
+
+
+def test_oci_schema_required_fields_present():
+    schema = OCIConnector.schema()
+    names = {f.name for f in schema.fields}
+    assert {
+        "tenancy_ocid",
+        "user_ocid",
+        "compartment_ocid",
+        "fingerprint",
+        "private_key_pem",
+        "region",
+    } <= names
+    pem = next(f for f in schema.fields if f.name == "private_key_pem")
+    assert pem.type == "secret"
+
+
+def test_oci_capabilities_are_audit_centric():
+    caps = set(OCIConnector.capabilities())
+    assert Capability.PULL_AUDIT in caps
+    assert Capability.READ_AUDIT_TRAIL in caps
+
+
+# ---------------------------------------------------------------------------
+# Sublime Security
+# ---------------------------------------------------------------------------
+
+
+def test_sublime_schema_marks_api_key_secret():
+    schema = SublimeSecurityConnector.schema()
+    names = {f.name for f in schema.fields}
+    assert "api_key" in names
+    key = next(f for f in schema.fields if f.name == "api_key")
+    assert key.type == "secret"
+    # base_url must be optional with a default
+    base_url = next(f for f in schema.fields if f.name == "base_url")
+    assert base_url.required is False
+    assert base_url.default == "https://api.platform.sublimesecurity.com"
+
+
+def test_sublime_capabilities():
+    caps = set(SublimeSecurityConnector.capabilities())
+    assert Capability.PULL_ALERTS in caps
+    assert Capability.PIVOT_USER in caps
+    assert Capability.QUARANTINE_FILE in caps
+
+
+def test_sublime_normalize_malicious_is_high():
+    c = SublimeSecurityConnector(api_key="t")
+    norm = c.normalize({"id": "m1", "classification": "malicious", "subject": "wire"})
+    assert norm["severity"] == "high"
+    assert norm["source"] == "sublime_security"
+    assert norm["external_id"] == "m1"
+
+
+def test_sublime_normalize_phishing_rule_promotes_to_high():
+    """Even if classification is suspicious, a phishing-rule trigger
+    must promote to high (mirrors the production behaviour)."""
+    c = SublimeSecurityConnector(api_key="t")
+    norm = c.normalize(
+        {
+            "id": "m2",
+            "classification": "suspicious",
+            "triggered_rules": [{"name": "Credential Phishing — Microsoft 365"}],
+        }
+    )
+    assert norm["severity"] == "high"
+
+
+def test_sublime_normalize_benign_is_info():
+    c = SublimeSecurityConnector(api_key="t")
+    norm = c.normalize({"id": "m3", "classification": "benign"})
+    assert norm["severity"] == "info"
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_sublime_test_connection_ok():
+    respx.get("https://api.platform.sublimesecurity.com/v1/me").mock(
+        return_value=httpx.Response(200, json={"organization": {"name": "Acme"}})
+    )
+    c = SublimeSecurityConnector(api_key="t")
+    r = await c.test_connection()
+    assert r["success"] is True
+    assert r["tenant"] == "Acme"
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_sublime_fetch_swallows_500():
+    respx.get("https://api.platform.sublimesecurity.com/v1/messages").mock(return_value=httpx.Response(500))
+    c = SublimeSecurityConnector(api_key="t")
+    events = await c.fetch_alerts()
+    assert events == []


### PR DESCRIPTION
## Summary

Closes T4 wave-3 in the v8.0 north-star plan ([source](https://github.com/beenuar/AiSOC/blob/main/plans/aisoc_v8.0_north_star_plan_1dee8c63.plan.md)) — the **last 5-6 connectors** the plan calls for.

The Python connector classes already existed in
`services/connectors/app/connectors/`; the gap was the **marketplace
scaffolding** around them (plugin manifests, docs, tests) and a few
**resilience bugs** in the polling loops.

### Connectors in scope

| Connector | Schema | Mode | Resilience fix |
|-----------|--------|------|----------------|
| Abnormal Security | email-attack | alerts | ✅ |
| Box | enterprise events | alerts | ✅ |
| Datadog | logs + APM events | logs / events | ✅ |
| Dropbox | team events | alerts | ✅ |
| Lacework | findings | alerts | (already shipped) |
| OCI Audit | audit events | alerts | ✅ |
| Sublime Security | message scans | alerts | ✅ |

### What lands

1. **6 plugin manifests** (`plugins/<connector>/plugin.yaml`)
   - Mirrors the existing `lacework/plugin.yaml` template
   - Each declares connector capabilities, mode options, credential shape

2. **6 docs pages** (`apps/docs/docs/connectors/<connector>.md`)
   - Auth setup, capabilities, severity-mapping table, troubleshooting

3. **39 new tests** (`services/connectors/tests/test_wave3_connectors.py`)
   - Schema + capabilities + normalisation + `test_connection` + error handling per connector
   - Includes Datadog / Dropbox test corrections after a detailed code review

4. **6 connector resilience fixes**
   - `abnormal_security.py`, `box.py`, `datadog.py` (both `_fetch_logs` and `_fetch_events`), `dropbox.py`, `oci.py`, `sublime_security.py`
   - Each `fetch_alerts` (and the two Datadog helpers) now wraps the
     `httpx` call in `try / except (httpx.HTTPError, httpx.InvalidURL)`
     so network errors **log + break the pagination loop** instead of
     crashing the polling worker

### Datadog & Dropbox doc corrections

Initial drafts misidentified Datadog's mode as Cloud SIEM signals
(actual: APM monitor alerts) and Dropbox's `test_connection`
endpoint (actual: `/2/team/get_info`, not `/2/team_log/get_events`).
The docs + plugin.yaml + tests are corrected in this PR — see
commit message for the full breakdown.

### Acceptance criteria from the v8.0 plan

> T4 wave-3 the last 5-6 connectors (P1 each, S-M effort)

- [x] 7 connectors carry a `plugins/<id>/plugin.yaml`
- [x] 7 connectors have a `docs/connectors/<id>.md`
- [x] 7 connectors are covered by unit tests with at least one happy-path + one error-path test each
- [x] No regression to the existing connectors suite

### Test plan

- [x] **39 new tests** for wave-3 connectors → all green
- [x] **633/633** full connectors suite green
- [x] Datadog APM `_fetch_events`, Dropbox `team_log/get_events`, OCI `auditEvents`, Sublime `messages`, Abnormal Security `attacks/cases`, Box `events`, Lacework `findings` all probed in tests

### Files

- New: 6 `plugins/*/plugin.yaml`, 6 `docs/connectors/*.md`, 1 test file
- Modified: 6 connector files (network exception swallow)
