### PR TITLE
chore(deps): bump github/codeql-action to v4.37.6 (init+autobuild+analyze together)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
+        uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
         with:
           languages: ${{ matrix.language }}
           queries: security-and-quality
@@ -41,9 +41,9 @@ jobs:
               - 'plans/cyble-aisoc/**'
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
+        uses: github/codeql-action/autobuild@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
+        uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
         with:
           category: '/language:${{ matrix.language }}'


### PR DESCRIPTION
Bumps all three `github/codeql-action` sub-actions (init, autobuild, analyze) to v4.37.6 (`5595ccaf`) in one change. They must share a version — the split dependabot PRs (#588, #596, #598) each fail the `Analyze` jobs on a version mismatch and would break `main` if merged individually. **Supersedes and closes #588, #596, #598.**

Made with [Cursor](https://cursor.com)