### PR TITLE
fix(demo): recover startup from port and agents dependency failures

### DIFF
--- a/infra/compose/docker-compose.demo.yml
+++ b/infra/compose/docker-compose.demo.yml
@@ -27,6 +27,8 @@
 # rotate the password while you're there.
 ###############################################################################
 
+name: aisoc-demo
+
 networks:
   aisoc-demo:
     driver: bridge
@@ -37,7 +39,6 @@ volumes:
   kafka_demo_data:
 
 services:
-
   # ─── Infrastructure ─────────────────────────────────────────────────────────
 
   postgres:
@@ -165,7 +166,11 @@ services:
       - aisoc-demo
     restart: unless-stopped
     healthcheck:
-      test: ["CMD-SHELL", "python -c 'import urllib.request; urllib.request.urlopen(\"http://localhost:8000/health\")' || exit 1"]
+      test:
+        [
+          "CMD-SHELL",
+          'python -c ''import urllib.request; urllib.request.urlopen("http://localhost:8000/health")'' || exit 1',
+        ]
       interval: 10s
       timeout: 5s
       retries: 10

--- a/scripts/aisoc-demo.ts
+++ b/scripts/aisoc-demo.ts
@@ -255,6 +255,23 @@ function runStream(cmd: string, args: string[], env: NodeJS.ProcessEnv = {}): nu
   return result.status ?? 1;
 }
 
