### PR TITLE
fix(web): build @aisoc/report-card in web image so /tools/coverage ships (v8 post-deploy hotfix)

### DIFF
--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -77,9 +77,12 @@ ENV NEXT_PUBLIC_DEMO_AUTOLOGIN_PASSWORD=${NEXT_PUBLIC_DEMO_AUTOLOGIN_PASSWORD}
 # so tsup/tsc bin shims resolve correctly inside each workspace package.
 RUN pnpm install --no-frozen-lockfile
 
-# Build workspace packages then the Next.js app.
+# Build workspace packages then the Next.js app. @aisoc/report-card must be
+# built here too — the /tools/coverage page imports it, and without its dist the
+# route silently drops from the build (404 in prod).
 RUN pnpm --filter @aisoc/types build && \
     pnpm --filter @aisoc/ui build && \
+    pnpm --filter @aisoc/report-card build && \
     pnpm --filter @aisoc/web build
 
 # ─── Runner ───────────────────────────────────────────────────────────────────

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -64,6 +64,10 @@ export default defineConfig({
   resolve: {
     alias: {
       '@': path.resolve(__dirname, './src'),
+      // @aisoc/report-card ships dist-based exports (built in the Docker image
+      // + turbo ^build). vitest runs without a prior build, so resolve it from
+      // source here — the package is pure TS with no build-time transform.
+      '@aisoc/report-card': path.resolve(__dirname, '../../packages/report-card/src/index.ts'),
     },
   },
 });

--- a/packages/aisoc-action/dist/index.js
+++ b/packages/aisoc-action/dist/index.js
@@ -353,7 +353,7 @@ async function fetchAlerts(client, owner, repo, sources) {
   return { alerts, notes };
 }
 
-// ../report-card/src/index.ts
+// ../report-card/dist/index.js
 function coverageGrade(percent) {
   if (percent >= 90) return "A";
   if (percent >= 75) return "B";

--- a/packages/report-card/package.json
+++ b/packages/report-card/package.json
@@ -4,13 +4,13 @@
   "description": "Shared, dependency-free renderer for AiSOC share cards (triage summaries, ATT&CK coverage grades, investigation-replay verdicts) as SVG + Markdown. Used by the aisoc CLI --share flag, the noise-tuning dashboard, and the web OG image routes.",
   "license": "MIT",
   "type": "module",
-  "main": "./src/index.ts",
-  "module": "./src/index.ts",
-  "types": "./src/index.ts",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "types": "./src/index.ts",
-      "import": "./src/index.ts"
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
     }
   },
   "files": ["dist", "src"],


### PR DESCRIPTION
Post-merge customer-journey review of tryaisoc.com found two issues from the v8 deploy:

1. **`/tools/coverage` → 404** — it's the only `/tools/*` page importing `@aisoc/report-card`, and the Fly web build's route table omitted it. Root cause: `apps/web/Dockerfile` builds `@aisoc/types` + `@aisoc/ui` before `next build` but **not** `@aisoc/report-card`, so its dist was absent and Next dropped the route.
2. **`/api/v1/r/demo-lockbit` → 500** — a transient migration soft-fail (Fly Postgres boot-race) meant migration `045` (published_replays) didn't apply on the prior deploy. Redeploying (this merge) re-runs `run_migrations.py`, which applies the pending `.sql` and re-seeds the demo replay.

## Fix
- `report-card`: dist-based exports (resolves in the Docker build once built), matching the `@aisoc/ui`/`@aisoc/types` pattern.
- `apps/web/Dockerfile`: build `@aisoc/report-card` before the web app.
- Keep `apps/web` tsconfig path `@aisoc/report-card` → src (tsc runs without a build); add the matching vitest alias → src (web-test runs without a build).
- Rebuild the committed `aisoc-action` bundle (dist-freshness gate).

## Test plan
- [x] `next build` emits `/tools/coverage`
- [x] aisoc-lite (22) + web tools (13) + action (6) tests green; web tsc green
- [x] docs build green
- [ ] post-merge: re-verify `/tools/coverage` 200 and `/r/demo-lockbit` on tryaisoc.com

Made with [Cursor](https://cursor.com)