### PR TITLE
fix(ci): pin sqlglot to prod range in isolation-live (keep main green)

### DIFF
--- a/.github/workflows/isolation-live.yml
+++ b/.github/workflows/isolation-live.yml
@@ -43,9 +43,14 @@ jobs:
           python-version: "3.12"
 
       - name: Install clients + test deps
+        # sqlglot MUST be pinned to the same range the API service ships
+        # (`>=23,<27`): the ClickHouse test runs the production
+        # lake_sql.rewrite_for_tenant, and sqlglot >= 27 silently stops
+        # injecting the tenant WHERE predicate (the tenant-isolation break this
+        # very gate exists to catch). test_lake_sql.py guards the pin itself.
         run: >-
           pip install --quiet
-          pytest pytest-asyncio structlog sqlglot
+          pytest pytest-asyncio structlog "sqlglot>=23,<27"
           neo4j "redis>=5,<6" clickhouse-driver "kafka-python>=2,<3"
 
       # Single-container stores run as `services:`-style `docker run` so we can


### PR DESCRIPTION
The Phase 3.4 `isolation-live` gate installed `sqlglot` unpinned; CI pulled 30.x while the API ships `sqlglot>=23,<27`. Under sqlglot ≥27 the production `lake_sql.rewrite_for_tenant` **silently stops injecting the tenant WHERE predicate**, so the ClickHouse replay returned tenant B's row to a tenant-A query — the exact isolation break this gate exists to catch, but against a sqlglot version the product doesn't ship. Pinned the test deps to `sqlglot>=23,<27`; verified the ClickHouse replay passes on sqlglot 26.33 against a real local container. Neo4j/Redis/Kafka already passed. `test_lake_sql.py` asserts predicate injection under the prod pin, so the pin is guarded. **Finding (tracked):** the rewriter isn't sqlglot-27+ compatible — upgrading requires fixing `rewrite_for_tenant` first.

Made with [Cursor](https://cursor.com)