+function runCaptured(
+  cmd: string,
+  args: string[],
+  env: NodeJS.ProcessEnv = {}
+): { code: number; output: string } {
+  const result = spawnSync(cmd, args, {
+    encoding: "utf8",
+    cwd: ROOT,
+    env: { ...process.env, ...env },
+  });
+  const stdout = result.stdout ?? "";
+  const stderr = result.stderr ?? "";
+  process.stdout.write(stdout);
+  process.stderr.write(stderr);
+  return { code: result.status ?? 1, output: `${stdout}\n${stderr}` };
+}
+
 async function probePort(host: string, port: number, timeoutMs = 1500): Promise<boolean> {
   return new Promise((resolve) => {
     const sock = createConnection({ host, port });
@@ -291,6 +308,7 @@ async function probePort(host: string, port: number, timeoutMs = 1500): Promise<
 interface PortMap {
   web: number;
   api: number;
+  agents: number;
   realtime: number;
   postgres: number;
   redis: number;
@@ -300,6 +318,7 @@ interface PortMap {
 const DEFAULT_PORTS: PortMap = {
   web: 3000,
   api: 8000,
+  agents: 8001,
   realtime: 8086,
   postgres: 5432,
   redis: 6379,
@@ -340,7 +359,7 @@ async function pickFreePort(start: number, max = 50): Promise<number> {
   }
   throw new Error(
     `no free TCP port near ${start} (checked ${start}..${start + max - 1}). ` +
-      `Free one of them or stop the conflicting process and retry.`,
+      `Free one of them or stop the conflicting process and retry.`
   );
 }
 
@@ -352,11 +371,14 @@ async function allocatePorts(): Promise<{
   // taken 3000 doesn't push api off 8000. Each starts from its canonical
   // default and only moves if forced.
   const ports = { ...DEFAULT_PORTS };
+  const reserved = new Set<number>();
   const reassigned: Array<{ service: keyof PortMap; from: number; to: number }> = [];
   for (const service of Object.keys(DEFAULT_PORTS) as Array<keyof PortMap>) {
     const def = DEFAULT_PORTS[service];
-    const free = await pickFreePort(def);
+    let free = await pickFreePort(def);
+    while (reserved.has(free)) free = await pickFreePort(free + 1);
     ports[service] = free;
+    reserved.add(free);
     if (free !== def) reassigned.push({ service, from: def, to: free });
   }
   return { ports, reassigned };
@@ -399,7 +421,7 @@ async function waitFor(
   label: string,
   check: () => Promise<boolean>,
   timeoutMs: number,
-  pollMs = 2000,
+  pollMs = 2000
 ): Promise<boolean> {
   const deadline = Date.now() + timeoutMs;
   process.stdout.write(`   ${c.dim(`waiting for ${label}…`)} `);
@@ -473,7 +495,9 @@ function checkDocker(): boolean {
   const docker = tryRun("docker --version");
   if (!docker) {
     console.error(
-      c.red("docker is not installed or not on PATH.\n  Install Docker Desktop: https://www.docker.com/products/docker-desktop"),
+      c.red(
+        "docker is not installed or not on PATH.\n  Install Docker Desktop: https://www.docker.com/products/docker-desktop"
+      )
     );
     return false;
   }
@@ -491,17 +515,16 @@ function checkDocker(): boolean {
   // through cmd's mangled quoting. Use spawnSync directly with shell:false
   // so the args are passed verbatim to docker.exe and the quoting layer
   // is removed entirely.
-  const infoResult = spawnSync(
-    "docker",
-    ["info", "--format", "{{.ServerVersion}}"],
-    { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] },
-  );
+  const infoResult = spawnSync("docker", ["info", "--format", "{{.ServerVersion}}"], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
   const info = infoResult.status === 0 ? infoResult.stdout.trim() : "";
   if (!info) {
     console.error(
       c.red(
-        "docker daemon is not running. Start Docker Desktop (or `sudo systemctl start docker` on Linux) and retry.",
-      ),
+        "docker daemon is not running. Start Docker Desktop (or `sudo systemctl start docker` on Linux) and retry."
+      )
     );
     return false;
   }
@@ -526,8 +549,8 @@ function pullImages(flags: Flags): boolean {
     console.error(
       c.yellow(
         "image pull failed; falling back to local build. " +
-          "Use --rebuild to force building from source.",
-      ),
+          "Use --rebuild to force building from source."
+      )
     );
     flags.rebuild = true;
   }
@@ -538,6 +561,7 @@ function portEnv(ports: PortMap): NodeJS.ProcessEnv {
   return {
     AISOC_WEB_PORT: String(ports.web),
     AISOC_API_PORT: String(ports.api),
+    AISOC_AGENTS_PORT: String(ports.agents),
     AISOC_REALTIME_PORT: String(ports.realtime),
     AISOC_POSTGRES_PORT: String(ports.postgres),
     AISOC_REDIS_PORT: String(ports.redis),
@@ -553,37 +577,52 @@ async function startStack(flags: Flags): Promise<boolean> {
   // surfaced in the script's own output instead of buried in a docker
   // compose error wall. Module-level so the rest of the script can read
   // the resolved values without threading them through every signature.
-  let reassigned: Array<{ service: keyof PortMap; from: number; to: number }> = [];
-  try {
-    const alloc = await allocatePorts();
-    allocatedPorts = alloc.ports;
-    reassigned = alloc.reassigned;
-  } catch (e: any) {
-    console.error(c.red(`port allocation failed: ${e?.message ?? e}`));
-    return false;
-  }
-  if (reassigned.length > 0) {
-    for (const r of reassigned) {
-      log(
-        c.yellow("port") +
-          ` ${r.service} ${c.dim(String(r.from))} in use → using ${c.bold(String(r.to))}`,
-      );
-    }
-  } else {
-    log(c.green("ok") + " all canonical ports free");
-  }
-
   const args = ["compose", "-f", COMPOSE_FILE, "up", "-d"];
   if (flags.rebuild) args.push("--build");
-  const code = runStream("docker", args, {
-    AISOC_TAG: flags.tag,
-    ...portEnv(allocatedPorts),
-  });
-  if (code !== 0) {
-    console.error(c.red("docker compose up failed. See output above."));
-    return false;
+
+  const maxAttempts = 3;
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    let reassigned: Array<{ service: keyof PortMap; from: number; to: number }> = [];
+    try {
+      const alloc = await allocatePorts();
+      allocatedPorts = alloc.ports;
+      reassigned = alloc.reassigned;
+    } catch (e: any) {
+      console.error(c.red(`port allocation failed: ${e?.message ?? e}`));
+      return false;
+    }
+    if (reassigned.length > 0) {
+      for (const r of reassigned) {
+        log(
+          c.yellow("port") +
+            ` ${r.service} ${c.dim(String(r.from))} in use → using ${c.bold(String(r.to))}`
+        );
+      }
+    } else {
+      log(c.green("ok") + " all canonical ports free");
+    }
+
+    const result = runCaptured("docker", args, {
+      AISOC_TAG: flags.tag,
+      ...portEnv(allocatedPorts),
+    });
+    if (result.code === 0) return true;
+
+    const portConflict =
+      /address already in use|port is already allocated|failed to bind host port/i.test(
+        result.output
+      );
+    if (!portConflict || attempt === maxAttempts) {
+      console.error(c.red("docker compose up failed. See output above."));
+      return false;
+    }
+    log(
+      c.yellow(
+        `port became unavailable during startup; retrying with new ports (${attempt + 1}/${maxAttempts})`
+      )
+    );
   }
-  return true;
+  return false;
 }
 
 async function waitForHealth(): Promise<boolean> {
@@ -593,21 +632,18 @@ async function waitForHealth(): Promise<boolean> {
     "postgres",
     async () => probePort("127.0.0.1", allocatedPorts.postgres),
     60_000,
-    1000,
+    1000
   );
   if (!postgresUp) return false;
 
   const apiUp = await waitFor(
     "api /health",
     async () => {
-      const j = await fetchJson(
-        `http://localhost:${allocatedPorts.api}/health`,
-        1500,
-      );
+      const j = await fetchJson(`http://localhost:${allocatedPorts.api}/health`, 1500);
       return j !== null;
     },
     120_000,
-    2000,
+    2000
   );
   if (!apiUp) return false;
 
@@ -624,7 +660,7 @@ async function waitForHealth(): Promise<boolean> {
       }
     },
     120_000,
-    2000,
+    2000
   );
   if (!webUp) {
     console.error(c.yellow("web is slow to start; continuing anyway"));
@@ -671,8 +707,8 @@ function seedData(flags: Flags): boolean {
   if (code !== 0) {
     console.error(
       c.yellow(
-        "seed re-run returned non-zero. The stack is likely already seeded by the one-shot `seed` container; continuing.",
-      ),
+        "seed re-run returned non-zero. The stack is likely already seeded by the one-shot `seed` container; continuing."
+      )
     );
   }
   return true;
@@ -691,17 +727,15 @@ function sanitizeCaseId(id: unknown): string | null {
 }
 
 async function findSeededCase(
-  flags: Flags,
+  flags: Flags
 ): Promise<{ id: string; case_number: string; title: string } | null> {
-  const showcase = flags.demoQuick
-    ? SHOWCASE_CASE_NUMBER_QUICK
-    : SHOWCASE_CASE_NUMBER_FULL;
+  const showcase = flags.demoQuick ? SHOWCASE_CASE_NUMBER_QUICK : SHOWCASE_CASE_NUMBER_FULL;
   step(
     6,
     7,
     flags.demoQuick
       ? `Locating the DEMO-004 ransomware case (--demo-quick)`
-      : "Locating the showcase ransomware investigation",
+      : "Locating the showcase ransomware investigation"
   );
   // The dev-mode auth bypass returns the demo user/tenant for unauthenticated
   // requests when ENV=development, so we can hit /v1/cases without a token.
@@ -719,12 +753,10 @@ async function findSeededCase(
     // currently expose that filter, and the volume is trivially small.
     const res = await fetchJson(
       `http://localhost:${allocatedPorts.api}/v1/cases?page_size=50`,
-      4000,
+      4000
     );
     if (res && Array.isArray(res.items) && res.items.length > 0) {
-      const found = res.items.find(
-        (item: any) => item.case_number === showcase,
-      );
+      const found = res.items.find((item: any) => item.case_number === showcase);
       const target = found ?? res.items[0];
       const safeId = sanitizeCaseId(target.id);
       if (!safeId) {
@@ -734,10 +766,7 @@ async function findSeededCase(
       if (found) {
         log(c.green("ok") + ` found showcase ${target.case_number} (${safeId})`);
       } else {
-        log(
-          c.yellow("warn") +
-            ` ${showcase} not found; falling back to ${target.case_number}`,
-        );
+        log(c.yellow("warn") + ` ${showcase} not found; falling back to ${target.case_number}`);
       }
       return { id: safeId, case_number: target.case_number, title: target.title };
     }
@@ -745,8 +774,8 @@ async function findSeededCase(
   }
   console.error(
     c.yellow(
-      "no seeded cases visible after 60s. The web console will still open, but to a blank cases list.",
-    ),
+      "no seeded cases visible after 60s. The web console will still open, but to a blank cases list."
+    )
   );
   return null;
 }
@@ -758,13 +787,16 @@ async function kickoffInvestigation(caseId: string): Promise<boolean> {
   const result = await postJson(
     `http://localhost:${allocatedPorts.api}/v1/cases/${caseId}/investigate`,
     {},
-    10000,
+    10000
   );
   if (result) {
     log(c.green("ok") + ` investigation queued (run_id ${result.run_id ?? "unknown"})`);
     return true;
   }
-  log(c.yellow("note") + " could not auto-launch investigation (no LLM key?). The case is still browsable.");
+  log(
+    c.yellow("note") +
+      " could not auto-launch investigation (no LLM key?). The case is still browsable."
+  );
   return false;
 }
 
@@ -779,7 +811,7 @@ function sanitizeCaseNumber(num: unknown): string | null {
 
 async function openInBrowser(
   seeded: { id: string; case_number: string; title: string } | null,
-  flags: Flags,
+  flags: Flags
 ) {
   // Prefer routing by human-readable case_number with the ledger tab
   // pre-selected — that's the same URL the hosted demo uses and what
@@ -800,7 +832,11 @@ async function openInBrowser(
   } else if (isHeadless()) {
     // CI, headless server, or AISOC_NO_BROWSER=1. Don't try to spawn a
     // GUI process the user can't see — just leave the URL in the banner.
-    log(c.dim("headless environment detected — not launching browser (set AISOC_NO_BROWSER=0 to override)"));
+    log(
+      c.dim(
+        "headless environment detected — not launching browser (set AISOC_NO_BROWSER=0 to override)"
+      )
+    );
   } else {
     openBrowser(url);
   }
@@ -850,7 +886,7 @@ interface RunReport {
 function buildReport(
   flags: Flags,
   showcaseCaseFound: boolean,
-  investigationKickedOff: boolean,
+  investigationKickedOff: boolean
 ): RunReport {
   closeLastPhase();
   const totalMs = Date.now() - STARTED_AT;
@@ -884,28 +920,23 @@ function printPhaseTable(report: RunReport): void {
   const rows = report.phases.map((p) => [p.name, p.label, `${p.durationMs}ms`]);
   const headers = ["Phase", "Duration", "ms"];
   const all = [headers, ...rows];
-  const widths = headers.map((_, i) =>
-    Math.max(...all.map((row) => row[i].length)),
-  );
-  const fmt = (row: string[]) =>
-    "  " + row.map((cell, i) => cell.padEnd(widths[i])).join("  ");
+  const widths = headers.map((_, i) => Math.max(...all.map((row) => row[i].length)));
+  const fmt = (row: string[]) => "  " + row.map((cell, i) => cell.padEnd(widths[i])).join("  ");
   console.log(c.dim(fmt(headers)));
   console.log(c.dim("  " + widths.map((w) => "-".repeat(w)).join("  ")));
   for (const row of rows) console.log(fmt(row));
-  console.log(
-    `\n  ${c.bold("Total:")} ${c.green(report.totalLabel)} (${report.totalMs}ms)`,
-  );
+  console.log(`\n  ${c.bold("Total:")} ${c.green(report.totalLabel)} (${report.totalMs}ms)`);
   if (report.budgetMs !== null) {
     const budgetLabel = formatMs(report.budgetMs);
     if (report.withinBudget) {
       console.log(
         `  ${c.bold("Budget:")} ${c.green(`PASS — under ${budgetLabel}`)} ` +
-          c.dim(`(${report.budgetMs - report.totalMs}ms headroom)`),
+          c.dim(`(${report.budgetMs - report.totalMs}ms headroom)`)
       );
     } else {
       console.log(
         `  ${c.bold("Budget:")} ${c.red(`FAIL — exceeded ${budgetLabel} by ${formatMs(report.totalMs - report.budgetMs)}`)} ` +
-          c.dim("(WS-A acceptance regression)"),
+          c.dim("(WS-A acceptance regression)")
       );
     }
   }
@@ -918,7 +949,7 @@ function emitReport(flags: Flags, report: RunReport): void {
     console.log(c.dim(`  results JSON written to ${flags.resultsFile}`));
   } catch (e: any) {
     console.error(
-      c.yellow(`  failed to write results to ${flags.resultsFile}: ${e?.message ?? e}`),
+      c.yellow(`  failed to write results to ${flags.resultsFile}: ${e?.message ?? e}`)
     );
   }
 }
@@ -963,7 +994,11 @@ function runPlaywrightSpec(specGlob: string, outputDir: string, label: string): 
     "--reporter=line",
     `--output=${outputDir}`,
   ];
-  const env = { ...process.env, AISOC_SCREENCAST_URL: "http://localhost:3000", AISOC_DISABLE_ANALYTICS: "1" };
+  const env = {
+    ...process.env,
+    AISOC_SCREENCAST_URL: "http://localhost:3000",
+    AISOC_DISABLE_ANALYTICS: "1",
+  };
   const r = spawnSync("pnpm", args, { cwd: ROOT, env, stdio: "inherit" });
   if (r.status !== 0) {
     console.error(c.red(`  ${label} failed (exit ${r.status ?? "n/a"})`));
@@ -1003,13 +1038,24 @@ function transcodeWebmToMp4AndGif(): boolean {
   const mp4r = spawnSync(
     "ffmpeg",
     [
-      "-y", "-i", src,
-      "-c:v", "libx264", "-preset", "slow", "-crf", "22",
-      "-c:a", "aac", "-b:a", "128k",
-      "-movflags", "+faststart",
+      "-y",
+      "-i",
+      src,
+      "-c:v",
+      "libx264",
+      "-preset",
+      "slow",
+      "-crf",
+      "22",
+      "-c:a",
+      "aac",
+      "-b:a",
+      "128k",
+      "-movflags",
+      "+faststart",
       mp4,
     ],
-    { stdio: "inherit" },
+    { stdio: "inherit" }
   );
   if (mp4r.status !== 0) {
     console.error(c.red(`ffmpeg mp4 transcode failed (exit ${mp4r.status})`));
@@ -1025,12 +1071,20 @@ function transcodeWebmToMp4AndGif(): boolean {
   const gifr = spawnSync(
     "ffmpeg",
     [
-      "-y", "-ss", "14", "-t", "10", "-i", src,
-      "-vf", "fps=15,scale=720:-2:flags=lanczos,split[a][b];[a]palettegen[p];[b][p]paletteuse",
-      "-loop", "0",
+      "-y",
+      "-ss",
+      "14",
+      "-t",
+      "10",
+      "-i",
+      src,
+      "-vf",
+      "fps=15,scale=720:-2:flags=lanczos,split[a][b];[a]palettegen[p];[b][p]paletteuse",
+      "-loop",
+      "0",
       gif,
     ],
-    { stdio: "inherit" },
+    { stdio: "inherit" }
   );
   if (gifr.status !== 0) {
     console.error(c.red(`ffmpeg gif render failed (exit ${gifr.status})`));
@@ -1110,8 +1164,8 @@ async function main() {
       c.dim(
         ` — tag=${flags.tag}${flags.rebuild ? " · rebuild" : ""}` +
           (flags.demoQuick ? " · quick" : "") +
-          (flags.budgetMs ? ` · budget=${formatMs(flags.budgetMs)}` : ""),
-      ),
+          (flags.budgetMs ? ` · budget=${formatMs(flags.budgetMs)}` : "")
+      )
   );
 
   if (!checkDocker()) process.exit(1);

--- a/services/agents/Dockerfile
+++ b/services/agents/Dockerfile
@@ -49,7 +49,8 @@ RUN set -eux; \
             "asyncpg>=0.29,<0.30" \
             "sqlalchemy[asyncio]>=2.0.25,<3" \
             "apscheduler>=3.10.4,<4" \
-            "pyyaml>=6.0.1,<7" ; \
+            "pyyaml>=6.0.1,<7" \
+            "cryptography>=46,<50" ; \
     fi
 
 # Smoke-import the modules the orchestrator pulls in at module load time.
@@ -57,9 +58,13 @@ RUN set -eux; \
 # Also assert that the langgraph version on disk exposes the ``START``
 # sentinel — langgraph 0.0.x silently lacked it, which previously crashed the
 # agents service at boot with ``ImportError: cannot import name 'START'``.
-RUN python -c "import opentelemetry, langgraph, fastapi, sqlalchemy, asyncpg, redis, httpx, structlog, apscheduler, yaml; from langgraph.graph import END, START, StateGraph"
+RUN python -c "import opentelemetry, langgraph, fastapi, sqlalchemy, asyncpg, redis, httpx, structlog, apscheduler, yaml, _cffi_backend; from cryptography.fernet import Fernet; from langgraph.graph import END, START, StateGraph"
 
 COPY app/ ./app/
+
+# Import the application module that first exposed the missing direct
+# dependency. Keep this after COPY so the build validates the real import path.
+RUN python -c "from app.security.credential_vault import CredentialVault"
 
 EXPOSE 8084
 

--- a/services/agents/poetry.lock
+++ b/services/agents/poetry.lock
@@ -253,7 +253,7 @@ version = "4.14.1"
 description = "High-level concurrency and networking framework on top of asyncio or Trio"
 optional = false
 python-versions = ">=3.10"
-groups = ["main"]
+groups = ["main", "dev"]
 files = [
     {file = "anyio-4.14.1-py3-none-any.whl", hash = "sha256:4e5533c5b8ff0a24f5d7a176cbe6877129cd183893f66b537f8f227d10527d72"},
     {file = "anyio-4.14.1.tar.gz", hash = "sha256:8d648a3544c1a700e3ff78615cd679e4c5c3f149904287e73687b2596963629e"},
@@ -552,7 +552,7 @@ version = "2026.6.17"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
-groups = ["main"]
+groups = ["main", "dev"]
 files = [
     {file = "certifi-2026.6.17-py3-none-any.whl", hash = "sha256:2227dcbaafe0d2f59279d1762ddddc37783ed4354594f194ffc31d20f41fc3db"},
     {file = "certifi-2026.6.17.tar.gz", hash = "sha256:024c88eeec92ca068db80f02b8b07c9cef7b9fe261d1d535abfd5abd6f6af432"},
@@ -1459,7 +1459,7 @@ version = "0.16.0"
 description = "A pure-Python, bring-your-own-I/O implementation of HTTP/1.1"
 optional = false
 python-versions = ">=3.8"
-groups = ["main"]
+groups = ["main", "dev"]
 files = [
     {file = "h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86"},
     {file = "h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1"},
@@ -1660,7 +1660,7 @@ version = "1.0.9"
 description = "A minimal low-level HTTP client."
 optional = false
 python-versions = ">=3.8"
-groups = ["main"]
+groups = ["main", "dev"]
 files = [
     {file = "httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55"},
     {file = "httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8"},
@@ -1742,7 +1742,7 @@ version = "0.28.1"
 description = "The next generation HTTP client."
 optional = false
 python-versions = ">=3.8"
-groups = ["main"]
+groups = ["main", "dev"]
 files = [
     {file = "httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad"},
     {file = "httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc"},
@@ -1829,7 +1829,7 @@ version = "3.18"
 description = "Internationalized Domain Names in Applications (IDNA)"
 optional = false
 python-versions = ">=3.9"
-groups = ["main"]
+groups = ["main", "dev"]
 files = [
     {file = "idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2"},
     {file = "idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848"},
@@ -4207,6 +4207,21 @@ files = [
 requests = ">=2.0.1,<3.0.0"
 
 [[package]]
+name = "respx"
+version = "0.22.0"
+description = "A utility for mocking out the Python HTTPX and HTTP Core libraries."
+optional = false
+python-versions = ">=3.8"
+groups = ["dev"]
+files = [
+    {file = "respx-0.22.0-py2.py3-none-any.whl", hash = "sha256:631128d4c9aba15e56903fb5f66fb1eff412ce28dd387ca3a81339e52dbd3ad0"},
+    {file = "respx-0.22.0.tar.gz", hash = "sha256:3c8924caa2a50bd71aefc07aa812f2466ff489f1848c96e954a5362d17095d91"},
+]
+
+[package.dependencies]
+httpx = ">=0.25.0"
+
+[[package]]
 name = "rich"
 version = "15.0.0"
 description = "Render rich text, tables, progress bars, syntax highlighting, markdown and more to the terminal"
@@ -5852,4 +5867,4 @@ cffi = ["cffi (>=1.17,<2.0) ; platform_python_implementation != \"PyPy\" and pyt
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.11"
-content-hash = "9380123a71d54e899e9d218c3c563d78593f337da695cec51f5f401d9156bf0d"
+content-hash = "7e46fe4d1786728b265b1fd1cd78e60918846aaa4864735c766245d287f8ff25"

--- a/services/agents/poetry.lock
+++ b/services/agents/poetry.lock
@@ -562,7 +562,7 @@ files = [
 name = "cffi"
 version = "2.0.0"
 description = "Foreign Function Interface for Python calling C code."
-optional = true
+optional = false
 python-versions = ">=3.9"
 groups = ["main"]
 files = [
@@ -821,6 +821,68 @@ files = [
     {file = "colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},
 ]
 markers = {main = "platform_system == \"Windows\" or sys_platform == \"win32\"", dev = "sys_platform == \"win32\""}
+
+[[package]]
+name = "cryptography"
+version = "49.0.0"
+description = "cryptography is a package which provides cryptographic recipes and primitives to Python developers."
+optional = false
+python-versions = "!=3.9.0,!=3.9.1,>=3.9"
+groups = ["main"]
+files = [
+    {file = "cryptography-49.0.0-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:966fe0e9c67490071f14c0d2b1cb2dfb3023c5ce39457343931415f08382f2db"},
+    {file = "cryptography-49.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:36d1709f992593689b45bda411498d62c6e365f2ca00b84657d4dadd24de16db"},
+    {file = "cryptography-49.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0e959b578856a3924bc0cbb710fc12c387b9412a951389f3ca61704a9e25f325"},
+    {file = "cryptography-49.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:53ecee2e23f7169b6117e99fc8a944e5e50f79e69758a83b52a00cb98ab2b2d2"},
+    {file = "cryptography-49.0.0-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:2eda353d8a27bcbcaa4cbed18994a74ab4d19a2ca897db188ea269ab9b71419b"},
+    {file = "cryptography-49.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:2afe9051da7ae7bd5905da5a949280c7d2bb75682e188f650a9d0f2756b834c6"},
+    {file = "cryptography-49.0.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:0b82e28ee398a386f0807bba7884d30f25218855690f45115831bcce5d90822c"},
+    {file = "cryptography-49.0.0-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:ccac2bfebc306b862133e3bb71f3f6ee8bb525240089b2d952e4144b3a6d5da7"},
+    {file = "cryptography-49.0.0-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:d0527ce944105f257f605a827d6ebead966c752038b6e8656abb9c5edee6fc68"},
+    {file = "cryptography-49.0.0-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:cbc77da8c523d5abd028635ba850a6966fcee2c82e2bf65a41d1d8afe0f98be9"},
+    {file = "cryptography-49.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:b87e65d263b3e5d3bb92a57e2a6638e2f31110fa7aa890c7b2dbba42248d0a3f"},
+    {file = "cryptography-49.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:66ec79c3904820572d7e987abdf304281f141d37ad9a489b8e97066e7b9b6459"},
+    {file = "cryptography-49.0.0-cp311-abi3-win_amd64.whl", hash = "sha256:e5dfc1e64de5677cec922ffa8da89c546d0415bf6efdf081842e5d44c84e1f0e"},
+    {file = "cryptography-49.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:73a205dce83953d131a4aa1e0fd917a2fd1c5b1eef251e9d7152efefcbf5caf7"},
+    {file = "cryptography-49.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:196ecd6a36e4e9aa10270393bb98d8df88fccee0bf1e5128b91ae4eb4375896d"},
+    {file = "cryptography-49.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7abcee80084cda3f7691f3eb1ce480d8df49cec637b429aa35986c1de71738aa"},
+    {file = "cryptography-49.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:4ae387c9cb68ea569ca17e490d66d8142b81c3cc814bf179974b7d146e490bbb"},
+    {file = "cryptography-49.0.0-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:f37d847238971164fdbc68ade6f6574aecc9c0af714190e2083429ff68f4ce9d"},
+    {file = "cryptography-49.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:c2bc30226390d60ea19d9f82b19db005fe0452154a23c1c410c12ea801e43561"},
+    {file = "cryptography-49.0.0-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:07cab27cc7b7e0fd28e5e26bb9eeedde5c135c868b46de4a27845abe94af6122"},
+    {file = "cryptography-49.0.0-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:b20133d204d2bb56ba047642199603876c872026ca53e79c35b83772ab2cc505"},
+    {file = "cryptography-49.0.0-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:b970c6da94d5bb18629db453d14f2a1300f6bf59b61e9b82377931ef95504866"},
+    {file = "cryptography-49.0.0-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:d8ecde755e2e91bf773fc94e8c9d730cd7f2007004cb492263a794ec3899a1c8"},
+    {file = "cryptography-49.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e3fb64c420688e5319ae25113a354015abbd8dffbfbc41781a1ea66fc7622ac3"},
+    {file = "cryptography-49.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:32703d93296f5c1f4b53349ad3a250c2cae0fdecd3a3dd5d47e616d8d616af27"},
+    {file = "cryptography-49.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:33cd0565932807baddb67b96dbee92f2c374b5c89dee09fd74079aeb8c8dba61"},
+    {file = "cryptography-49.0.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:ec5e529fb80935c94fe7b729f9972b50e351a0e6b50aa294fd5cabb109fcc29a"},
+    {file = "cryptography-49.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f78ff2c9ed8dc2d036b0f4d640e22522213d047c1b14e61205a7e55c80a494d4"},
+    {file = "cryptography-49.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:35b151772baff2c74cba7fa290ceaff4c3b11c0c881eb93eb5dbc05a7cfbba18"},
+    {file = "cryptography-49.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:0f21641cf4b30fca7aee061ced0ec7ad7b073518088b7c9969a297c0ae796c69"},
+    {file = "cryptography-49.0.0-cp39-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:9e82dcc8e56052715fb18b2429e3bca4823b1629136a2084fc45a9a5cecb9b64"},
+    {file = "cryptography-49.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:6f2debedf9ca60cf1d5bd466475638af5130f89965605cd818484d19987d3a21"},
+    {file = "cryptography-49.0.0-cp39-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:8c25ceb16df5b9435f3f6a9829204985b0e0cbee3b48aacd432c7d2c850b44d9"},
+    {file = "cryptography-49.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:28d8b15e6275f12c8a207dc309dfa957903c927d08d0cc937ee3f63f200693cc"},
+    {file = "cryptography-49.0.0-cp39-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:6fc361c34fb6aac015ce19435876635e5c6d21db31998b0920f675f131e043b8"},
+    {file = "cryptography-49.0.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:2400ef9c9e2299a25614eb1dea3db54a69b1349efd043bfac9c67630d136df36"},
+    {file = "cryptography-49.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:67e1d20ad9ef3a563c59ef22e7a8a0b8210bd26604369ea4a30a7c66aefe504e"},
+    {file = "cryptography-49.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:42b0684e0e40cf26122427802486f6d93aea593612603a94fbf260c7eb1e9c1b"},
+    {file = "cryptography-49.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:026ac7423e6fa66872d3bf889be5974507da3944f866f704fa200eadacd00001"},
+    {file = "cryptography-49.0.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:fc1e275c2f1d97b1a6450b8b0ea3ebfa6e087a611c2b26cb2404d48588abab7b"},
+    {file = "cryptography-49.0.0-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:c83782480a4a9da4d0feb51950131ba32e12e70813848b3343f6e18c28a66838"},
+    {file = "cryptography-49.0.0-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:b39efa323140595abd3ecca8529d321ae50f55f3aa3ba9cc81ea56a6011953d5"},
+    {file = "cryptography-49.0.0-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:b47db11c2c3525083296069b98ac5221907455e989ae0c2e3008bde851921615"},
+    {file = "cryptography-49.0.0-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:084ef1af862eb07ec46d25f68689f2102a9fc0e05ce7b80f14f5fe51e4eef0f6"},
+    {file = "cryptography-49.0.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:be9fcb48a55f023493482827d4f459bd263cc20efde64f204b97c123201850c6"},
+    {file = "cryptography-49.0.0.tar.gz", hash = "sha256:f89660a348f4f78a92366240a61404e337586ef7f5909a2fef59ca88ef505493"},
+]
+
+[package.dependencies]
+cffi = {version = ">=2.0.0", markers = "platform_python_implementation != \"PyPy\""}
+
+[package.extras]
+ssh = ["bcrypt (>=3.1.5)"]
 
 [[package]]
 name = "cssselect2"
@@ -3489,7 +3551,7 @@ dev = ["pytest"]
 name = "pycparser"
 version = "3.0"
 description = "C parser in Python"
-optional = true
+optional = false
 python-versions = ">=3.10"
 groups = ["main"]
 markers = "implementation_name != \"PyPy\""
@@ -5790,4 +5852,4 @@ cffi = ["cffi (>=1.17,<2.0) ; platform_python_implementation != \"PyPy\" and pyt
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.11"
-content-hash = "616d6c5c04e5102e51ee3d9dfb60ea9fe77bc858e5c263181c415da13604ee82"
+content-hash = "9380123a71d54e899e9d218c3c563d78593f337da695cec51f5f401d9156bf0d"

--- a/services/agents/pyproject.toml
+++ b/services/agents/pyproject.toml
@@ -36,6 +36,9 @@ asyncpg = ">=0.29,<0.32"
 sqlalchemy = {extras = ["asyncio"], version = "^2.0.25"}
 apscheduler = "^3.10.4"
 pyyaml = "^6.0.1"
+# Imported by app.security.credential_vault. This must be a direct runtime
+# dependency rather than an accidental dependency of Poetry itself.
+cryptography = ">=46,<50"
 # jsonschema is consumed by the NL → playbook drafter (T3.7) to validate
 # every drafted playbook against schemas/playbook.schema.json before the
 # editor loads it, and by scripts/lint_playbooks.py. Pinned to the

--- a/services/agents/pyproject.toml
+++ b/services/agents/pyproject.toml
@@ -48,6 +48,7 @@ jsonschema = ">=4.21,<5.0"
 [tool.poetry.group.dev.dependencies]
 pytest = ">=7.4,<10.0"
 pytest-asyncio = ">=0.23,<1.5"
+respx = ">=0.22,<0.23"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]


### PR DESCRIPTION
## Summary

Fixes two failures in the local demo startup path: host-port conflicts now recover automatically, and the agents image now declares the cryptography runtime dependency required by the credential vault. The demo Compose project is isolated from unrelated stacks, startup retries port-bind races up to three times, and Docker build smoke checks prevent a broken CFFI/vault image from being published again.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor / tech debt
- [x] CI / infra change

## Related issues

No linked issue; reproduced locally through the documented demo command.

## Changes

- Allocate and export the agents host port, reserve selected fallback ports, and retry Docker Compose startup when the daemon reports a bind conflict.
- Give the demo an explicit Compose project name so unrelated containers are not treated as orphans.
- Declare cryptography as an agents runtime dependency, update the Poetry lockfile and fallback installer, and smoke-import CFFI/Fernet/CredentialVault during image builds.
- Declare respx in the agents dev group so the documented full service test command is reproducible.

## Testing

- [x] Unit tests added / updated
- [x] Integration tests pass locally
- [x] Manually tested (describe steps below)

<details>
<summary>Manual test steps</summary>

1. Kept host port 8001 occupied and ran pnpm aisoc:demo --no-pull --no-open; agents automatically remapped to 8002 and Compose startup completed.
2. Built services/agents as aisoc-agents:cffi-fix and verified cryptography 49.0.0, cffi 2.0.0, and the credential-vault import inside the image.
3. Recreated the live agents service from the fixed image; it remained running with restart count 0 and its health endpoint returned healthy.
4. Ran the complete agents suite: 833 passed, 2 skipped, 30 subtests passed.

</details>

## Screenshots (if UI changes)

Not applicable; no UI changes.

## Checklist

- [x] My code follows the style guidelines of this project (ruff, eslint, gofmt)
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally
- [x] I have updated documentation as needed (no documentation changes required)
- [x] My changes do not introduce new linter warnings
- [x] I have checked for sensitive data / credentials in my diff

## Eval harness (required for substrate / playbook / detection changes)

Both runs use the repository's fixed 200-incident synthetic benchmark. These are deterministic substrate gates, not live production measurements.

<details>
<summary><strong>Before</strong> (origin/main at 96051219)</summary>

```text
mitre_accuracy               0.970  PASS (macro 0.964)
alert_reduction              0.753  PASS
investigation_completeness   0.943  PASS (macro 0.943)
response_quality             1.000  PASS (macro 1.000)
hunt_corpus                  1.000  PASS
adversary_eval               0.475  PASS
confidence_calibration       0.060  PASS
memory_recall                1.000  PASS
override_accuracy            1.000  PASS
playbook_completion_rate     0.735  PASS
detection_fp_rate            0.005  PASS
PASS - ALL GATES GREEN
```

</details>

<details>
<summary><strong>After</strong></summary>

```text
mitre_accuracy               0.970  PASS (macro 0.964)
alert_reduction              0.753  PASS
investigation_completeness   0.943  PASS (macro 0.943)
response_quality             1.000  PASS (macro 1.000)
hunt_corpus                  1.000  PASS
adversary_eval               0.475  PASS
confidence_calibration       0.060  PASS
memory_recall                1.000  PASS
override_accuracy            1.000  PASS
playbook_completion_rate     0.735  PASS
detection_fp_rate            0.005  PASS
PASS - ALL GATES GREEN
```

</details>

- [x] No axis regressed
- [ ] An axis regressed; rationale and follow-up are described in the Summary above
