### PR TITLE
feat(federated): QRadar AQL backend (Wave 3b)

### DIFF
--- a/services/connectors/app/connectors/qradar.py
+++ b/services/connectors/app/connectors/qradar.py
@@ -14,12 +14,15 @@ consoles via a toggle (many QRadar deployments use an internal CA).
 
 from __future__ import annotations
 
+import asyncio
 from typing import Any
 
 import httpx
 import structlog
 
 from app.connectors.base import BaseConnector, Capability, ConnectorSchema, Field
+from app.federated.query import UnifiedQuery
+from app.federated.translators import to_aql
 
 logger = structlog.get_logger()
 
@@ -32,6 +35,7 @@ class QRadarConnector(BaseConnector):
     connector_id = "qradar"
     connector_name = "IBM QRadar"
     connector_category = "siem"
+    supports_federated_search = True
 
     @classmethod
     def schema(cls) -> ConnectorSchema:
@@ -126,6 +130,37 @@ class QRadarConnector(BaseConnector):
         if m >= 2:
             return "low"
         return "info"
+
+    async def query(self, unified: UnifiedQuery) -> list[dict[str, Any]]:
+        """Run a translated AQL search via the QRadar Ariel API.
+
+        Returns raw event rows for analyst pivoting (not normalized alerts), so
+        the API layer stamps connector identity onto each row downstream. The
+        Ariel flow is create-search -> poll-until-COMPLETED -> fetch-results.
+        """
+        aql = to_aql(unified, table="events")
+        async with httpx.AsyncClient(timeout=60.0, verify=self._verify) as client:
+            resp = await client.post(
+                f"{self._base}/api/ariel/searches",
+                headers=self._headers(),
+                params={"query_expression": aql},
+            )
+            resp.raise_for_status()
+            search_id = resp.json().get("search_id")
+            if not search_id:
+                return []
+            for _ in range(30):
+                status_resp = await client.get(f"{self._base}/api/ariel/searches/{search_id}", headers=self._headers())
+                state = status_resp.json().get("status", "")
+                if state in ("COMPLETED", "ERROR", "CANCELED"):
+                    break
+                await asyncio.sleep(2)
+            results = await client.get(
+                f"{self._base}/api/ariel/searches/{search_id}/results",
+                headers={**self._headers(), "Range": "items=0-999"},
+            )
+            results.raise_for_status()
+            return list(results.json().get("events", []))
 
     def normalize(self, raw: dict[str, Any]) -> dict[str, Any]:
         return {

--- a/services/connectors/app/federated/translators/__init__.py
+++ b/services/connectors/app/federated/translators/__init__.py
@@ -8,8 +8,9 @@ are pure: no I/O, no global state, no exceptions other than
 
 from __future__ import annotations
 
+from app.federated.translators.aql import to_aql
 from app.federated.translators.esql import to_esql
 from app.federated.translators.kql import to_kql
 from app.federated.translators.spl import to_spl
 
-__all__ = ["to_esql", "to_kql", "to_spl"]
+__all__ = ["to_aql", "to_esql", "to_kql", "to_spl"]

--- a/services/connectors/app/federated/translators/aql.py
+++ b/services/connectors/app/federated/translators/aql.py
@@ -1,0 +1,68 @@
+"""Translate ``UnifiedQuery`` -> IBM QRadar AQL (Ariel Query Language).
+
+Shape:
+
+    SELECT * FROM <table> WHERE <filters> LAST <N> MINUTES LIMIT <limit>
+
+String values are single-quoted with embedded quotes escaped. The time window
+is expressed with AQL's ``LAST N MINUTES`` clause (QRadar's native relative
+window), and free text uses AQL ``TEXT SEARCH``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from app.federated.query import Indicator, QueryError, UnifiedQuery
+
+
+def _aql_quote(value: Any) -> str:
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, int | float):
+        return str(value)
+    return "'" + str(value).replace("'", "''") + "'"
+
+
+def _indicator_to_aql(indicator: Indicator) -> str:
+    field = indicator.field
+    op = indicator.operator
+    value = indicator.value
+
+    if op == "eq":
+        return f"{field} = {_aql_quote(value)}"
+    if op == "ne":
+        return f"{field} <> {_aql_quote(value)}"
+    if op == "contains":
+        return f"{field} ILIKE '%{value}%'"
+    if op == "starts_with":
+        return f"{field} ILIKE '{value}%'"
+    if op == "ends_with":
+        return f"{field} ILIKE '%{value}'"
+    if op == "gt":
+        return f"{field} > {_aql_quote(value)}"
+    if op == "gte":
+        return f"{field} >= {_aql_quote(value)}"
+    if op == "lt":
+        return f"{field} < {_aql_quote(value)}"
+    if op == "lte":
+        return f"{field} <= {_aql_quote(value)}"
+    if op == "in":
+        joined = ", ".join(_aql_quote(v) for v in value)
+        return f"{field} IN ({joined})"
+    raise QueryError(f"unsupported operator for AQL: {op}")
+
+
+def to_aql(query: UnifiedQuery, *, table: str = "events") -> str:
+    """Render a ``UnifiedQuery`` as an IBM QRadar AQL search string."""
+    clauses: list[str] = []
+    if query.free_text:
+        clauses.append(f"TEXT SEARCH {_aql_quote(query.free_text)}")
+    clauses.extend(_indicator_to_aql(indicator) for indicator in query.indicators)
+
+    sql = f"SELECT * FROM {table}"
+    if clauses:
+        sql += " WHERE " + " AND ".join(clauses)
+    minutes = max(1, query.since_seconds // 60)
+    sql += f" LAST {minutes} MINUTES LIMIT {query.limit}"
+    return sql

--- a/services/connectors/tests/test_federated_aql.py
+++ b/services/connectors/tests/test_federated_aql.py
@@ -1,0 +1,50 @@
+"""Wave 3b — QRadar AQL federated-search backend."""
+
+from __future__ import annotations
+
+from app.connectors.qradar import QRadarConnector
+from app.federated.query import parse_unified_query
+from app.federated.translators import to_aql
+
+
+def _q(payload: dict):
+    return parse_unified_query(payload)
+
+
+def test_to_aql_basic_eq_and_window():
+    aql = to_aql(_q({"indicators": [{"field": "sourceip", "operator": "eq", "value": "1.2.3.4"}], "since_seconds": 600, "limit": 50}))
+    assert aql.startswith("SELECT * FROM events WHERE ")
+    assert "sourceip = '1.2.3.4'" in aql
+    assert "LAST 10 MINUTES" in aql
+    assert "LIMIT 50" in aql
+
+
+def test_to_aql_operators_and_free_text():
+    aql = to_aql(
+        _q(
+            {
+                "free_text": "malware",
+                "indicators": [
+                    {"field": "username", "operator": "contains", "value": "svc"},
+                    {"field": "magnitude", "operator": "gte", "value": 7},
+                    {"field": "category", "operator": "in", "value": ["a", "b"]},
+                ],
+                "since_seconds": 300,
+                "limit": 10,
+            }
+        )
+    )
+    assert "TEXT SEARCH 'malware'" in aql
+    assert "username ILIKE '%svc%'" in aql
+    assert "magnitude >= 7" in aql
+    assert "category IN ('a', 'b')" in aql
+
+
+def test_to_aql_escapes_single_quotes():
+    aql = to_aql(_q({"indicators": [{"field": "user", "operator": "eq", "value": "o'brien"}], "since_seconds": 60, "limit": 5}))
+    assert "user = 'o''brien'" in aql
+
+
+def test_qradar_declares_federated_search():
+    assert QRadarConnector.supports_federated_search is True
+    assert hasattr(QRadarConnector, "query")


### PR DESCRIPTION
Adds a 4th federated-search backend — IBM QRadar **AQL** — with a `to_aql` translator (10 operators, free-text `TEXT SEARCH`, `LAST N MINUTES` window, quote-escaping) and wires `QRadarConnector.query()` through the Ariel search API (create -> poll -> results). Tests cover the translator + the federation flag. Chronicle/Sumo/Devo/Snowflake translators, response reversibility, auto-onboarding, SCIM, and golden-payload smoke are follow-on Wave 3b items.

Made with [Cursor](https://cursor.com)