### PR TITLE
fix(security): resolve open CodeQL code-scanning alerts

### DIFF
--- a/services/api/app/services/backtest.py
+++ b/services/api/app/services/backtest.py
@@ -60,6 +60,8 @@ def rows_to_events(columns: list[str], rows: list[list[Any]]) -> list[dict[str, 
                         # keep the OCSF columns available too.
                         event = {**event, **parsed}
                 except (ValueError, TypeError):
+                    # Payload isn't valid JSON — keep the event as-is rather than
+                    # drop it (best-effort raw_data expansion).
                     pass
             elif isinstance(payload, dict):
                 event = {**event, **payload}

--- a/services/api/app/services/report_builder.py
+++ b/services/api/app/services/report_builder.py
@@ -10,9 +10,12 @@ and an exported PDF/HTML report.
 
 from __future__ import annotations
 
+import logging
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from typing import Any
+
+logger = logging.getLogger(__name__)
 
 WIDGET_TYPES = frozenset({"metric", "table", "timeseries", "bar", "pie", "text"})
 # Whitelisted data sources a widget may bind to. Extend as new resolvers land.
@@ -100,7 +103,11 @@ def render_report(definition: ReportDefinition, resolvers: dict[str, Resolver]) 
             else:
                 try:
                     entry["data"] = resolver(widget.params)
-                except Exception as exc:  # noqa: BLE001 — one bad widget shouldn't break the report
-                    entry["error"] = f"{type(exc).__name__}: {exc}"
+                except Exception:  # noqa: BLE001 — one bad widget shouldn't break the report
+                    # Log the detail server-side but never expose the raw
+                    # exception (it may carry stack/internal detail) to the API
+                    # caller — the widget just carries a generic error.
+                    logger.warning("report widget %r resolver failed", widget.id, exc_info=True)
+                    entry["error"] = "resolver failed"
         rendered.append(entry)
     return {"name": definition.name, "widgets": rendered}

--- a/services/connectors/app/connectors/splunk.py
+++ b/services/connectors/app/connectors/splunk.py
@@ -211,6 +211,7 @@ class SplunkConnector(BaseConnector):
             if isinstance(data, dict) and data.get("sid"):
                 return str(data["sid"])
         except (ValueError, KeyError):
+            # Response wasn't JSON with a sid — fall through to the XML path below.
             pass
         # The dispatch endpoint may answer with XML (<sid>…</sid>) despite
         # output_mode=json depending on Splunk version.

--- a/services/fusion/app/services/windowed_detection.py
+++ b/services/fusion/app/services/windowed_detection.py
@@ -122,6 +122,7 @@ class WindowedDetectionEngine:
                 if isinstance(parsed, dict):
                     return parsed
             except (ValueError, TypeError):
+                # raw_data isn't valid JSON — fall back to the OCSF envelope.
                 pass
         return ocsf
 


### PR DESCRIPTION
Clears the 4 open alerts on the code-scanning page:

- **#815 `py/stack-trace-exposure` [medium]** (`report_builder` render endpoint) — the widget resolver's raw exception (`str(exc)`) flowed into the API response. Now logged server-side with a generic `"resolver failed"` returned to the caller.
- **#813 / #812 / #809 `py/empty-except` [note]** (`backtest.py`, `windowed_detection.py`, `splunk.py`) — intentional best-effort `json.loads` fall-through blocks; added the explanatory comments CodeQL asks for.

No behavior change beyond not leaking exception text. Lint clean; `test_report_builder.py` + `test_backtest.py` pass (14).

Made with [Cursor](https://cursor.com)