### PR TITLE
ci: cap OpenSSF Scorecard at 15m + bump setuptools to 83.0.0 (PYSEC-2026-3447)

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -14,6 +14,12 @@ jobs:
   analysis:
     name: Scorecard analysis
     runs-on: ubuntu-latest
+    # Healthy runs finish in ~40s. Guard against the scorecard binary
+    # occasionally hanging on an upstream API call: without this cap the
+    # job inherits GitHub's 6-hour default and a single stall shows up as
+    # a red/cancelled check on main for hours. Fail fast so it can just be
+    # re-run instead.
+    timeout-minutes: 15
     permissions:
       # Needed to publish results to the public Scorecard API (drives the
       # README badge at https://api.securityscorecards.dev/projects/...).

--- a/services/agents/poetry.lock
+++ b/services/agents/poetry.lock
@@ -4304,24 +4304,24 @@ files = [
 
 [[package]]
 name = "setuptools"
-version = "82.0.1"
+version = "83.0.0"
 description = "Most extensible Python build backend with support for C/C++ extension modules"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "setuptools-82.0.1-py3-none-any.whl", hash = "sha256:a59e362652f08dcd477c78bb6e7bd9d80a7995bc73ce773050228a348ce2e5bb"},
-    {file = "setuptools-82.0.1.tar.gz", hash = "sha256:7d872682c5d01cfde07da7bccc7b65469d3dca203318515ada1de5eda35efbf9"},
+    {file = "setuptools-83.0.0-py3-none-any.whl", hash = "sha256:29b23c360f22f414dc7336bb39178cc7bcbf6021ed2733cde173f09dba19abb3"},
+    {file = "setuptools-83.0.0.tar.gz", hash = "sha256:025bccbbf0fa05b6192bc64ae1e7b16e001fd6d6d4d5de03c97b1c1ade523bef"},
 ]
 
 [package.extras]
-check = ["pytest-checkdocs (>=2.4)", "pytest-ruff (>=0.2.1) ; sys_platform != \"cygwin\"", "ruff (>=0.13.0) ; sys_platform != \"cygwin\""]
+check = ["pytest-checkdocs (>=2.14)", "pytest-ruff (>=0.2.1) ; sys_platform != \"cygwin\"", "ruff (>=0.13.0) ; sys_platform != \"cygwin\""]
 core = ["importlib_metadata (>=6) ; python_version < \"3.10\"", "jaraco.functools (>=4)", "jaraco.text (>=3.7)", "more_itertools", "more_itertools (>=8.8)", "packaging (>=24.2)", "tomli (>=2.0.1) ; python_version < \"3.11\"", "wheel (>=0.43.0)"]
 cover = ["pytest-cov"]
 doc = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "pyproject-hooks (!=1.1)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-favicon", "sphinx-inline-tabs", "sphinx-lint", "sphinx-notfound-page (>=1,<2)", "sphinx-reredirects", "sphinxcontrib-towncrier", "towncrier (<24.7)"]
-enabler = ["pytest-enabler (>=2.2)"]
+enabler = ["pytest-enabler (>=3.4)"]
 test = ["build[virtualenv] (>=1.0.3)", "filelock (>=3.4.0)", "ini2toml[lite] (>=0.14)", "jaraco.develop (>=7.21) ; python_version >= \"3.9\" and sys_platform != \"cygwin\"", "jaraco.envs (>=2.2)", "jaraco.path (>=3.7.2)", "jaraco.test (>=5.5)", "packaging (>=24.2)", "pip (>=19.1)", "pyproject-hooks (!=1.1)", "pytest (>=6,!=8.1.*)", "pytest-home (>=0.5)", "pytest-perf ; sys_platform != \"cygwin\"", "pytest-subprocess", "pytest-timeout", "pytest-xdist (>=3)", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel (>=0.44.0)"]
-type = ["importlib_metadata (>=7.0.2) ; python_version < \"3.10\"", "jaraco.develop (>=7.21) ; sys_platform != \"cygwin\"", "mypy (==1.18.*)", "pytest-mypy"]
+type = ["importlib_metadata (>=7.0.2) ; python_version < \"3.10\"", "jaraco.develop (>=7.21) ; sys_platform != \"cygwin\"", "mypy (==1.18.*)", "pytest-mypy (>=1.0.1) ; platform_python_implementation != \"PyPy\""]
 
 [[package]]
 name = "shellingham"


### PR DESCRIPTION
Two fixes to get/keep `main` green.

## 1. OpenSSF Scorecard 6-hour hang
The Scorecard `analysis` job had no `timeout-minutes`, so when the scorecard binary hung on an upstream API call it inherited GitHub's **6-hour** default and was force-cancelled — a red/cancelled check on `main` for hours (run [29268794998](https://github.com/beenuar/AiSOC/actions/runs/29268794998)) even though healthy runs finish in ~40s. A re-run cleared it in 36s (transient). Added `timeout-minutes: 15` so any future stall fails fast and is trivially re-run.

## 2. Newly-disclosed setuptools advisory
`PYSEC-2026-3447` / CVE-2026-59890 (setuptools `MANIFEST.in` exclude directives bypassed via Unicode NFD/NFC filenames on macOS) turned **Security Audit** red. It's fixed in setuptools **83.0.0**, so bump the transitive pin in `services/agents` (the only lockfile carrying it — 82.0.1 → 83.0.0, isolated diff). Local audit: `0 findings, 52 ignored`.

## Test plan
- [ ] Security Audit green
- [ ] Scorecard analysis green on `main` after merge
- [ ] Full CI green