### PR TITLE
feat(autonomy): unified confidence x blast x reversibility policy (Wave 5b)

### DIFF
--- a/services/actions/app/services/unified_autonomy.py
+++ b/services/actions/app/services/unified_autonomy.py
@@ -1,0 +1,74 @@
+"""Unified autonomy policy (Wave 5b).
+
+The agent produces a verdict + confidence; the actions gate keys on blast radius
++ tier. They never shared a contract, so confidence never influenced execution.
+This module unifies them into one decision over (confidence, blast radius,
+reversibility).
+
+Posture: **aggressive-but-safe** — a REVERSIBLE, low-blast-radius action with
+high model confidence may auto-execute by default (it can be rolled back and
+its scope is limited), while anything non-reversible, high/critical blast, or
+low-confidence still requires a human. This is the "auto-response by default for
+reversible low-blast actions, gated by confidence + rollback" behaviour.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from app.models.action import BlastRadius
+from app.services.autonomy_safety import REVERSIBLE_ACTIONS, AutonomyMode
+
+# Confidence needed to auto-execute a reversible LOW-blast action.
+AUTO_LOW_BLAST_CONFIDENCE = 0.85
+# Higher bar to auto-execute a reversible MEDIUM-blast action.
+AUTO_MEDIUM_BLAST_CONFIDENCE = 0.95
+
+
+@dataclass(frozen=True)
+class AutonomyDecision:
+    mode: AutonomyMode
+    rationale: str
+    confidence: float
+    reversible: bool
+
+
+def is_reversible(action_type: str) -> bool:
+    return action_type in REVERSIBLE_ACTIONS
+
+
+def unified_decision(
+    *,
+    action_type: str,
+    blast_radius: BlastRadius,
+    confidence: float,
+    reversible: bool | None = None,
+    low_blast_floor: float = AUTO_LOW_BLAST_CONFIDENCE,
+    medium_blast_floor: float = AUTO_MEDIUM_BLAST_CONFIDENCE,
+) -> AutonomyDecision:
+    """Decide how an action may run, unifying model confidence with blast radius."""
+    rev = is_reversible(action_type) if reversible is None else reversible
+    conf = max(0.0, min(1.0, confidence))
+
+    def d(mode: AutonomyMode, why: str) -> AutonomyDecision:
+        return AutonomyDecision(mode=mode, rationale=why, confidence=conf, reversible=rev)
+
+    # Critical blast is never auto, regardless of confidence.
+    if blast_radius == BlastRadius.CRITICAL:
+        return d(AutonomyMode.QUEUED_APPROVAL, "CRITICAL blast radius always requires human approval")
+
+    # Without a real rollback path, never auto-execute — a wrong call can't be undone.
+    if not rev:
+        return d(AutonomyMode.QUEUED_APPROVAL, "non-reversible action requires human approval")
+
+    # High blast, even reversible, needs a human.
+    if blast_radius == BlastRadius.HIGH:
+        return d(AutonomyMode.QUEUED_APPROVAL, "reversible HIGH-blast action queued for approval")
+
+    if blast_radius == BlastRadius.LOW and conf >= low_blast_floor:
+        return d(AutonomyMode.AUTO, f"reversible LOW-blast action, confidence {conf:.2f} >= {low_blast_floor:.2f} — auto-execute")
+
+    if blast_radius == BlastRadius.MEDIUM and conf >= medium_blast_floor:
+        return d(AutonomyMode.AUTO, f"reversible MEDIUM-blast action, confidence {conf:.2f} >= {medium_blast_floor:.2f} — auto-execute")
+
+    return d(AutonomyMode.QUEUED_APPROVAL, f"confidence {conf:.2f} below auto floor for {blast_radius.value} blast — queued for approval")

--- a/services/actions/tests/test_unified_autonomy.py
+++ b/services/actions/tests/test_unified_autonomy.py
@@ -1,0 +1,43 @@
+"""Wave 5b — unified autonomy policy (confidence x blast radius x reversibility)."""
+
+from __future__ import annotations
+
+from app.models.action import BlastRadius
+from app.services.autonomy_safety import AutonomyMode
+from app.services.unified_autonomy import unified_decision
+
+
+def test_reversible_low_blast_high_confidence_auto_executes():
+    d = unified_decision(action_type="block_ip", blast_radius=BlastRadius.LOW, confidence=0.9, reversible=True)
+    assert d.mode == AutonomyMode.AUTO
+
+
+def test_reversible_low_blast_low_confidence_queues():
+    d = unified_decision(action_type="block_ip", blast_radius=BlastRadius.LOW, confidence=0.6, reversible=True)
+    assert d.mode == AutonomyMode.QUEUED_APPROVAL
+
+
+def test_non_reversible_never_auto_even_at_max_confidence():
+    d = unified_decision(action_type="isolate_host", blast_radius=BlastRadius.LOW, confidence=0.99, reversible=False)
+    assert d.mode == AutonomyMode.QUEUED_APPROVAL
+
+
+def test_critical_blast_never_auto():
+    d = unified_decision(action_type="block_ip", blast_radius=BlastRadius.CRITICAL, confidence=0.99, reversible=True)
+    assert d.mode == AutonomyMode.QUEUED_APPROVAL
+
+
+def test_reversible_medium_blast_needs_higher_confidence():
+    assert (
+        unified_decision(action_type="block_ip", blast_radius=BlastRadius.MEDIUM, confidence=0.9, reversible=True).mode
+        == AutonomyMode.QUEUED_APPROVAL
+    )
+    assert (
+        unified_decision(action_type="block_ip", blast_radius=BlastRadius.MEDIUM, confidence=0.96, reversible=True).mode
+        == AutonomyMode.AUTO
+    )
+
+
+def test_reversible_high_blast_queues():
+    d = unified_decision(action_type="block_ip", blast_radius=BlastRadius.HIGH, confidence=0.99, reversible=True)
+    assert d.mode == AutonomyMode.QUEUED_APPROVAL


### PR DESCRIPTION
Unifies the agent's confidence with the actions blast-radius gate into one decision. **Aggressive-but-safe posture** (per direction): a **reversible, low-blast** action with high confidence (>=0.85) **auto-executes by default**; reversible medium-blast needs >=0.95; non-reversible, HIGH/CRITICAL blast, or low-confidence still require a human. Pure + 6 unit tests. SLA-driven escalation + auto-assignment + RBA-to-queue join are follow-on Wave 5b items.

Made with [Cursor](https://cursor.com)