### PR TITLE
feat(evals): groundedness / hallucination eval axis (Wave 6)

### DIFF
--- a/services/agents/app/confidence/groundedness.py
+++ b/services/agents/app/confidence/groundedness.py
@@ -1,0 +1,71 @@
+"""Groundedness / hallucination eval axis (Wave 6).
+
+The eval harness's four axes are substrate self-consistency gates (keyword
+matching over synthetic descriptions), not measures of whether the *live agent*
+invented facts. This module adds a distinct, blind axis: **groundedness** —
+what fraction of the concrete indicators an agent asserts in its output actually
+appear in the evidence it was given. An indicator in the output that is absent
+from the evidence is a hallucination.
+
+This is deliberately conservative and deterministic (regex indicator
+extraction), so it can gate the agent in CI without an LLM in the loop, and it
+grounds the "prove the AI's output" honesty bar: a confident verdict that cites
+IOCs the evidence never contained should score low and be flagged.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+
+# Concrete, checkable indicators. Deliberately narrow — we only score things
+# that must be traceable to evidence, not prose.
+_PATTERNS: dict[str, re.Pattern[str]] = {
+    "ipv4": re.compile(r"\b(?:\d{1,3}\.){3}\d{1,3}\b"),
+    "sha256": re.compile(r"\b[a-fA-F0-9]{64}\b"),
+    "md5": re.compile(r"\b[a-fA-F0-9]{32}\b"),
+    "cve": re.compile(r"\bCVE-\d{4}-\d{4,7}\b", re.IGNORECASE),
+    "mitre": re.compile(r"\bT\d{4}(?:\.\d{3})?\b"),
+    "domain": re.compile(r"\b(?:[a-z0-9-]+\.)+[a-z]{2,}\b", re.IGNORECASE),
+}
+
+# Domains that are structural noise, not claimed indicators.
+_DOMAIN_STOPWORDS = {"e.g", "i.e", "etc.al"}
+
+
+@dataclass(frozen=True)
+class GroundednessResult:
+    score: float  # 1.0 = every claimed indicator is grounded in evidence
+    grounded: list[str] = field(default_factory=list)
+    hallucinated: list[str] = field(default_factory=list)
+
+    @property
+    def has_hallucination(self) -> bool:
+        return bool(self.hallucinated)
+
+
+def _extract(text: str) -> set[str]:
+    found: set[str] = set()
+    for kind, pattern in _PATTERNS.items():
+        for match in pattern.findall(text or ""):
+            token = match.lower()
+            if kind == "domain" and (token in _DOMAIN_STOPWORDS or "." not in token):
+                continue
+            found.add(token)
+    return found
+
+
+def score_groundedness(output_text: str, evidence_text: str) -> GroundednessResult:
+    """Fraction of the output's concrete indicators that appear in the evidence.
+
+    No indicators claimed => perfectly grounded (score 1.0): the agent didn't
+    assert any checkable fact to hallucinate.
+    """
+    claimed = _extract(output_text)
+    if not claimed:
+        return GroundednessResult(score=1.0)
+    evidence = _extract(evidence_text)
+    grounded = sorted(claimed & evidence)
+    hallucinated = sorted(claimed - evidence)
+    score = len(grounded) / len(claimed)
+    return GroundednessResult(score=round(score, 4), grounded=grounded, hallucinated=hallucinated)

--- a/services/agents/tests/test_groundedness_eval.py
+++ b/services/agents/tests/test_groundedness_eval.py
@@ -1,0 +1,38 @@
+"""Wave 6 — groundedness / hallucination eval axis."""
+
+from __future__ import annotations
+
+from app.confidence.groundedness import score_groundedness
+
+
+def test_fully_grounded_output_scores_one():
+    evidence = "Beacon from 45.9.148.99 to c2.evil.example matching T1071. CVE-2024-1234 present."
+    output = "Malicious beacon: 45.9.148.99 contacting c2.evil.example (T1071); exploited CVE-2024-1234."
+    r = score_groundedness(output, evidence)
+    assert r.score == 1.0
+    assert r.has_hallucination is False
+
+
+def test_hallucinated_indicator_is_flagged():
+    evidence = "Beacon from 45.9.148.99 observed."
+    # 203.0.113.7 is NOT in the evidence -> hallucination.
+    output = "Attacker used 45.9.148.99 and pivoted to 203.0.113.7."
+    r = score_groundedness(output, evidence)
+    assert r.score == 0.5
+    assert "203.0.113.7" in r.hallucinated
+    assert "45.9.148.99" in r.grounded
+    assert r.has_hallucination is True
+
+
+def test_output_with_no_indicators_is_grounded():
+    r = score_groundedness("The activity appears benign and expected.", "some evidence")
+    assert r.score == 1.0
+    assert r.has_hallucination is False
+
+
+def test_fabricated_cve_and_hash_flagged():
+    evidence = "Suspicious process launch on host web-01."
+    output = "Linked to CVE-2021-44228 and hash " + "a" * 64
+    r = score_groundedness(output, evidence)
+    assert r.score == 0.0
+    assert any("cve-2021-44228" == h for h in r.hallucinated)


### PR DESCRIPTION
Adds a **blind** eval axis distinct from the keyword self-consistency gates: `score_groundedness` measures the fraction of concrete indicators an agent asserts (IPs/hashes/CVEs/ATT&CK IDs/domains) that actually appear in the evidence it was given — an asserted indicator absent from evidence is a flagged **hallucination**. Deterministic (regex), so it gates in CI without an LLM and backs the 'prove the AI output' honesty bar. 4 tests. Autonomy eval gates, data-lane SLOs, and claim-to-gate matrix rows are follow-on Wave 6 items.

Made with [Cursor](https://cursor.com)