### PR TITLE
chore(deps): bump github/codeql-action to 4.37.1 (all steps together)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4
+        uses: github/codeql-action/init@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
         with:
           languages: ${{ matrix.language }}
           queries: security-and-quality
@@ -41,9 +41,9 @@ jobs:
               - 'plans/cyble-aisoc/**'
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4
+        uses: github/codeql-action/autobuild@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4
+        uses: github/codeql-action/analyze@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
         with:
           category: '/language:${{ matrix.language }}'


### PR DESCRIPTION
## Summary
Supersedes #500 (autobuild) and #499 (analyze). Dependabot split the codeql-action 4.37.0 → 4.37.1 bump per action path, but `codeql.yml` runs `init` + `autobuild` + `analyze` and CodeQL requires them all on the **same** version. Merging either split PR alone left `init` at 4.37.0 while one step moved to 4.37.1 → version mismatch → all three `Analyze (*)` jobs failed.

This bumps all three steps together to 4.37.1.

## Test plan
- [x] All three `codeql-action/*` refs pinned to the same SHA (`7188fc36…` = v4.37.1)
- [ ] CodeQL `Analyze (javascript-typescript / python / go)` pass on this PR

Made with [Cursor](https://cursor.com)