### PR TITLE
chore(security): fix 2 CodeQL hygiene notes, stop Scorecard from flooding code-scanning

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -15,9 +15,8 @@ jobs:
     name: Scorecard analysis
     runs-on: ubuntu-latest
     permissions:
-      # Needed to upload the results to code-scanning dashboard.
-      security-events: write
-      # Needed to publish results and get a badge (see publish_results below).
+      # Needed to publish results to the public Scorecard API (drives the
+      # README badge at https://api.securityscorecards.dev/projects/...).
       id-token: write
       contents: read
       actions: read
@@ -32,6 +31,10 @@ jobs:
         with:
           results_file: results.sarif
           results_format: sarif
+          # publish_results writes the score to the public Scorecard API so
+          # the README badge stays live. The score lives at
+          # https://securityscorecards.dev/viewer/?uri=github.com/beenuar/AiSOC
+          # and is the single source of truth for our Scorecard signal.
           publish_results: true
 
       - name: Upload artifact
@@ -41,7 +44,20 @@ jobs:
           path: results.sarif
           retention-days: 5
 
-      - name: Upload to code-scanning
-        uses: github/codeql-action/upload-sarif@v3
-        with:
-          sarif_file: results.sarif
+      # NOTE: we deliberately do NOT upload the SARIF to GitHub's code-scanning
+      # dashboard.
+      #
+      # Why: Scorecard emits one finding per check (pinned-deps, vulnerabilities,
+      # fuzzing, code-review, etc.). These are score-tracking *metadata* — the
+      # score itself is the actionable signal, not the per-check rows. On a
+      # repo this size that's hundreds of alerts that drown out real CodeQL /
+      # secret-scanning findings. Maintainers should consume the Scorecard
+      # signal via:
+      #
+      #   * The README badge (always live, driven by publish_results above).
+      #   * The public Scorecard viewer linked from the badge.
+      #   * The uploaded SARIF artifact above for ad-hoc local inspection.
+      #
+      # If we ever want individual Scorecard rows in the code-scanning dashboard
+      # again, add back the github/codeql-action/upload-sarif step here AND add
+      # `security-events: write` to the permissions block above.

--- a/apps/web/stories/primitives/ErrorState.stories.tsx
+++ b/apps/web/stories/primitives/ErrorState.stories.tsx
@@ -1,5 +1,4 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import React from 'react';
 import { ErrorState } from '@/components/ui/ErrorState';
 
 const meta: Meta<typeof ErrorState> = {

--- a/services/agents/tests/test_playbook_nl_drafter.py
+++ b/services/agents/tests/test_playbook_nl_drafter.py
@@ -43,7 +43,7 @@ from app.playbook import (
 def _run(coro: Any) -> Any:
     """Run an awaitable synchronously, with one event loop per call."""
 
-    return asyncio.get_event_loop().run_until_complete(coro) if False else asyncio.run(coro)
+    return asyncio.run(coro)
 
 
 def _step_types(pb: Playbook) -> list[str]:


### PR DESCRIPTION
## Summary

Closes the open code-scanning queue (250 → 0):

| Source     | Open before | Action                                                                           |
|------------|------------:|----------------------------------------------------------------------------------|
| CodeQL     | 3           | 2 fixed in code, 1 dismissed as false positive (cross-call global state).        |
| Scorecard  | 247         | Mass-dismissed — Scorecard is a score, not a per-row triage queue. Workflow updated to publish the badge but not flood the dashboard. |

## What this PR changes (code)

- **`services/agents/tests/test_playbook_nl_drafter.py:46`** — drop the dead `if False else` branch in `_run()`. The expression always evaluated to `asyncio.run(coro)`. Closes CodeQL #476 (`py/constant-conditional-expression`).
- **`apps/web/stories/primitives/ErrorState.stories.tsx:2`** — drop the unused `import React from 'react'`. JSX transform handles it. Closes CodeQL #475 (`js/unused-local-variable`).
- **`.github/workflows/scorecard.yml`** — drop the `github/codeql-action/upload-sarif` step. The badge keeps working (driven by `publish_results: true` against the public Scorecard API). The SARIF is still uploaded as a workflow artifact for ad-hoc inspection. Drops the `security-events: write` permission accordingly. Long-form comment explains the trade-off in the workflow file.

## What this PR does NOT change (dismissals only)

- **CodeQL #474** (`py/unused-global-variable` against `_warned_unconfigured` in `services/threatintel/app/api/auth.py`) — dismissed as **false positive**. The global IS used: it gates the once-per-process warning at line 53 on the *next* call. CodeQL's analysis stops at the function boundary, so the cross-call read is invisible to it. Rewriting would lose the dedup.
- **Scorecard ×247** — dismissed as **won't fix**. The score itself is what's actionable; per-row rows are score-tracking metadata. CodeQL keeps writing to the dashboard via `.github/workflows/codeql.yml` so we don't lose real security findings.

## Effect on the security signal

- `gh api /repos/beenuar/AiSOC/code-scanning/alerts?state=open` → returns `[]` once this PR merges.
- README's OpenSSF Scorecard badge keeps rendering (publish_results unchanged).
- Future Scorecard runs no longer re-create 247 alerts.
- Real CodeQL findings on future PRs still surface normally.

## Test plan

- [x] `python3 -c 'import ast; ast.parse(open("services/agents/tests/test_playbook_nl_drafter.py").read())'` (parses).
- [x] `services/agents/tests/test_playbook_nl_drafter.py` still uses `asyncio.run(coro)` semantics it had before (the `if False` branch was never taken).
- [x] `apps/web/stories/primitives/ErrorState.stories.tsx` renders without the React import (no direct `React.` references).
- [x] `.github/workflows/scorecard.yml` YAML parses (no permission errors at workflow start).


Made with [Cursor](https://cursor.com)