### PR TITLE
fix(api): widen migration connect-retry for Fly Postgres autostart (v8 post-deploy hotfix 3)

### DIFF
--- a/services/api/app/scripts/run_migrations.py
+++ b/services/api/app/scripts/run_migrations.py
@@ -114,9 +114,13 @@ async def _connect() -> asyncpg.Connection:
     """
     dsn, kwargs = _asyncpg_dsn(str(settings.DATABASE_URL))
     last_exc: Exception | None = None
-    for attempt in range(1, 7):  # ~30 s total at the back-off schedule below
+    # ~3 min total window (see the back-off below). On the Fly demo, the
+    # release_command machine is often the *first* thing to touch the Postgres
+    # app after autostop, so it must wait out a full autostart + cold boot — a
+    # 30 s window let migrations soft-fail and ship code against a stale schema.
+    for attempt in range(1, 11):
         try:
-            return await asyncpg.connect(dsn, **kwargs)
+            return await asyncpg.connect(dsn, timeout=10, **kwargs)
         except (
             asyncpg.exceptions.ConnectionDoesNotExistError,
             asyncpg.exceptions.CannotConnectNowError,
@@ -124,7 +128,7 @@ async def _connect() -> asyncpg.Connection:
             OSError,
         ) as exc:
             last_exc = exc
-            delay = min(2 ** (attempt - 1), 8)
+            delay = min(2 ** (attempt - 1), 12)
             logger.warning(
                 "asyncpg.connect failed on attempt %d (%s: %s); retrying in %ds",
                 attempt,


### PR DESCRIPTION
The hosted-demo replay endpoint `/api/v1/r/demo-lockbit` 500s because migration `045` (published_replays) never applied: the `release_command` runner's ~30s connect window was too short to ride out the demo's autostop Postgres cold-boot, so it soft-failed (AISOC_MIGRATIONS_REQUIRED=0) and shipped code against a stale schema. Widen to ~3 min (10 attempts, 10s per-attempt timeout, backoff cap 8→12s). Merging forces a fresh API image → the release_command re-runs migrations against a now-reachable DB → 045 applies + seed_demo populates the demo replay. Existing `test_run_migrations_retry.py` contract preserved.

Made with [Cursor](https://cursor.com)