### PR TITLE
chore(deps): widen fastapi cap to <0.142 (api + actions)

### DIFF
--- a/services/actions/pyproject.toml
+++ b/services/actions/pyproject.toml
@@ -7,7 +7,7 @@ license = "MIT"
 
 [tool.poetry.dependencies]
 python = "^3.11"
-fastapi = ">=0.109,<0.141"
+fastapi = ">=0.109,<0.142"
 uvicorn = {extras = ["standard"], version = ">=0.27,<0.53"}
 pydantic = "^2.5.0"
 pydantic-settings = "^2.1.0"

--- a/services/api/pyproject.toml
+++ b/services/api/pyproject.toml
@@ -8,7 +8,7 @@ readme = "README.md"
 
 [tool.poetry.dependencies]
 python = "^3.11"
-fastapi = ">=0.111,<0.141"
+fastapi = ">=0.111,<0.142"
 uvicorn = { version = ">=0.29,<0.53", extras = ["standard"] }
 # EmailStr (used in auth/passkeys/tenants endpoints) requires the optional
 # email-validator package, which is only pulled in via the "email" extra.


### PR DESCRIPTION
Combines the two Dependabot fastapi range bumps into one pyproject-only change:

- services/actions: fastapi >=0.109,<0.141 -> <0.142 — #549
- services/api: fastapi >=0.111,<0.141 -> <0.142 — #554

Supersedes #549, #554.

Made with [Cursor](https://cursor.com)