### PR TITLE
fix(security): fully clear shodan.go CodeQL log alerts (static message)

### DIFF
--- a/services/ingest/internal/enrichment/shodan.go
+++ b/services/ingest/internal/enrichment/shodan.go
@@ -78,11 +78,12 @@ func (s *ShodanEnricher) Enrich(ctx context.Context, event map[string]interface{
 
 	host, err := s.lookup(ctx, ip)
 	if err != nil {
-		// Log a sanitized IP only. `ip` is derived from an ingested (attacker-
-		// influenceable) event, so strip control chars to prevent log
-		// injection; and we deliberately do NOT log `err`, which can carry the
-		// request URL (with the Shodan API key) or response-derived data.
-		s.log.Warn("Shodan lookup failed", "ip", sanitizeLogValue(ip))
+		// Best-effort enrichment: a lookup failure is non-fatal (the event
+		// flows through unmodified). Log a static message with no fields —
+		// neither the raw `err` (which can carry the request URL with the
+		// Shodan API key or response-derived data) nor the event-derived `ip`
+		// (attacker-influenceable + PII) reaches the log.
+		s.log.Warn("Shodan host lookup failed; enrichment skipped")
 		return event
 	}
 	if host == nil {
@@ -190,20 +191,4 @@ func ExtractPublicIP(event map[string]interface{}) string {
 		return ip
 	}
 	return ""
-}
-
-// sanitizeLogValue strips CR/LF and other control characters so a value
-// derived from an ingested (attacker-influenceable) event cannot forge or
-// inject additional log lines.
-func sanitizeLogValue(s string) string {
-	cleaned := strings.Map(func(r rune) rune {
-		if r < 0x20 || r == 0x7f {
-			return -1
-		}
-		return r
-	}, s)
-	if len(cleaned) > 256 {
-		return cleaned[:256]
-	}
-	return cleaned
 }


### PR DESCRIPTION
Follow-up to #443. The first shodan.go fix moved `go/log-injection` + `go/clear-text-logging` to the new log line — CodeQL flags the event-derived `ip` itself (user-controlled + PII-from-HTTP-header) and doesn't recognize a local control-char strip as a sanitizer. A Shodan lookup failure is best-effort/non-fatal, so the warn is now a **static message with no fields** (neither `err` nor `ip` reaches the log). Removed the unused `sanitizeLogValue` helper. `go vet` + `go build` clean.

Made with [Cursor](https://cursor.com)