### PR TITLE
fix(ci): action-setup v6 pnpm version conflict (docs/screencast) + langchain-core advisory triage

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -26,9 +26,11 @@ jobs:
         with:
           fetch-depth: 0
 
+      # No `version:` input — action-setup@v6 reads the root
+      # `packageManager: pnpm@8.15.1`. Pinning a different version (was
+      # `version: 9`) is a hard error under v6:
+      # "Multiple versions of pnpm specified ... ERR_PNPM_BAD_PM_VERSION".
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
-        with:
-          version: 9
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:

--- a/.github/workflows/screencast.yml
+++ b/.github/workflows/screencast.yml
@@ -40,9 +40,11 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Set up pnpm
+        # No `version:` input — action-setup@v6 reads the root
+        # `packageManager: pnpm@8.15.1`. Pinning a different version (was
+        # `version: 9`) is a hard error under v6:
+        # "Multiple versions of pnpm specified ... ERR_PNPM_BAD_PM_VERSION".
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
-        with:
-          version: 9
 
       - name: Set up Node 22
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0

--- a/scripts/security_audit_ignores.txt
+++ b/scripts/security_audit_ignores.txt
@@ -105,3 +105,12 @@ python|PYSEC-2026-1325|ecdsa 0.19.2 is latest release; no patched version availa
 # Both PYSEC and GHSA forms listed since pip-audit may report either as primary.
 python|PYSEC-2026-2193|langchain-core prompts.loading path traversal (fixed in 1.2.22); requires langchain 0.3 → 1.x major bump, module unused in codebase; tracked with langchain migration PR|2026-10-11
 python|GHSA-qh6h-p6c9-ff54|langchain-core prompts.loading path traversal (fixed in 1.2.22); requires langchain 0.3 → 1.x major bump, module unused in codebase; tracked with langchain migration PR|2026-10-11
+
+# langchain-core SSRF via image_url token counting in
+# ChatOpenAI.get_num_tokens_from_messages (low severity, freshly disclosed).
+# Fixed only in langchain-core 1.2.11 — same langchain 0.3 → 1.x major bump as
+# the entries above. The affected method is not called anywhere in this
+# codebase (verified via repo-wide grep for get_num_tokens_from_messages /
+# image_url), so no untrusted image URL ever reaches it.
+python|PYSEC-2026-2562|langchain-core SSRF in ChatOpenAI.get_num_tokens_from_messages (low; fixed in 1.2.11); requires langchain 0.3 → 1.x major bump, method unused in codebase; tracked with langchain migration PR|2026-10-11
+python|GHSA-2g6r-c272-w58r|langchain-core SSRF in ChatOpenAI.get_num_tokens_from_messages (low; fixed in 1.2.11); requires langchain 0.3 → 1.x major bump, method unused in codebase; tracked with langchain migration PR|2026-10-11


### PR DESCRIPTION
Two CI-greenness fixes that surfaced while merging the Dependabot backlog (#461–#468).

## 1. action-setup v6 pnpm version conflict (docs + screencast)
PR #462 bumped `pnpm/action-setup` to v6.0.9. Under v6, a `version:` input that differs from the root `packageManager: pnpm@8.15.1` is a **hard error** ("Multiple versions of pnpm specified … `ERR_PNPM_BAD_PM_VERSION`"), whereas v3/v4 silently tolerated it.
- Broke **Deploy Docs to GitHub Pages** on `main` (`deploy-docs.yml` pinned `version: 9`) at the pnpm-setup step.
- `screencast.yml` carried the same `version: 9` pin (manual dispatch) and would fail identically.

Fix: drop the `version: 9` input on both `ubuntu-latest` jobs so action-setup uses the repo-pinned 8.15.1 — consistent with `ci.yml` and local dev. Validated by dispatching `deploy-docs` on this branch: **Build Docusaurus succeeded** (pnpm setup + install + build); only the Pages deploy step was skipped by the `main`-only environment protection rule.

## 2. Newly-disclosed langchain-core advisory
`PYSEC-2026-2562` / CVE-2026-26013 (low-severity SSRF in `ChatOpenAI.get_num_tokens_from_messages`) was published against `langchain-core 0.3.86`, turning **Security Audit** red. Fixed only in langchain-core 1.2.11 (the same 0.3→1.x major bump already tracked in `security_audit_ignores.txt`); the affected method is unused in this repo (verified via grep). Added a time-boxed ignore. Local audit: `0 findings, 52 ignored`.

## Test plan
- [ ] Security Audit green
- [ ] Deploy Docs to GitHub Pages green on `main` after merge
- [ ] Full CI green