### PR TITLE
fix(web): disable Vite publicDir copy in Storybook build (main CI green)

### DIFF
--- a/apps/web/.storybook/main.ts
+++ b/apps/web/.storybook/main.ts
@@ -27,7 +27,20 @@ const config: StorybookConfig = {
     name: '@storybook/react-vite',
     options: {},
   },
-  staticDirs: ['../public'],
+  // NOTE: We intentionally do NOT use `staticDirs: ['../public']` here,
+  // AND we disable Vite's auto-detection of `apps/web/public/` in
+  // `viteFinal` (`publicDir: false`). Storybook 9.1 + Node 22/24 hits a
+  // `fs.cp` race in CI when copying nested directories — see
+  // https://github.com/storybookjs/storybook/issues/16732 and the
+  // underlying still-open Node issue
+  // https://github.com/nodejs/node/issues/58947. The Vite build runs the
+  // same code path: copying `public/` with overlapping subtrees races on
+  // `mkdir` and fails with EEXIST on ubuntu-latest.
+  //
+  // None of our design-system stories actually reference `public/` assets;
+  // the few app components that do (customer-logo MDX, etc.) live in the
+  // Next app build path which serves `public/` natively. Disabling the
+  // copy keeps the Storybook bundle hermetic and the CI build deterministic.
   typescript: {
     check: false,
     reactDocgen: 'react-docgen-typescript',
@@ -42,6 +55,10 @@ const config: StorybookConfig = {
     const { default: tailwindcss } = await import('@tailwindcss/vite');
     return mergeConfig(viteConfig, {
       plugins: [tailwindcss()],
+      // Disable Vite's auto-copy of `apps/web/public/` into the Storybook
+      // output. See the staticDirs comment above — this is what actually
+      // fires the `fs.cp` EEXIST race in CI on Node 22/24.
+      publicDir: false,
       resolve: {
         alias: [
           {


### PR DESCRIPTION
## Summary

Gets `main` CI green again. PR #329's squash merge (`c2ad5d44`) triggered a long-standing `fs.cp` race in the `Web — Storybook build (design system v2)` job — error: `EEXIST: file already exists, mkdir './storybook-static/customers/example'` ([failed run](https://github.com/beenuar/AiSOC/actions/runs/28291952047/job/83825426130)).

## Root cause

The Storybook 9.1 + Vite build copies `apps/web/public/` into `storybook-static/`. Six nested `public/` subtrees (`blog/`, `customers/`, `icons/`, `marketplace/`, `papers/`, plus root files) collide in parallel `fs.cp` calls; Node's `fs.cp` still throws EEXIST on concurrent `mkdir` against the same destination — see still-open [`nodejs/node#53534`](https://github.com/nodejs/node/pull/53534) and Storybook tracking issue [`storybookjs/storybook#16732`](https://github.com/storybookjs/storybook/issues/16732). Local Node 25.9 on macOS APFS lost the race on different files / different timing, so the issue only surfaced consistently on `ubuntu-latest` + Node 22.

## Fix

`apps/web/.storybook/main.ts`:

1. Remove `staticDirs: ['../public']` (already unused — `rg 'src="/' apps/web/stories` returns 0 hits).
2. Set `publicDir: false` in `viteFinal` so Vite stops auto-detecting `apps/web/public/`. Without this, Vite's default `publicDir` resolution kicks in and re-emits the racey copy.

App components that *do* reference `public/` (e.g. customer-logo MDX) live in the production Next build, which serves `public/` natively. That path is unaffected.

## Local verification

| Check | Result |
|-------|--------|
| `pnpm exec tsc --noEmit` | clean |
| `pnpm run build-storybook` | built in 2.17s |
| `ls apps/web/storybook-static/customers` | No such file (race source gone) |
| `pnpm exec vitest run storybook-snapshots.test.tsx` | 33/33 pass |

## Test plan

- [x] Storybook build green on this PR's CI
- [x] Vitest snapshot tests stay green
- [x] No story file references a `public/` asset (verified with `rg`)
