### PR TITLE
fix(qa): restore hosted demo — Postgres pool + waitlist funnel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -269,6 +269,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+
+- **Hosted demo API 500s from stale Postgres pool + broken waitlist funnel (QA 2026-07-19).**
+  Live `/health` showed `demo_bootstrap.last_error_type=create_seed:ConnectionDoesNotExistError`
+  after 22 attempts — Fly Postgres autostop closed pooled sockets and every
+  subsequent checkout 500ed (`/api/v1/auth/login`, `/metrics/*`, `/alerts/*`,
+  `/cases` → 503). Fixes: (1) `pool_pre_ping=True` + `pool_recycle=300` on the
+  SQLAlchemy engine; (2) demo self-heal bootstrap now disposes the pool after
+  every disconnect, splits create_all / SQL migrations / seed into separate
+  steps, and surfaces stage-tagged errors on `/health`; (3) demo-mode middleware
+  allowlists `POST /api/v1/waitlist/signup` so the managed-instance conversion
+  funnel on tryaisoc.com is no longer 403ed for every visitor.
+
+
 - **Out-of-the-box 500 from schema drift on migration-bootstrapped installs (#492).**
   `docker-compose.yml` mounts `services/api/migrations` into
   `/docker-entrypoint-initdb.d`, so a fresh compose stack builds Postgres from

--- a/services/api/app/core/config.py
+++ b/services/api/app/core/config.py
@@ -268,6 +268,11 @@ class Settings(BaseSettings):
     DATABASE_URL: PostgresDsn = "postgresql+asyncpg://aisoc:aisoc_dev_secret@localhost:5432/aisoc"  # type: ignore[assignment]
     DATABASE_POOL_SIZE: int = 20
     DATABASE_MAX_OVERFLOW: int = 10
+    # Recycle pooled connections before managed Postgres idle-closes them.
+    # Fly Postgres autostop + idle TCP teardown made stale pool entries the
+    # dominant source of ``ConnectionDoesNotExistError`` 500s on the hosted
+    # demo; 300s is well under typical idle timeouts while keeping churn low.
+    DATABASE_POOL_RECYCLE_SECONDS: int = 300
 
     # Redis
     REDIS_URL: RedisDsn = "redis://localhost:6379/0"  # type: ignore[assignment]

--- a/services/api/app/db/database.py
+++ b/services/api/app/db/database.py
@@ -68,10 +68,18 @@ def _normalize_async_pg_url(url: str) -> tuple[str, dict[str, Any]]:
 
 _normalized_url, _connect_args = _normalize_async_pg_url(str(settings.DATABASE_URL))
 
+# pool_pre_ping + pool_recycle are required for Fly Postgres (and any
+# managed Postgres that autostops / idle-closes). Without pre_ping the
+# pool hands out sockets that the server already closed, and asyncpg
+# surfaces that as ``ConnectionDoesNotExistError`` on the next query —
+# which is exactly what was 500ing every demo endpoint on tryaisoc.com
+# (auth/login, metrics/*, alerts/*, …) while /health still looked fine.
 engine = create_async_engine(
     _normalized_url,
     pool_size=settings.DATABASE_POOL_SIZE,
     max_overflow=settings.DATABASE_MAX_OVERFLOW,
+    pool_pre_ping=True,
+    pool_recycle=settings.DATABASE_POOL_RECYCLE_SECONDS,
     echo=settings.DEBUG,
     future=True,
     connect_args=_connect_args,

--- a/services/api/app/main.py
+++ b/services/api/app/main.py
@@ -146,9 +146,7 @@ async def _demo_self_heal_bootstrap() -> None:
             async with AsyncSessionLocal() as session:
                 await session.execute(text("SELECT 1"))  # wake / confirm connectivity
                 _DEMO_BOOTSTRAP_STATUS["reachable"] = True
-                seeded = await session.scalar(
-                    select(PublishedReplay.id).where(PublishedReplay.slug == CANONICAL_REPLAY_SLUG)
-                )
+                seeded = await session.scalar(select(PublishedReplay.id).where(PublishedReplay.slug == CANONICAL_REPLAY_SLUG))
                 _DEMO_BOOTSTRAP_STATUS["table_present"] = True
             if seeded:
                 _DEMO_BOOTSTRAP_STATUS.update(seeded=True, done=True, last_error_type=None)

--- a/services/api/app/main.py
+++ b/services/api/app/main.py
@@ -82,6 +82,26 @@ _DEMO_BOOTSTRAP_STATUS: dict[str, object] = {
 }
 
 
+async def _invalidate_stale_db_pool(reason: str) -> None:
+    """Drop every pooled connection after a mid-flight disconnect.
+
+    Fly Postgres autostop (and idle TCP teardown) closes the server side of a
+    pooled socket without the client noticing. The next checkout then raises
+    ``ConnectionDoesNotExistError``. Disposing the pool forces fresh connects
+    on the next attempt — critical for the hosted demo where this was the
+    dominant cause of out-of-the-box 500s.
+    """
+    try:
+        await engine.dispose()
+        logger.info("demo bootstrap: disposed DB pool after %s", reason)
+    except Exception as dispose_exc:  # noqa: BLE001 — best-effort; next attempt still retries
+        logger.warning(
+            "demo bootstrap: engine.dispose failed after %s: %s",
+            reason,
+            type(dispose_exc).__name__,
+        )
+
+
 async def _demo_self_heal_bootstrap() -> None:
     """Best-effort schema + seed bootstrap for the hosted demo, run in the background.
 
@@ -93,10 +113,13 @@ async def _demo_self_heal_bootstrap() -> None:
     bare ``asyncpg`` connect (what ``run_migrations`` uses) is unreliable here,
     which is why the release_command never applied 045. So we do everything
     through the engine: periodically create any missing ORM tables (``checkfirst``
-    skips existing ones) and, when the canonical replay is absent, run the
-    idempotent demo seed — retrying for a while so it lands whenever Postgres
-    becomes reachable. Detached from boot so it never blocks readiness; every
-    failure is logged and swallowed.
+    skips existing ones), apply pending SQL migrations, and, when the canonical
+    replay is absent, run the idempotent demo seed — retrying for a while so it
+    lands whenever Postgres becomes reachable. Detached from boot so it never
+    blocks readiness; every failure is logged and swallowed.
+
+    Each failed attempt disposes the SQLAlchemy pool so the next tick does not
+    reuse a socket the server already closed (``ConnectionDoesNotExistError``).
     """
     from sqlalchemy import select, text  # noqa: PLC0415
 
@@ -123,7 +146,9 @@ async def _demo_self_heal_bootstrap() -> None:
             async with AsyncSessionLocal() as session:
                 await session.execute(text("SELECT 1"))  # wake / confirm connectivity
                 _DEMO_BOOTSTRAP_STATUS["reachable"] = True
-                seeded = await session.scalar(select(PublishedReplay.id).where(PublishedReplay.slug == CANONICAL_REPLAY_SLUG))
+                seeded = await session.scalar(
+                    select(PublishedReplay.id).where(PublishedReplay.slug == CANONICAL_REPLAY_SLUG)
+                )
                 _DEMO_BOOTSTRAP_STATUS["table_present"] = True
             if seeded:
                 _DEMO_BOOTSTRAP_STATUS.update(seeded=True, done=True, last_error_type=None)
@@ -132,23 +157,54 @@ async def _demo_self_heal_bootstrap() -> None:
         except Exception as exc:  # noqa: BLE001 — table-missing or DB-unreachable; create below
             _DEMO_BOOTSTRAP_STATUS["last_error_type"] = f"probe:{type(exc).__name__}"
             logger.info("demo bootstrap: schema not ready (attempt %d/40): %s", attempt, type(exc).__name__)
+            await _invalidate_stale_db_pool(f"probe:{type(exc).__name__}")
 
+        # ── Step A: create missing ORM tables via the engine ─────────────────
         try:
-            # Create any missing ORM tables (incl. published_replays) via the
-            # ENGINE — the path that reliably reaches the demo's Fly Postgres.
-            # checkfirst (create_all default) skips existing tables, so this only
-            # fills the gap the soft-failed migration left. Then seed the
-            # canonical replay + demo data through the same engine-backed session.
             async with engine.begin() as conn:
                 await conn.run_sync(Base.metadata.create_all)
             _DEMO_BOOTSTRAP_STATUS["table_present"] = True
+        except Exception as exc:  # noqa: BLE001 — Postgres likely still waking
+            _DEMO_BOOTSTRAP_STATUS["last_error_type"] = f"create_all:{type(exc).__name__}"
+            logger.info(
+                "demo bootstrap: create_all deferred (attempt %d/40): %s",
+                attempt,
+                type(exc).__name__,
+            )
+            await _invalidate_stale_db_pool(f"create_all:{type(exc).__name__}")
+            await asyncio.sleep(45)
+            continue
+
+        # ── Step B: apply pending SQL migrations (fills columns create_all
+        #    cannot add to existing tables — e.g. 046 detection_rules drift).
+        try:
+            from app.scripts.run_migrations import main as run_sql_migrations  # noqa: PLC0415
+
+            await run_sql_migrations()
+        except Exception as exc:  # noqa: BLE001 — soft-fail; seed may still work via ORM
+            _DEMO_BOOTSTRAP_STATUS["last_error_type"] = f"migrate:{type(exc).__name__}"
+            logger.info(
+                "demo bootstrap: SQL migrations deferred (attempt %d/40): %s",
+                attempt,
+                type(exc).__name__,
+            )
+            await _invalidate_stale_db_pool(f"migrate:{type(exc).__name__}")
+            # Don't continue — still try the seed; create_all may be enough.
+
+        # ── Step C: idempotent full seed ─────────────────────────────────────
+        try:
             await _run_full_seed()
             _DEMO_BOOTSTRAP_STATUS.update(seeded=True, done=True, last_error_type=None)
             logger.info("demo bootstrap: create_all + seed pass complete (attempt %d)", attempt)
             return
         except Exception as exc:  # noqa: BLE001 — Postgres likely still waking; retry next tick
-            _DEMO_BOOTSTRAP_STATUS["last_error_type"] = f"create_seed:{type(exc).__name__}"
-            logger.info("demo bootstrap: create_all+seed deferred (attempt %d/40): %s", attempt, type(exc).__name__)
+            _DEMO_BOOTSTRAP_STATUS["last_error_type"] = f"seed:{type(exc).__name__}"
+            logger.info(
+                "demo bootstrap: seed deferred (attempt %d/40): %s",
+                attempt,
+                type(exc).__name__,
+            )
+            await _invalidate_stale_db_pool(f"seed:{type(exc).__name__}")
 
         await asyncio.sleep(45)
 

--- a/services/api/app/middleware/demo_mode.py
+++ b/services/api/app/middleware/demo_mode.py
@@ -42,6 +42,11 @@ _ALWAYS_ALLOWED_PREFIXES: tuple[str, ...] = (
     "/api/openapi.json",
     "/api/v1/auth/",
     "/api/v1/dev-auth",
+    # Managed-instance waitlist lives on tryaisoc.com itself — blocking the
+    # POST under demo mode made the public conversion funnel 403 for every
+    # visitor (QA 2026-07-19). Waitlist rows are a separate table from the
+    # demo SOC dataset, so writes here do not corrupt the shared demo.
+    "/api/v1/waitlist/",
     "/saml/",
     "/oidc/",
 )

--- a/services/api/tests/test_database_pool.py
+++ b/services/api/tests/test_database_pool.py
@@ -1,0 +1,61 @@
+"""Pin the SQLAlchemy pool settings that keep Fly Postgres usable.
+
+Without ``pool_pre_ping`` the pool hands out sockets the managed Postgres
+already closed (autostop / idle teardown). The next query then raises
+``asyncpg.exceptions.ConnectionDoesNotExistError``, which is what was
+500ing every demo endpoint on tryaisoc.com while ``/health`` still looked
+fine. These tests are import-free (parse the source) so they run in the
+same lightweight CI job as the schema-drift guards — no full API dep set
+required.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+_API_ROOT = Path(__file__).resolve().parents[1]
+_DATABASE_PY = _API_ROOT / "app" / "db" / "database.py"
+_CONFIG_PY = _API_ROOT / "app" / "core" / "config.py"
+_MAIN_PY = _API_ROOT / "app" / "main.py"
+
+
+def test_engine_enables_pool_pre_ping():
+    src = _DATABASE_PY.read_text(encoding="utf-8")
+    assert "pool_pre_ping=True" in src, (
+        "create_async_engine must set pool_pre_ping=True — without it Fly "
+        "Postgres autostop produces ConnectionDoesNotExistError 500s on every "
+        "demo endpoint"
+    )
+
+
+def test_engine_recycles_pooled_connections():
+    src = _DATABASE_PY.read_text(encoding="utf-8")
+    assert "pool_recycle=" in src, "create_async_engine must set pool_recycle"
+    assert "DATABASE_POOL_RECYCLE_SECONDS" in src
+
+
+def test_pool_recycle_setting_defaults_to_five_minutes():
+    src = _CONFIG_PY.read_text(encoding="utf-8")
+    match = re.search(
+        r"DATABASE_POOL_RECYCLE_SECONDS:\s*int\s*=\s*(\d+)",
+        src,
+    )
+    assert match, "DATABASE_POOL_RECYCLE_SECONDS must be declared on Settings"
+    assert int(match.group(1)) == 300
+
+
+def test_demo_bootstrap_disposes_pool_on_connection_errors():
+    """The self-heal loop must invalidate the pool after a disconnect.
+
+    Otherwise every retry reuses the same dead socket and the hosted demo
+    stays 500ing for the full ~30 min budget (what /health.demo_bootstrap
+    showed on 2026-07-19: 22 attempts, all ConnectionDoesNotExistError).
+    """
+    src = _MAIN_PY.read_text(encoding="utf-8")
+    assert "async def _invalidate_stale_db_pool" in src
+    assert "await engine.dispose()" in src
+    # Every failure path in the bootstrap must call the invalidator.
+    for stage in ("probe:", "create_all:", "migrate:", "seed:"):
+        assert stage in src, f"bootstrap must tag failures as {stage!r}"
+    assert src.count("await _invalidate_stale_db_pool(") >= 3

--- a/services/api/tests/test_demo_mode.py
+++ b/services/api/tests/test_demo_mode.py
@@ -62,6 +62,10 @@ def app(monkeypatch: pytest.MonkeyPatch) -> FastAPI:
     def login() -> dict[str, Any]:
         return {"token": "fake"}
 
+    @app.post("/api/v1/waitlist/signup")
+    def waitlist_signup() -> dict[str, Any]:
+        return {"ok": True}
+
     return app
 
 
@@ -168,6 +172,30 @@ def test_auth_login_is_allowed(app: FastAPI) -> None:
     r = client.post("/api/v1/auth/login", json={"username": "demo", "password": "demo"})
     assert r.status_code == 200
     assert r.json() == {"token": "fake"}
+
+
+def test_waitlist_signup_is_allowed(app: FastAPI) -> None:
+    """Managed-instance waitlist must accept signups on the public demo host.
+
+    ``/waitlist`` is the conversion funnel for tryaisoc.com. Demo-mode must
+    not 403 the POST — waitlist rows are not part of the shared demo SOC
+    dataset, so allowing the write does not let visitors mutate the canned
+    alerts/cases every other visitor sees.
+    """
+    client = TestClient(app)
+    r = client.post(
+        "/api/v1/waitlist/signup",
+        json={
+            "email": "champ@acme.com",
+            "company": "Acme",
+            "role": "SOC Manager",
+            "soc_stack": ["Splunk"],
+            "motivation": "Alert volume is drowning the team.",
+        },
+    )
+    assert r.status_code == 200
+    assert r.json() == {"ok": True}
+    assert r.headers["X-AiSOC-Demo"] == "true"
 
 
 def test_options_preflight_is_allowed(app: FastAPI) -> None:


### PR DESCRIPTION
## Summary
- **ISSUE-001:** Hosted demo on tryaisoc.com was 500ing every `/api/v1/*` call (`auth/login`, metrics, alerts, cases→503) while `/health` reported `demo_bootstrap.last_error_type=create_seed:ConnectionDoesNotExistError` after 22 attempts. Root cause: SQLAlchemy pool reused sockets that Fly Postgres autostop already closed. Fix: `pool_pre_ping` + `pool_recycle=300`, and demo self-heal bootstrap now disposes the pool after every disconnect and stages create_all / SQL migrations / seed.
- **ISSUE-002:** `POST /api/v1/waitlist/signup` was blocked by `DemoModeMiddleware` (`demo_mode_read_only`), so the managed-instance conversion funnel on tryaisoc.com could never submit. Allowlisted `/api/v1/waitlist/`.
- Full QA report: `.gstack/qa-reports/qa-report-tryaisoc-com-2026-07-19.md` (local; `.gstack/` is gitignored).

## Test plan
- [x] `uvx pytest services/api/tests/test_database_pool.py` — 4 passed
- [ ] CI: Python lint + API unit tests (incl. `test_demo_mode.py` waitlist allowlist)
- [ ] After merge + Fly deploy: `https://api.tryaisoc.com/health` shows `demo_bootstrap.done=true`
- [ ] `https://tryaisoc.com/dashboard` — metrics banners gone / live data
- [ ] `https://tryaisoc.com/waitlist` — Request access → 200 (not 403)


Made with [Cursor](https://cursor.com)