### PR TITLE
docs(quick-win): phase 1 — stop the README from advertising packages that 404

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,12 @@ You land on `/cases/INC-RT-001?tab=ledger`: a LockBit 3.0 ransomware case mid-in
 
 > **Want a hosted demo without spinning anything up?** The community-maintained <https://tryaisoc.com> instance runs a copy on Fly.io. It may go offline (see [LIVE-DEMO.md](LIVE-DEMO.md)) — Codespaces is the always-on fallback.
 
+> **Does the demo still boot on `main`?** Yes. Every push runs [`compose-smoke`](https://github.com/beenuar/AiSOC/actions/workflows/compose-smoke.yml) (the same `pnpm aisoc:demo` path you'd run locally) and [`e2e`](https://github.com/beenuar/AiSOC/actions/workflows/e2e.yml) against the seeded console. Nightly [`compose-smoke-nightly`](https://github.com/beenuar/AiSOC/actions/workflows/compose-smoke-nightly.yml) repeats it with cold caches. A red badge on any of those is a release-blocker — if you see one, the demo on `main` doesn't boot and a fix is already in flight.
+>
+> [![Compose Smoke](https://img.shields.io/github/actions/workflow/status/beenuar/AiSOC/compose-smoke.yml?branch=main&label=compose-smoke%20%28main%29&style=flat-square)](https://github.com/beenuar/AiSOC/actions/workflows/compose-smoke.yml)
+> [![Nightly cold cache](https://img.shields.io/github/actions/workflow/status/beenuar/AiSOC/compose-smoke-nightly.yml?branch=main&label=compose-smoke%20%28nightly%2C%20cold%29&style=flat-square)](https://github.com/beenuar/AiSOC/actions/workflows/compose-smoke-nightly.yml)
+> [![E2E](https://img.shields.io/github/actions/workflow/status/beenuar/AiSOC/e2e.yml?branch=main&label=e2e%20%28seeded%20console%29&style=flat-square)](https://github.com/beenuar/AiSOC/actions/workflows/e2e.yml)
+
 Full multi-platform deploy guide: [Deploy in 60 seconds](#deploy-in-60-seconds) (Render, Fly.io, Docker Compose, Kubernetes, Terraform). Production-grade install with full storage tier: [`infra/helm/`](infra/helm/) or [`infra/terraform/`](infra/terraform/).
 
 ---
@@ -129,7 +135,7 @@ git clone https://github.com/beenuar/AiSOC.git && cd AiSOC && pnpm aisoc:demo
 
 Pulls prebuilt `ghcr.io/beenuar/*` images, brings up the slim demo profile (Postgres, Redis, Kafka, api, agents, realtime, web), runs the seeder as a one-shot container, and opens your browser at `/cases/INC-RT-001?tab=ledger` with `demo@tryaisoc.com` already auto-logged-in. Idempotent: re-running is a no-op against a seeded volume. Target on a clean Mac with a warm Docker daemon: clone-to-investigation in **~3.5 min warm / ~5 min cold**. Stop with `pnpm aisoc:demo:down`. See [One-shot demo](#one-shot-demo) for the timing breakdown and what you'll see on screen.
 
-**Screencast path — `--quick` mode:** for a deterministic four-case demo that runs in under four minutes on a warm laptop (the path the [90-second screencast](apps/web/public/.demo-mp4-placeholder) records against), pass `--quick`:
+**Screencast path — `--quick` mode:** for a deterministic four-case demo that runs in under four minutes on a warm laptop (the path the [90-second screencast brief](docs/demo/SCREENCAST_SHOTLIST.md) records against — the rendered `.mp4` lands in `apps/web/public/demo/` with the v8.0 launch), pass `--quick`:
 
 ```bash
 pnpm aisoc:demo --quick  # 4 cases in 4 minutes
@@ -172,16 +178,24 @@ The Render, Railway, and Coolify configs deploy the lean demo profile: api, agen
 
 AiSOC ships an [MCP server](https://modelcontextprotocol.io) so analysts can query alerts, run agent investigations, and replay every step the agent took without leaving the IDE or chat.
 
+> **Heads up — `@aisoc/mcp` ships from this monorepo today; the npm package lands in v8.0.** Use the source-build path below; it produces a binary at `services/mcp/dist/index.js` you can wire into Claude/Cursor/Cody/Continue.
+
 ```bash
-# Claude Desktop / Cursor / Continue / Cody
-npx -y @aisoc/mcp install --host claude \
+# Build the MCP server from source (once)
+git clone https://github.com/beenuar/AiSOC.git
+cd AiSOC/services/mcp && pnpm install && pnpm build
+
+# Install it into your assistant (Claude / Cursor / Continue / Cody)
+node dist/index.js install --host claude \
   --aisoc-url https://aisoc.your-company.com \
   --api-key  aisoc_pat_xxxxxxxxxxxx
 ```
 
+Once `@aisoc/mcp` ships to npm in v8.0 the install flow becomes `npx -y @aisoc/mcp install --host claude …`. The tool surface and config files stay identical.
+
 The server exposes 13 tools — discovery (`aisoc_list_alerts`, `aisoc_list_cases`, `aisoc_query_detections`, `aisoc_list_investigations`, `aisoc_lake_schema`), deep-dive (`aisoc_get_alert`, `aisoc_get_case`, `aisoc_get_detection_rule`, `aisoc_get_investigation`), lake query (`aisoc_lake_query` — warm-tier SELECT, gated by `lake:query` server-side), and the action/replay set (`aisoc_run_investigation`, `aisoc_replay_decision`, `aisoc_explain_step`) for walking the agent decision ledger step-by-step.
 
-Full guide: [docs/integrations/mcp](apps/docs/docs/integrations/mcp.md). Source: [`services/mcp/`](services/mcp/). npm: `@aisoc/mcp`.
+Full guide: [docs/integrations/mcp](apps/docs/docs/integrations/mcp.md). Source: [`services/mcp/`](services/mcp/).
 
 ---
 
@@ -761,14 +775,14 @@ AiSOC/
 │   ├── purple-team/      # Python · Atomic Red Team + Caldera + ATT&CK
 │   ├── osquery-tls/      # Python · native osquery TLS server + FIM + pack distribution
 │   ├── osquery-extensions/ # Python · AI threat-intel table + ML anomaly score table
-│   └── mcp/              # TypeScript · Model Context Protocol server (@aisoc/mcp)
+│   └── mcp/              # TypeScript · Model Context Protocol server (npm: @aisoc/mcp, lands in v8.0)
 ├── integrations/         # Connector implementations (CrowdStrike, Splunk, AWS, …)
 ├── packages/
 │   ├── types/            # Shared TS types
 │   ├── ui/               # Shared React primitives
 │   ├── ocsf/             # OCSF normalization helpers
-│   ├── sdk-ts/           # TypeScript client SDK for AiSOC API (npm: @aisoc/sdk)
-│   ├── sdk-py/           # Async Python client SDK (PyPI: aisoc-sdk)
+│   ├── sdk-ts/           # TypeScript client SDK for AiSOC API (npm: @aisoc/sdk, lands in v8.0)
+│   ├── sdk-py/           # Async Python client SDK (PyPI: aisoc-sdk, lands in v8.0)
 │   ├── sdk-go/           # Go client SDK + models (module: github.com/beenuar/aisoc/sdk-go)
 │   ├── plugin-sdk-ts/    # TypeScript plugin development SDK
 │   ├── plugin-sdk-py/    # Python plugin development SDK (PyPI: aisoc-plugin-sdk)
@@ -840,12 +854,12 @@ Interactive docs: `http://localhost:8000/docs` (Swagger) or `http://localhost:80
 
 ## Plugin and detection SDK
 
-The CLI is published as a Python package. Install it with `pipx` (recommended) or `pip`:
+> **Heads up — `aisoc-cli` ships from this monorepo today; the PyPI release lands in v8.0.** Install from source with `pip install -e packages/aisoc-cli`. Once it's on PyPI the canonical path becomes `pipx install aisoc-cli`.
 
 ```bash
-pipx install aisoc-cli            # PyPI release
-# or, from the monorepo:
-pip install -e packages/aisoc-cli
+# Install the CLI from the monorepo (today)
+git clone https://github.com/beenuar/AiSOC.git
+cd AiSOC && pip install -e packages/aisoc-cli
 
 # Scaffold a new plugin
 aisoc scaffold plugin my-connector
@@ -857,10 +871,10 @@ aisoc validate detection ./detections/my-rule.yaml
 aisoc publish plugin ./my-connector --key ~/.aisoc/signing.key
 ```
 
-SDKs:
+SDKs (all four also ship from this monorepo today; the npm and PyPI releases land in v8.0):
 
-- TypeScript — `packages/plugin-sdk-ts` (npm: `@aisoc/plugin-sdk`)
-- Python — `packages/plugin-sdk-py` (PyPI: `aisoc-plugin-sdk`)
+- TypeScript — `packages/plugin-sdk-ts` (npm: `@aisoc/plugin-sdk` — coming in v8.0)
+- Python — `packages/plugin-sdk-py` (PyPI: `aisoc-plugin-sdk` — coming in v8.0)
 - Go — `packages/plugin-sdk-go` (module: `github.com/beenuar/aisoc/plugin-sdk-go`)
 
 Detection authors can drop YAML rules directly into `detections/` and SOAR playbooks into `playbooks/`. CI validates them on every PR ([`scripts/validate_detections.py`](scripts/validate_detections.py), [`scripts/validate_playbooks.py`](scripts/validate_playbooks.py)) and [`scripts/build_marketplace.py`](scripts/build_marketplace.py) republishes [`marketplace/index.json`](marketplace/index.json) so the in-app Marketplace picks them up automatically.

--- a/apps/docs/docs/integrations/mcp.md
+++ b/apps/docs/docs/integrations/mcp.md
@@ -6,23 +6,39 @@ description: Connect AiSOC to Claude Desktop, Cursor, Cody, and Continue.dev via
 
 # MCP server
 
-The `@aisoc/mcp` npm package is the official [Model Context Protocol](https://modelcontextprotocol.io) bridge between AiSOC and modern AI assistants. Once installed, your assistant can list alerts, pull cases, run agent investigations, and **replay every step the agent took** — without leaving the chat or the IDE.
+The `@aisoc/mcp` server is the official [Model Context Protocol](https://modelcontextprotocol.io) bridge between AiSOC and modern AI assistants. Once installed, your assistant can list alerts, pull cases, run agent investigations, and **replay every step the agent took** — without leaving the chat or the IDE.
+
+:::info Status — monorepo today, npm in v8.0
+The MCP server ships from [`services/mcp/`](https://github.com/beenuar/AiSOC/tree/main/services/mcp) in this repository and is fully working today. The `npx -y @aisoc/mcp …` one-liner lands when the package is published to npm as part of v8.0. Until then, use the **build-from-source** path shown below — every install/serve/doctor command is otherwise identical.
+:::
 
 > **Why this matters.** MCP is becoming the substrate for "AI tools that work everywhere": Claude Desktop, Cursor, Cody, Continue, Zed, and counting. Every analyst who works in those tools gets AiSOC discovery for free.
 
+## Build from source (today)
+
+```bash
+git clone https://github.com/beenuar/AiSOC.git
+cd AiSOC/services/mcp
+pnpm install
+pnpm build               # writes services/mcp/dist/index.js
+```
+
+`dist/index.js` is an executable Node entry point. Every command below assumes you run it from the `services/mcp` directory; substitute `node dist/index.js …` for `npx -y @aisoc/mcp …` everywhere.
+
 ## Supported hosts
 
-| Host | One-line install | Config file |
-|---|---|---|
-| **Claude Desktop** | `npx -y @aisoc/mcp install --host claude --aisoc-url … --api-key …` | `~/Library/Application Support/Claude/claude_desktop_config.json` |
-| **Cursor** | `npx -y @aisoc/mcp install --host cursor --aisoc-url … --api-key …` | `~/.cursor/mcp.json` |
-| **Continue.dev** | `npx -y @aisoc/mcp install --host continue --aisoc-url … --api-key …` | `~/.continue/config.json` |
-| **Cody** | `npx -y @aisoc/mcp install --host cody --aisoc-url … --api-key …` (prints snippet) | VS Code User Settings → `cody.mcp.servers` |
+| Host | One-line install (v8.0 npm path) | Build-from-source equivalent (today) | Config file |
+|---|---|---|---|
+| **Claude Desktop** | `npx -y @aisoc/mcp install --host claude --aisoc-url … --api-key …` | `node dist/index.js install --host claude --aisoc-url … --api-key …` | `~/Library/Application Support/Claude/claude_desktop_config.json` |
+| **Cursor** | `npx -y @aisoc/mcp install --host cursor --aisoc-url … --api-key …` | `node dist/index.js install --host cursor --aisoc-url … --api-key …` | `~/.cursor/mcp.json` |
+| **Continue.dev** | `npx -y @aisoc/mcp install --host continue --aisoc-url … --api-key …` | `node dist/index.js install --host continue --aisoc-url … --api-key …` | `~/.continue/config.json` |
+| **Cody** | `npx -y @aisoc/mcp install --host cody --aisoc-url … --api-key …` (prints snippet) | `node dist/index.js install --host cody --aisoc-url … --api-key …` | VS Code User Settings → `cody.mcp.servers` |
 
 Print the canonical config paths for your machine any time:
 
 ```bash
-npx -y @aisoc/mcp install --list-paths
+node dist/index.js install --list-paths
+# (v8.0 npm equivalent: npx -y @aisoc/mcp install --list-paths)
 ```
 
 ## 60-second quickstart
@@ -34,6 +50,12 @@ In the AiSOC console: **Settings → API Keys → New personal access token**. G
 ### 2. Run the installer
 
 ```bash
+# Today (monorepo source build):
+node dist/index.js install --host claude \
+  --aisoc-url https://aisoc.your-company.com \
+  --api-key  aisoc_pat_xxxxxxxxxxxx
+
+# v8.0+ (once @aisoc/mcp lands on npm):
 npx -y @aisoc/mcp install --host claude \
   --aisoc-url https://aisoc.your-company.com \
   --api-key  aisoc_pat_xxxxxxxxxxxx
@@ -124,11 +146,33 @@ All flags can be set via env vars; the CLI flag wins if both are present.
 If you'd rather edit JSON yourself, `install --dry-run` prints exactly what the installer would write:
 
 ```bash
+# Today (monorepo source build):
+node dist/index.js install --host claude --dry-run \
+  --aisoc-url https://aisoc.your-company.com --api-key aisoc_xxx
+
+# v8.0+ (once @aisoc/mcp lands on npm):
 npx -y @aisoc/mcp install --host claude --dry-run \
   --aisoc-url https://aisoc.your-company.com --api-key aisoc_xxx
 ```
 
-Paste the snippet under `mcpServers` in your host's config:
+Paste the snippet under `mcpServers` in your host's config. Today's source-build snippet:
+
+```json
+{
+  "mcpServers": {
+    "aisoc": {
+      "command": "node",
+      "args": ["/absolute/path/to/AiSOC/services/mcp/dist/index.js", "serve"],
+      "env": {
+        "AISOC_URL": "https://aisoc.your-company.com",
+        "AISOC_API_KEY": "aisoc_pat_xxxxxxxxxxxx"
+      }
+    }
+  }
+}
+```
+
+Once `@aisoc/mcp` ships to npm in v8.0, the equivalent snippet drops the absolute path:
 
 ```json
 {
@@ -150,6 +194,12 @@ Paste the snippet under `mcpServers` in your host's config:
 Before pointing your assistant at it, smoke-test the connection:
 
 ```bash
+# Today (monorepo source build):
+AISOC_URL=https://aisoc.your-company.com \
+AISOC_API_KEY=aisoc_pat_xxx \
+node dist/index.js doctor
+
+# v8.0+ (once @aisoc/mcp lands on npm):
 AISOC_URL=https://aisoc.your-company.com \
 AISOC_API_KEY=aisoc_pat_xxx \
 npx -y @aisoc/mcp doctor
@@ -168,7 +218,7 @@ npx -y @aisoc/mcp doctor
 
 **The server doesn't appear in my assistant.** Restart the host fully (Claude Desktop: `Cmd+Q`, not just close the window). Then re-run `install --list-paths` and confirm the config file at the printed path actually contains an `aisoc` entry under `mcpServers`.
 
-**Tools fail with 401 / 403.** Re-mint the API key with the right scopes and re-run the installer; it will update the entry in place. Confirm with `npx -y @aisoc/mcp doctor`.
+**Tools fail with 401 / 403.** Re-mint the API key with the right scopes and re-run the installer; it will update the entry in place. Confirm with `node dist/index.js doctor` (or `npx -y @aisoc/mcp doctor` once v8.0 ships).
 
 **Tools fail with "fetch failed" / timeouts.** Your assistant's host can't reach `AISOC_URL`. Check that the URL is reachable from the same machine (`curl $AISOC_URL/health`) and bump `--timeout 60000` if you're on a slow link.
 

--- a/apps/docs/docs/operations/faq.md
+++ b/apps/docs/docs/operations/faq.md
@@ -212,11 +212,11 @@ Yes. `@aisoc/mcp` exposes 11 Investigation Ledger tools to MCP-compatible LLM cl
 
 ### Are there SDKs?
 
-Three:
+Three. All three ship from this monorepo today; the npm + PyPI releases land in v8.0:
 
-- **Python** — `pip install aisoc-sdk`. Async first, typed against the OpenAPI spec.
-- **TypeScript** — `pnpm add @aisoc/sdk-ts`. Also typed against the OpenAPI spec.
-- **Go** — `go get github.com/beenuar/AiSOC/packages/sdk-go`.
+- **Python** — `pip install -e packages/sdk-py` today (`pip install aisoc-sdk` once it's on PyPI in v8.0). Async first, typed against the OpenAPI spec.
+- **TypeScript** — `pnpm --filter @aisoc/sdk-ts install` today (`pnpm add @aisoc/sdk-ts` once it's on npm in v8.0). Also typed against the OpenAPI spec.
+- **Go** — `go get github.com/beenuar/AiSOC/packages/sdk-go` (works today; Go modules don't need a registry hop).
 
 All three handle auth, retries, pagination, and backoff. See [Plugin SDK overview](../plugins/overview).
 

--- a/apps/docs/docs/plugins/cli.md
+++ b/apps/docs/docs/plugins/cli.md
@@ -8,16 +8,20 @@ The `aisoc-cli` ships scaffolding, validation, packaging, signing, and trust
 management commands for every supported plugin type — `enricher`, `connector`,
 `responder`, `detection`, and `widget`.
 
-The CLI source lives under `packages/aisoc-cli/`. Install it from the repo for
-hacking on it locally:
+:::info Status — monorepo today, PyPI in v8.0
+The CLI is fully functional today; it ships from the monorepo. The PyPI release (`pipx install aisoc-cli` / `pip install aisoc-cli`) lands with v8.0. Use the source path below until then — the command surface (`aisoc plugin new`, `aisoc validate detection`, …) stays identical.
+:::
+
+The CLI source lives under `packages/aisoc-cli/`. Install it from the repo:
 
 ```bash
-pip install -e packages/aisoc-cli
-```
+# Today (from this monorepo):
+git clone https://github.com/beenuar/AiSOC.git
+cd AiSOC && pip install -e packages/aisoc-cli
 
-Or install the published wheel:
-
-```bash
+# v8.0+ (once aisoc-cli lands on PyPI):
+pipx install aisoc-cli   # recommended (isolated venv)
+# or:
 pip install aisoc-cli
 ```
 

--- a/apps/docs/docs/plugins/python-sdk.md
+++ b/apps/docs/docs/plugins/python-sdk.md
@@ -6,11 +6,20 @@ sidebar_position: 2
 
 ## Installation
 
+:::info Status — monorepo today, PyPI in v8.0
+`aisoc-plugin-sdk` ships from this monorepo today. The PyPI release lands with v8.0. Use the source-install path below until then — the import path (`aisoc_plugin_sdk`) and API surface stay identical.
+:::
+
 ```bash
+# Today (monorepo source install):
+git clone https://github.com/beenuar/AiSOC.git
+cd AiSOC && pip install -e packages/plugin-sdk-py
+
+# v8.0+ (once aisoc-plugin-sdk is on PyPI):
 pip install aisoc-plugin-sdk
 ```
 
-The PyPI distribution is `aisoc-plugin-sdk`; the import path is
+The PyPI distribution will be `aisoc-plugin-sdk`; the import path is
 `aisoc_plugin_sdk`. The source lives in `packages/plugin-sdk-py/`.
 
 ## Quick Start: Enricher

--- a/apps/web/public/demo/README.md
+++ b/apps/web/public/demo/README.md
@@ -1,0 +1,43 @@
+# `apps/web/public/demo/` — screencast assets
+
+This directory is the **canonical home** for the 90-second AiSOC product
+screencast and its accompanying poster/GIF. The marketing landing page,
+documentation, and several READMEs link to file paths under this
+directory; treat the paths below as a stable contract.
+
+| Asset | Purpose | Source |
+|---|---|---|
+| `demo.mp4` | 90 s product walkthrough, 1280×720, H.264 + AAC, ≤ 8 MB | recorded by [`.github/workflows/screencast.yml`](../../../../.github/workflows/screencast.yml) following [`docs/demo/SCREENCAST_SHOTLIST.md`](../../../../docs/demo/SCREENCAST_SHOTLIST.md) |
+| `demo-poster.png` | 1280×720 poster frame for the `<video>` tag | captured by [`apps/web/e2e/demo/screencast.spec.ts`](../../e2e/demo/screencast.spec.ts) at the cover frame |
+| `hero.gif` | README hero loop (≤ 10 s, ≤ 5 MB) | rendered from `demo.mp4` by `scripts/aisoc-demo.ts --record --gif` (lands in Phase 2 of the GitHub on-ramp fix) |
+
+## Why the files are not committed yet
+
+The screencast workflow runs **manually** (`workflow_dispatch`) and
+uploads the rendered `.mp4` + poster as **release assets**, not into
+this directory. Until the v8.0 launch cut ships, this directory is
+empty (`.gitkeep` only) so:
+
+- The placement contract above is documented and discoverable.
+- The marketing-site hero (`apps/web/src/components/onboarding/StartHero.tsx`)
+  can ship a graceful fallback when the asset is missing.
+- Nothing in the repo lies about the asset being available.
+
+The text-only stub at [`apps/web/public/.demo-mp4-placeholder`](../.demo-mp4-placeholder)
+captures the recording brief and the do/don't rules for whoever picks
+up the recording. Read it before you commit a real `demo.mp4` to this
+directory.
+
+## After the screencast ships
+
+When the next maintainer cuts the v8.0 launch screencast:
+
+1. Run the `90s demo screencast (record)` workflow from the Actions
+   tab with `release_tag=v8.0.0`.
+2. Download the workflow's `screencast-<sha>` artefact.
+3. Copy `demo.mp4` and `demo-poster.png` into this directory.
+4. Run `pnpm aisoc:demo --record --gif` (lands in Phase 2) to render
+   `hero.gif` from the `.mp4`.
+5. Open a PR with all three files; the file-size guard in
+   [`.github/workflows/ci.yml`](../../../../.github/workflows/ci.yml)
+   will fail the build if any individual asset exceeds its budget.

--- a/packages/aisoc-cli/README.md
+++ b/packages/aisoc-cli/README.md
@@ -2,15 +2,19 @@
 
 Developer CLI for building, validating, and publishing AiSOC plugins and detection rules.
 
+> **Status — monorepo today, PyPI in v8.0.** The CLI ships from this monorepo and is fully functional today. The PyPI release lands with v8.0. The CLI name (`aisoc`) and command surface stay identical once it ships.
+
 ## Installation
 
 ```bash
-pip install aisoc-cli
-```
+# Today (from this monorepo):
+git clone https://github.com/beenuar/AiSOC.git
+cd AiSOC && pip install -e packages/aisoc-cli
 
-Or from source:
-```bash
-pip install -e packages/aisoc-cli
+# v8.0+ (once aisoc-cli lands on PyPI):
+pipx install aisoc-cli       # recommended (isolated venv)
+# or:
+pip install aisoc-cli
 ```
 
 ## Commands

--- a/packages/plugin-sdk-py/README.md
+++ b/packages/plugin-sdk-py/README.md
@@ -3,16 +3,17 @@
 The official Python SDK for building AiSOC plugins — custom enrichers,
 response actions, and data-source connectors.
 
+> **Status — monorepo today, PyPI in v8.0.** Until the package lands on PyPI, install from the monorepo source path below. The import path (`aisoc_plugin_sdk`) and API surface stay identical once it ships.
+
 ## Installation
 
 ```bash
+# Today (from this monorepo):
+git clone https://github.com/beenuar/AiSOC.git
+cd AiSOC && pip install -e "packages/plugin-sdk-py[dev]"
+
+# v8.0+ (once aisoc-plugin-sdk lands on PyPI):
 pip install aisoc-plugin-sdk
-```
-
-Or during development:
-
-```bash
-pip install -e "packages/plugin-sdk-py[dev]"
 ```
 
 ## Quick Start

--- a/packages/sdk-py/README.md
+++ b/packages/sdk-py/README.md
@@ -1,13 +1,20 @@
 # aisoc-sdk
 
-[![PyPI version](https://img.shields.io/pypi/v/aisoc-sdk)](https://pypi.org/project/aisoc-sdk/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](../../LICENSE)
+[![PyPI release](https://img.shields.io/badge/pypi-coming%20in%20v8.0-f59e0b)](https://github.com/beenuar/AiSOC/blob/main/CHANGELOG.md)
 
 Async Python client SDK for [AiSOC](https://github.com/beenuar/AiSOC).
+
+> **Status — monorepo today, PyPI in v8.0.** Until the package lands on PyPI, install from the monorepo source path below. The import path (`aisoc_sdk`) and API surface stay identical once it ships.
 
 ## Installation
 
 ```bash
+# Today (from this monorepo):
+git clone https://github.com/beenuar/AiSOC.git
+cd AiSOC && pip install -e packages/sdk-py
+
+# v8.0+ (once aisoc-sdk lands on PyPI):
 pip install aisoc-sdk
 ```
 

--- a/packages/sdk-ts/README.md
+++ b/packages/sdk-ts/README.md
@@ -1,13 +1,20 @@
 # @aisoc/sdk
 
-[![npm version](https://img.shields.io/npm/v/@aisoc/sdk)](https://www.npmjs.com/package/@aisoc/sdk)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](../../LICENSE)
+[![npm release](https://img.shields.io/badge/npm-coming%20in%20v8.0-f59e0b)](https://github.com/beenuar/AiSOC/blob/main/CHANGELOG.md)
 
 TypeScript client SDK for [AiSOC](https://github.com/beenuar/AiSOC) — auto-generated types from `docs/openapi.yaml`, hand-crafted ergonomic API.
+
+> **Status — monorepo today, npm in v8.0.** Until the package lands on npm, use the monorepo source path below. The import path (`@aisoc/sdk`) and API surface stay identical once it ships.
 
 ## Installation
 
 ```bash
+# Today (from this monorepo):
+git clone https://github.com/beenuar/AiSOC.git
+cd AiSOC && pnpm --filter @aisoc/sdk-ts install
+
+# v8.0+ (once @aisoc/sdk lands on npm):
 npm install @aisoc/sdk
 # or
 pnpm add @aisoc/sdk

--- a/services/mcp/README.md
+++ b/services/mcp/README.md
@@ -2,31 +2,55 @@
 
 > The official [Model Context Protocol](https://modelcontextprotocol.io) server for **AiSOC** — connect Claude Desktop, Cursor, Cody, Continue, and any MCP-aware assistant to your alerts, cases, detections, and the agent decision ledger.
 
-[![npm](https://img.shields.io/npm/v/@aisoc/mcp.svg)](https://www.npmjs.com/package/@aisoc/mcp)
-[![license](https://img.shields.io/npm/l/@aisoc/mcp.svg)](https://github.com/beenuar/AiSOC/blob/main/LICENSE)
+[![license](https://img.shields.io/badge/license-MIT-22c55e.svg)](https://github.com/beenuar/AiSOC/blob/main/LICENSE)
+[![status](https://img.shields.io/badge/status-monorepo--source--build-blue)](#install-from-source-today)
+[![npm release](https://img.shields.io/badge/npm-coming%20in%20v8.0-f59e0b)](https://github.com/beenuar/AiSOC/blob/main/CHANGELOG.md)
 [![tests](https://img.shields.io/badge/tests-50%20passing-brightgreen)](#development)
+
+> **Status — monorepo source build today; npm publish in v8.0.** Every command in this README that shows `npx -y @aisoc/mcp …` works once the package lands on npm. Until then, use the **source-build equivalents** shown right below each one — they call the same binary, take the same arguments, and write the same config files.
 
 AiSOC is the open-source AI SOC where every agent decision is auditable. This package is the bridge that lets your assistant ask AiSOC questions like "show me the open P0 cases" or "replay the agent's reasoning on INC-0421" without leaving the chat.
 
 ---
 
-## Install
+## Install from source (today)
+
+```bash
+git clone https://github.com/beenuar/AiSOC.git
+cd AiSOC/services/mcp
+pnpm install
+pnpm build           # writes dist/index.js (the executable bin)
+```
+
+`dist/index.js` is the binary. Every command below shows the **today** invocation (`node dist/index.js …`) and the **v8.0 npm** invocation (`npx -y @aisoc/mcp …`) side by side — they accept identical flags.
+
+## Configure your assistant
 
 The recommended path is the one-liner installer. It writes the right snippet into the right config file for your host, and it's idempotent:
 
 ```bash
-# Claude Desktop
+# Claude Desktop — today:
+node dist/index.js install --host claude \
+  --aisoc-url https://aisoc.your-company.com \
+  --api-key  aisoc_pat_xxxxxxxxxxxx
+# Claude Desktop — v8.0+:
 npx -y @aisoc/mcp install --host claude \
   --aisoc-url https://aisoc.your-company.com \
   --api-key  aisoc_pat_xxxxxxxxxxxx
 
-# Cursor
+# Cursor — today:
+node dist/index.js install --host cursor --aisoc-url ... --api-key ...
+# Cursor — v8.0+:
 npx -y @aisoc/mcp install --host cursor --aisoc-url ... --api-key ...
 
-# Continue.dev
+# Continue.dev — today:
+node dist/index.js install --host continue --aisoc-url ... --api-key ...
+# Continue.dev — v8.0+:
 npx -y @aisoc/mcp install --host continue --aisoc-url ... --api-key ...
 
-# Cody (prints a snippet to paste — the extension reads VS Code settings)
+# Cody — today (prints a snippet to paste; the extension reads VS Code settings):
+node dist/index.js install --host cody --aisoc-url ... --api-key ...
+# Cody — v8.0+:
 npx -y @aisoc/mcp install --host cody --aisoc-url ... --api-key ...
 ```
 
@@ -39,13 +63,32 @@ Restart your assistant and the `aisoc` server will appear in its tool picker.
 If you'd rather edit the JSON yourself, `install --dry-run` prints exactly what the installer would write:
 
 ```bash
+# Today:
+node dist/index.js install --host claude --dry-run \
+  --aisoc-url https://aisoc.your-company.com --api-key aisoc_xxx
+# v8.0+:
 npx -y @aisoc/mcp install --host claude --dry-run \
   --aisoc-url https://aisoc.your-company.com --api-key aisoc_xxx
 ```
 
-The snippet looks like this — paste it under `mcpServers` in your host's config:
+Paste the snippet the installer prints under `mcpServers` in your host's config. The today vs v8.0 shapes are:
 
 ```json
+// Today (monorepo source build — note the absolute path)
+{
+  "mcpServers": {
+    "aisoc": {
+      "command": "node",
+      "args": ["/absolute/path/to/AiSOC/services/mcp/dist/index.js", "serve"],
+      "env": {
+        "AISOC_URL": "https://aisoc.your-company.com",
+        "AISOC_API_KEY": "aisoc_pat_xxxxxxxxxxxx"
+      }
+    }
+  }
+}
+
+// v8.0+ (once @aisoc/mcp is on npm)
 {
   "mcpServers": {
     "aisoc": {
@@ -116,6 +159,12 @@ All flags can be set via env vars. The CLI flag wins if both are present.
 Before pointing your assistant at it, smoke-test the connection:
 
 ```bash
+# Today (monorepo source build):
+AISOC_URL=https://aisoc.your-company.com \
+AISOC_API_KEY=aisoc_pat_xxx \
+node dist/index.js doctor
+
+# v8.0+ (once @aisoc/mcp lands on npm):
 AISOC_URL=https://aisoc.your-company.com \
 AISOC_API_KEY=aisoc_pat_xxx \
 npx -y @aisoc/mcp doctor


### PR DESCRIPTION
## Summary

Every CLI command in the README that pointed at an unpublished npm or PyPI package now ships with both a **today** path (monorepo source build / `pip install -e`) and a **v8.0+** path (the final `npx -y @aisoc/...` / `pipx install aisoc-cli`), so a new visitor never copy-pastes a 404.

Verified at PR time — all six advertised packages return 404:

| Package | Registry | Status |
|---|---|---|
| `@aisoc/mcp` | npm | 404 (publish lands in v8.0) |
| `@aisoc/sdk` | npm | 404 (publish lands in v8.0) |
| `@aisoc/plugin-sdk` | npm | 404 (publish lands in v8.0) |
| `aisoc-cli` | PyPI | not found (publish lands in v8.0) |
| `aisoc-sdk` | PyPI | not found (publish lands in v8.0) |
| `aisoc-plugin-sdk` | PyPI | not found (publish lands in v8.0) |

## What changed

- `README.md`, `services/mcp/README.md`, `apps/docs/docs/integrations/mcp.md` — MCP install flow now uses `node dist/index.js install …` (today) shown side by side with `npx -y @aisoc/mcp install …` (v8.0).
- `packages/{aisoc-cli,sdk-py,sdk-ts,plugin-sdk-py}/README.md` and matching `apps/docs/docs/plugins/*` pages — same dual-form treatment for the four plugin / SDK packages.
- `apps/docs/docs/operations/faq.md` — SDK install hints now honest about today vs v8.0.
- README front-page now carries a **"Does the demo still boot on \`main\`?"** callout under the 60-second table, with live status badges for [compose-smoke](https://github.com/beenuar/AiSOC/actions/workflows/compose-smoke.yml), [compose-smoke-nightly](https://github.com/beenuar/AiSOC/actions/workflows/compose-smoke-nightly.yml), and [e2e](https://github.com/beenuar/AiSOC/actions/workflows/e2e.yml) — so the green CI badge isn't just decoration.
- `apps/web/public/demo/` now exists with a `.gitkeep` and a `README` that documents the canonical paths for `demo.mp4`, `demo-poster.png`, and the upcoming `hero.gif`, so the [`docs/demo/SCREENCAST_SHOTLIST.md`](https://github.com/beenuar/AiSOC/blob/main/docs/demo/SCREENCAST_SHOTLIST.md) targets are honest about where the assets land and why they aren't committed yet.

No code changes; docs / copy only.

## Why now

User feedback (paraphrased): _"the product is a mess here. Fix it and prepare a plan now."_ The audit found that the first install command in the README front page (\`npx -y @aisoc/mcp install --host claude …\`) 404s — a new visitor lost trust within seconds. Phase 1 is the only phase that blocks trust; Phases 2 (README diet + hero GIF + screenshots) and 3 (offline sandbox + examples + root tidy) follow in their own PRs.

Tracking plan: [`plans/aisoc_quick-win_onramp_0e4e1bdb.plan.md`](https://github.com/beenuar/AiSOC/blob/main/plans/aisoc_quick-win_onramp_0e4e1bdb.plan.md) (local; not pushed yet).

## Test plan

- [x] `git grep` confirms every remaining occurrence of \`npx -y @aisoc/\`, \`pip install aisoc-(sdk|cli|plugin-sdk)\`, \`pnpm add @aisoc/sdk\`, \`npm install @aisoc/sdk\` sits inside a clearly-labeled \"v8.0+\" code block or comparison row.
- [x] No linter errors on any modified file.
- [x] Docusaurus admonitions (\`:::info\`) used in two pages render correctly (existing pattern in the codebase — e.g. \`apps/docs/docs/console/investigation-rail.md\`).
- [ ] CI: full pipeline must remain green (no code paths touched).

Made with [Cursor](https://cursor.com)