### PR TITLE
fix(ci): ruff-format detection_eval.py for pinned ruff 0.4.x (keep main green)

### DIFF
--- a/services/api/app/services/detection_eval.py
+++ b/services/api/app/services/detection_eval.py
@@ -119,18 +119,14 @@ def evaluate_candidate_rule(
         fired, err = _fires(rule_language, rule_body, event)
         if fired:
             positives_fired += 1
-        outcomes.append(
-            FixtureOutcome(index=i, kind="positive", fired=fired, expected_fire=True, ok=fired, error=err)
-        )
+        outcomes.append(FixtureOutcome(index=i, kind="positive", fired=fired, expected_fire=True, ok=fired, error=err))
 
     negatives_fired = 0
     for i, event in enumerate(negative_fixtures):
         fired, err = _fires(rule_language, rule_body, event)
         if fired:
             negatives_fired += 1
-        outcomes.append(
-            FixtureOutcome(index=i, kind="negative", fired=fired, expected_fire=False, ok=not fired, error=err)
-        )
+        outcomes.append(FixtureOutcome(index=i, kind="negative", fired=fired, expected_fire=False, ok=not fired, error=err))
 
     fired_on_all_positives = positives_fired == len(positive_fixtures)
     silent_on_all_negatives = negatives_fired == 0


### PR DESCRIPTION
The CI `Python — Lint & Type-check` job pins `ruff>=0.4.4,<0.5`. `ruff format --check services/` went red after #429 because `services/api/app/services/detection_eval.py` was formatted by a newer local ruff that wraps a `FixtureOutcome(...)` call across lines, whereas 0.4.x keeps it single-line (it fits the 140 col limit). Reformatted with pinned ruff 0.4.10; the whole `services/` tree now passes `ruff format --check`. Formatting-only, no behavior change.

Made with [Cursor](https://cursor.com)