### PR TITLE
chore(dependabot): quarantine eslint family until ESLint-10 plugin support

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,7 +14,22 @@ updates:
       radix-ui:
         patterns: ["@radix-ui/*"]
       dev-tooling:
-        patterns: ["typescript", "eslint*", "@typescript-eslint/*", "tailwindcss*", "postcss*"]
+        # NOTE: `eslint*` and `@typescript-eslint/*` deliberately quarantined
+        # below — see the `dev-tooling-eslint` group. ESLint 10 changed the
+        # rule-context API in a way that `eslint-plugin-react@7.37.5`
+        # doesn't support (`TypeError: contextOrFilename.getFilename is not
+        # a function`), so the whole `eslint` family stays out of this group
+        # until `eslint-plugin-react` ships an ESLint-10-compatible release.
+        # Tracking issue: see the open `eslint-plugin-react / ESLint 10`
+        # issue in this repo.
+        patterns: ["typescript", "tailwindcss*", "postcss*"]
+      dev-tooling-eslint:
+        # Quarantined ESLint family. Dependabot still opens these PRs, but
+        # they land separately so a single incompatible plugin can't block
+        # the whole `dev-tooling` group from merging. Remove this group
+        # (and merge it back into `dev-tooling`) once
+        # `eslint-plugin-react` is ESLint-10-compatible.
+        patterns: ["eslint*", "@typescript-eslint/*"]
 
   # ── pip (api) ────────────────────────────────────────────────
   - package-ecosystem: pip


### PR DESCRIPTION
## Summary
Splits the `dev-tooling` Dependabot group so the failed ESLint 9 → 10 bump in #342 can't keep blocking unrelated dev-tooling bumps. `typescript`, `tailwindcss*`, `postcss*` stay in `dev-tooling`; `eslint*` + `@typescript-eslint/*` move to a new quarantined `dev-tooling-eslint` group.

## Why
PR #342 (the previous batched `dev-tooling` bump) failed with:

```
TypeError: Error while loading rule 'react/display-name':
contextOrFilename.getFilename is not a function
  at eslint-plugin-react/lib/util/version.js:31
```

`eslint-plugin-react@7.37.5` is the latest release on npm and is not yet compatible with the new ESLint 10 rule-context API. Until that compatibility lands upstream, keeping ESLint inside the batched group means every other dev-tool bump it groups with (typescript, tailwindcss, postcss) is held hostage to a third-party fix we don't control.

## Effect
- Dependabot will continue to open ESLint upgrade PRs; they will land separately and can be closed/rebased without holding back the rest of the dev-tooling queue.
- Once `eslint-plugin-react` ships ESLint-10 support, drop the `dev-tooling-eslint` group and merge `eslint*` / `@typescript-eslint/*` back into `dev-tooling`.

## Follow-up
- Close #342 with a redirect comment.
- Tracking issue: `eslint-plugin-react / ESLint 10 compatibility` (filed alongside this PR).

## Test plan
- [x] `dependabot.yml` parses (YAML lint).
- [x] No runtime behaviour changes; this only affects Dependabot's grouping for future PRs.

Made with [Cursor](https://cursor.com)