### PR TITLE
chore(deps): bump github/codeql-action to v4.37.4 (init+autobuild+analyze)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
+        uses: github/codeql-action/init@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
         with:
           languages: ${{ matrix.language }}
           queries: security-and-quality
@@ -41,9 +41,9 @@ jobs:
               - 'plans/cyble-aisoc/**'
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
+        uses: github/codeql-action/autobuild@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
+        uses: github/codeql-action/analyze@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
         with:
           category: '/language:${{ matrix.language }}'


### PR DESCRIPTION
CodeQL requires init/autobuild/analyze on the same version within a run. Dependabot split the 4.37.1->4.37.4 bump across #555 (init) and #541 (analyze), so each alone fails the Analyze jobs on a version mismatch. This bumps all three legs together. Supersedes #541 and #555.

Made with [Cursor](https://cursor.com)