### PR TITLE
Add table-aware field aliases for Sentinel KQL translation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -125,4 +125,4 @@ services/api/marketplace/
 # (default mode). The source of truth is `schemas/graph-schema.yaml`; the
 # `-current.yaml` file is a runtime artefact that varies by environment.
 schemas/graph-schema-current.yaml
-.codex/
+

--- a/.gitignore
+++ b/.gitignore
@@ -125,4 +125,4 @@ services/api/marketplace/
 # (default mode). The source of truth is `schemas/graph-schema.yaml`; the
 # `-current.yaml` file is a runtime artefact that varies by environment.
 schemas/graph-schema-current.yaml
-
+.codex/

--- a/services/connectors/app/federated/translators/kql.py
+++ b/services/connectors/app/federated/translators/kql.py
@@ -17,10 +17,20 @@ Shape:
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Final
 
 from app.federated.query import Indicator, QueryError, UnifiedQuery
 
+_SENTINEL_TABLE_FIELD_ALIASES: Final[dict[str, dict[str, str]]] = {
+    "SecurityIncident": {
+        "device.name": "CompromisedEntity",
+        "severity": "Severity",
+        "message": "AlertName",
+    },
+    "SigninLogs": {
+        "user.name": "UserPrincipalName",
+    },
+}
 
 def _kql_quote(value: Any) -> str:
     if isinstance(value, bool):
@@ -32,8 +42,28 @@ def _kql_quote(value: Any) -> str:
     return f'"{escaped}"'
 
 
-def _indicator_to_kql(indicator: Indicator) -> str:
-    field_token = indicator.field
+def _resolve_kql_field(field: str, table: str) -> str:
+    aliases = _SENTINEL_TABLE_FIELD_ALIASES.get(table)
+
+    if aliases is None:
+        return field
+
+    return aliases.get(field, field)
+
+
+def _indicator_to_kql(
+    indicator: Indicator,
+    *,
+    table: str,
+) -> str:
+    
+    """Render a single ``Indicator`` as a KQL where-clause."""
+
+    field_token = _resolve_kql_field(
+    indicator.field,
+    table,
+)
+    
     op = indicator.operator
     value = indicator.value
 
@@ -71,7 +101,10 @@ def to_kql(query: UnifiedQuery, *, table: str = "CommonSecurityLog") -> str:
         # KQL's "search" verb does free-text across all string columns;
         # we use it as a where-clause so the pipeline shape stays uniform.
         lines.append(f"| where * contains {_kql_quote(query.free_text)}")
+
     for indicator in query.indicators:
-        lines.append(f"| where {_indicator_to_kql(indicator)}")
+        lines.append(
+            f"| where {_indicator_to_kql(indicator, table=table)}"
+        )
     lines.append(f"| take {query.limit}")
     return "\n".join(lines)

--- a/services/connectors/app/federated/translators/kql.py
+++ b/services/connectors/app/federated/translators/kql.py
@@ -32,6 +32,7 @@ _SENTINEL_TABLE_FIELD_ALIASES: Final[dict[str, dict[str, str]]] = {
     },
 }
 
+
 def _kql_quote(value: Any) -> str:
     if isinstance(value, bool):
         return "true" if value else "false"
@@ -56,14 +57,13 @@ def _indicator_to_kql(
     *,
     table: str,
 ) -> str:
-    
     """Render a single ``Indicator`` as a KQL where-clause."""
 
     field_token = _resolve_kql_field(
-    indicator.field,
-    table,
-)
-    
+        indicator.field,
+        table,
+    )
+
     op = indicator.operator
     value = indicator.value
 
@@ -103,8 +103,6 @@ def to_kql(query: UnifiedQuery, *, table: str = "CommonSecurityLog") -> str:
         lines.append(f"| where * contains {_kql_quote(query.free_text)}")
 
     for indicator in query.indicators:
-        lines.append(
-            f"| where {_indicator_to_kql(indicator, table=table)}"
-        )
+        lines.append(f"| where {_indicator_to_kql(indicator, table=table)}")
     lines.append(f"| take {query.limit}")
     return "\n".join(lines)

--- a/services/connectors/tests/test_kql_aliases.py
+++ b/services/connectors/tests/test_kql_aliases.py
@@ -1,0 +1,84 @@
+from app.federated.query import Indicator, UnifiedQuery
+from app.federated.translators import to_kql
+
+
+
+def test_kql_translator_aliases_user_name_for_signinlogs():
+    q = UnifiedQuery(
+        indicators=(
+            Indicator(
+                field="user.name",
+                operator="eq",
+                value="alice@example.com",
+            ),
+        ),
+    )
+
+    kql = to_kql(q, table="SigninLogs")
+
+    assert "UserPrincipalName" in kql
+    assert "user.name" not in kql
+
+
+def test_kql_translator_aliases_securityincident_fields():
+    q = UnifiedQuery(
+        indicators=(
+            Indicator(
+                field="device.name",
+                operator="eq",
+                value="host01",
+            ),
+            Indicator(
+                field="severity",
+                operator="eq",
+                value="High",
+            ),
+            Indicator(
+                field="message",
+                operator="contains",
+                value="mimikatz",
+            ),
+        ),
+    )
+
+    kql = to_kql(q, table="SecurityIncident")
+
+    assert "CompromisedEntity" in kql
+    assert "Severity" in kql
+    assert "AlertName" in kql
+
+    assert "device.name" not in kql
+    assert "severity" not in kql
+    assert "message" not in kql
+
+
+def test_kql_translator_unknown_fields_pass_through():
+    q = UnifiedQuery(
+        indicators=(
+            Indicator(
+                field="source.ip",
+                operator="eq",
+                value="10.0.0.5",
+            ),
+        ),
+    )
+
+    kql = to_kql(q, table="SigninLogs")
+
+    assert "source.ip" in kql
+
+
+def test_kql_translator_unknown_tables_pass_through():
+    q = UnifiedQuery(
+        indicators=(
+            Indicator(
+                field="user.name",
+                operator="eq",
+                value="alice",
+            ),
+        ),
+    )
+
+    kql = to_kql(q, table="SomeFutureTable")
+
+    assert "user.name" in kql

--- a/services/connectors/tests/test_kql_aliases.py
+++ b/services/connectors/tests/test_kql_aliases.py
@@ -2,7 +2,6 @@ from app.federated.query import Indicator, UnifiedQuery
 from app.federated.translators import to_kql
 
 
-
 def test_kql_translator_aliases_user_name_for_signinlogs():
     q = UnifiedQuery(
         indicators=(


### PR DESCRIPTION
## Summary
Adds table-aware field alias resolution to the federated KQL translator.

## Changes
- Added Sentinel table alias registry
- Added field resolution helper
- Added SigninLogs alias mapping
- Added SecurityIncident alias mapping
- Preserved passthrough behavior for unknown fields and tables
- Added regression tests covering alias resolution and fallback behavior

## Validation
```powershell
pytest tests/test_kql_aliases.py -v
```

Result:
4 tests passed