### PR TITLE
fix(ci): ruff-format fusion/app/main.py for pinned ruff 0.4.x (keep main green)

### DIFF
--- a/services/fusion/app/main.py
+++ b/services/fusion/app/main.py
@@ -33,9 +33,7 @@ async def lifespan(app: FastAPI):
     confidence_scorer = ConfidenceScorer(enabled=settings.confidence_enabled)
     # Phase A4 — behavioral-model fusion: one cache shared by the engine
     # (fuse-time lookup) and the worker (records the ueba.anomalies stream).
-    ueba_cache = (
-        UebaSignalCache(redis_client, ttl_seconds=settings.ueba_signal_ttl_seconds) if settings.ueba_fusion_enabled else None
-    )
+    ueba_cache = UebaSignalCache(redis_client, ttl_seconds=settings.ueba_signal_ttl_seconds) if settings.ueba_fusion_enabled else None
     engine = FusionEngine(
         dedup,
         correlator,


### PR DESCRIPTION
The Python-lint job pins `ruff>=0.4.4,<0.5`; the A4 edit to `services/fusion/app/main.py` was wrapped by a newer local ruff, so `ruff format --check services/` went red. Reformatted with pinned ruff 0.4.10; whole `services/` tree clean. Formatting-only.

Made with [Cursor](https://cursor.com)