### PR TITLE
fix(web): commit the /tools/coverage page (was gitignored) — v8 post-deploy hotfix 2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,11 @@ coverage.xml
 # uploaded as artefacts — never committed.
 coverage/
 **/coverage/
+# BUT keep app-source route directories literally named `coverage` (e.g. the
+# /tools/coverage page). The rules above are for generated test-coverage output;
+# without this negation the coverage tool page silently drops from the build.
+!apps/web/src/app/**/coverage/
+!apps/web/src/app/**/coverage/**
 *.lcov
 
 # IDE

--- a/apps/web/src/app/(tools)/tools/coverage/CoverageTool.tsx
+++ b/apps/web/src/app/(tools)/tools/coverage/CoverageTool.tsx
@@ -1,0 +1,118 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { renderCardSvg } from "@aisoc/report-card";
+
+import { gradeCoverage } from "../../../../lib/tools/coverage";
+
+const SAMPLE = `# Paste your Sigma rules (or a list of technique IDs).
+tags:
+  - attack.t1566
+  - attack.t1059.001
+  - attack.t1486
+  - attack.t1078`;
+
+const GRADE_COLOR: Record<string, string> = { A: "#22c55e", B: "#22c55e", C: "#fbbf24", D: "#fbbf24", F: "#f87171" };
+
+export function CoverageTool() {
+  const [text, setText] = useState(SAMPLE);
+  const report = useMemo(() => gradeCoverage(text), [text]);
+
+  const downloadCard = () => {
+    const svg = renderCardSvg({
+      kind: "coverage",
+      grade: report.grade,
+      covered: report.covered,
+      total: report.total,
+      percent: report.percent,
+      topUncovered: report.topUncovered.map((t) => t.id),
+    });
+    const blob = new Blob([svg], { type: "image/svg+xml" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = `aisoc-coverage-grade-${report.grade}.svg`;
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const gradeColor = GRADE_COLOR[report.grade] ?? "#f87171";
+
+  return (
+    <div style={{ display: "grid", gap: 20 }}>
+      <textarea
+        value={text}
+        onChange={(e) => setText(e.target.value)}
+        rows={8}
+        spellCheck={false}
+        style={{
+          width: "100%",
+          background: "#0b1020",
+          color: "#c4cae0",
+          border: "1px solid #232b4d",
+          borderRadius: 10,
+          padding: 14,
+          fontFamily: "ui-monospace,SFMono-Regular,Menlo,monospace",
+          fontSize: 13,
+          resize: "vertical",
+        }}
+      />
+
+      <div style={{ display: "flex", gap: 24, alignItems: "center", flexWrap: "wrap" }}>
+        <div style={{ fontSize: 96, fontWeight: 800, color: gradeColor, lineHeight: 1 }}>{report.grade}</div>
+        <div>
+          <div style={{ fontSize: 28, fontWeight: 700 }}>{report.percent}% coverage</div>
+          <div style={{ color: "#8b93b7" }}>
+            {report.covered} / {report.total} high-prevalence techniques covered
+          </div>
+        </div>
+        <button onClick={downloadCard} style={{ marginLeft: "auto", ...btn, padding: "10px 16px", fontWeight: 700 }}>
+          ↓ Download grade card
+        </button>
+      </div>
+
+      <div>
+        <h2 style={hdr}>Coverage by tactic</h2>
+        <div style={{ display: "grid", gap: 8 }}>
+          {report.byTactic.map((t) => {
+            const pct = t.total ? Math.round((t.covered / t.total) * 100) : 0;
+            return (
+              <div key={t.tactic} style={{ display: "grid", gridTemplateColumns: "180px 1fr 60px", gap: 10, alignItems: "center" }}>
+                <span style={{ color: "#c4cae0", fontSize: 13 }}>{t.tactic}</span>
+                <div style={{ background: "#232b4d", borderRadius: 6, height: 16, overflow: "hidden" }}>
+                  <div style={{ width: `${pct}%`, height: "100%", background: pct >= 60 ? "#22c55e" : pct >= 30 ? "#fbbf24" : "#f87171" }} />
+                </div>
+                <span style={{ color: "#8b93b7", fontSize: 12, textAlign: "right" }}>
+                  {t.covered}/{t.total}
+                </span>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+
+      <div>
+        <h2 style={hdr}>Top 10 highest-prevalence uncovered techniques</h2>
+        {report.topUncovered.length === 0 ? (
+          <p style={{ color: "#22c55e" }}>Nice — every catalog technique is covered.</p>
+        ) : (
+          <ol style={{ margin: 0, paddingLeft: 20, color: "#c4cae0", display: "grid", gap: 4 }}>
+            {report.topUncovered.map((t) => (
+              <li key={t.id} style={{ fontSize: 14 }}>
+                <code style={{ color: "#f87171" }}>{t.id}</code> {t.name} <span style={{ color: "#6b7394" }}>· {t.tactic}</span>
+              </li>
+            ))}
+          </ol>
+        )}
+      </div>
+
+      <p style={{ color: "#6b7394", fontSize: 12, margin: 0 }}>
+        Graded against a curated 40-technique high-prevalence catalog (a quick self-check, not an authoritative audit). Runs
+        entirely in your browser.
+      </p>
+    </div>
+  );
+}
+
+const btn: React.CSSProperties = { background: "#232b4d", color: "#e6e9f5", border: "none", borderRadius: 6, padding: "6px 12px", fontSize: 13, cursor: "pointer" };
+const hdr: React.CSSProperties = { fontSize: 14, textTransform: "uppercase", letterSpacing: 1, color: "#8b93b7", margin: "0 0 12px" };

--- a/apps/web/src/app/(tools)/tools/coverage/page.tsx
+++ b/apps/web/src/app/(tools)/tools/coverage/page.tsx
@@ -1,0 +1,42 @@
+import type { Metadata } from "next";
+
+import { getPublicSiteUrl } from "../../../../lib/site";
+import { CoverageTool } from "./CoverageTool";
+
+export const metadata: Metadata = {
+  title: "MITRE ATT&CK coverage grader for Sigma rules | AiSOC",
+  description:
+    "Paste your Sigma detection rules and get a free MITRE ATT&CK coverage grade (A–F), a per-tactic heatmap, and your top uncovered high-prevalence techniques. In-browser, open source.",
+  alternates: { canonical: `${getPublicSiteUrl()}/tools/coverage` },
+  openGraph: {
+    title: "MITRE ATT&CK coverage grader | AiSOC",
+    description: "Grade your detection coverage A–F and see your top uncovered techniques. Free & open source.",
+    url: `${getPublicSiteUrl()}/tools/coverage`,
+  },
+};
+
+const JSON_LD = {
+  "@context": "https://schema.org",
+  "@type": "SoftwareApplication",
+  name: "AiSOC ATT&CK Coverage Grader",
+  applicationCategory: "SecurityApplication",
+  operatingSystem: "Web",
+  offers: { "@type": "Offer", price: "0", priceCurrency: "USD" },
+  url: `${getPublicSiteUrl()}/tools/coverage`,
+};
+
+export default function CoveragePage() {
+  return (
+    <main>
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(JSON_LD) }} />
+      <h1 style={{ fontSize: 30, fontWeight: 800, margin: 0 }}>ATT&CK coverage grader</h1>
+      <p style={{ color: "#8b93b7", fontSize: 16, marginTop: 10, maxWidth: 680 }}>
+        Paste your Sigma rules (or a list of technique IDs) and get a coverage grade, a per-tactic heatmap, and the top
+        highest-prevalence techniques you&apos;re missing. Download a shareable grade card.
+      </p>
+      <div style={{ marginTop: 24 }}>
+        <CoverageTool />
+      </div>
+    </main>
+  );
+}


### PR DESCRIPTION
The `**/coverage/` gitignore rule silently excluded `apps/web/src/app/(tools)/tools/coverage/` (the coverage tool page), so `/tools/coverage` 404'd in prod despite passing CI (the tool *logic* in `lib/tools/coverage.ts` was tracked + tested; only the *page* was missing). Negated the ignore for app-source `coverage/` route dirs and committed the two files. Verified locally that `next build` emits `/tools/coverage`.

Made with [Cursor](https://cursor.com)